### PR TITLE
Add Resize.

### DIFF
--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -90,9 +90,14 @@ struct Size GetTextSize(const char* text, int fontFace, double fontScale, int th
     return size;
 }
 
-void PutText(Mat img, const char* text, Point org, int fontFace, double fontScale, 
+void PutText(Mat img, const char* text, Point org, int fontFace, double fontScale,
     Scalar color, int thickness) {
     cv::Point pt(org.x, org.y);
     cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
     cv::putText(*img, text, pt, fontFace, fontScale, c, thickness);
+}
+
+void Resize(Mat src, Mat dst, Size dsize, double fx, double fy, int interp) {
+  cv::Size sz(dsize.width, dsize.height);
+  cv::resize(*src, *dst, sz, fx, fy, interp);
 }

--- a/imgproc.go
+++ b/imgproc.go
@@ -380,3 +380,50 @@ func PutText(img Mat, text string, org image.Point, fontFace HersheyFont, fontSc
 	C.PutText(img.p, cText, pOrg, C.int(fontFace), C.double(fontScale), sColor, C.int(thickness))
 	return
 }
+
+// InterpolationFlags are bit flags that control the interpolation algorithm
+// that is used.
+type InterpolationFlags int
+
+const (
+	// InterpolationNearestNeighbor is nearest neighbor. (fast but low quality)
+	InterpolationNearestNeighbor InterpolationFlags = 0
+
+	// InterpolationLinear is bilinear interpolation.
+	InterpolationLinear = 1
+
+	// InterpolationCubic is bicube interpolation.
+	InterpolationCubic = 2
+
+	// InterpolationArea uses pixel area relation. It is preferred for image
+	// decimation as it gives moire-free results.
+	InterpolationArea = 3
+
+	// InterpolationLanczos4 is Lanczos interpolation over 8x8 neighborhood.
+	InterpolationLanczos4 = 4
+
+	// InterpolationDefault is an alias for InterpolationLinear.
+	InterpolationDefault = InterpolationLinear
+
+	// Mask for interpolation codes.
+	InterpolationMax = 7
+)
+
+// Resize resizes an image.
+// It resizes the image src down to or up to the specified size, storing the
+// result in dst. Note that src and dst may be the same image. If you wish to
+// scale by factor, an empty sz may be passed and non-zero fx and fy. Likewise,
+// if you wish to scale to an explicit size, a non-empty sz may be passed with
+// zero for both fx and fy.
+//
+// For further details, please see:
+// https://docs.opencv.org/3.3.0/da/d54/group__imgproc__transform.html#ga47a974309e9102f5f08231edc7e7529d
+func Resize(src, dst Mat, sz image.Point, fx, fy float64, interp InterpolationFlags) {
+	pSize := C.struct_Size{
+		width:  C.int(sz.X),
+		height: C.int(sz.Y),
+	}
+
+	C.Resize(src.p, dst.p, pSize, C.double(fx), C.double(fy), C.int(interp))
+	return
+}

--- a/imgproc.h
+++ b/imgproc.h
@@ -29,8 +29,9 @@ void Circle(Mat img, Point center, int radius, Scalar color, int thickness);
 void Line(Mat img, Point pt1, Point pt2, Scalar color, int thickness);
 void Rectangle(Mat img, Rect rect, Scalar color, int thickness);
 struct Size GetTextSize(const char* text, int fontFace, double fontScale, int thickness);
-void PutText(Mat img, const char* text, Point org, int fontFace, double fontScale, 
+void PutText(Mat img, const char* text, Point org, int fontFace, double fontScale,
              Scalar color, int thickness);
+void Resize(Mat src, Mat dst, Size sz, double fx, double fy, int interp);
 
 
 #ifdef __cplusplus

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -270,3 +270,24 @@ func TestPutText(t *testing.T) {
 		t.Error("Error in PutText test")
 	}
 }
+
+func TestResize(t *testing.T) {
+	src := IMRead("images/gocvlogo.jpg", IMReadColor)
+	if src.Empty() {
+		t.Error("Invalid read of Mat in GaussianBlur test")
+	}
+	defer src.Close()
+
+	dst := NewMat()
+	defer dst.Close()
+
+	Resize(src, dst, image.Point{}, 0.5, 0.5, InterpolationDefault)
+	if dst.Cols() != 200 || dst.Rows() != 172 {
+		t.Errorf("Expected dst size of 200x172 got %dx%d", dst.Cols(), dst.Rows())
+	}
+
+	Resize(src, dst, image.Pt(440, 377), 0, 0, InterpolationCubic)
+	if dst.Cols() != 440 || dst.Rows() != 377 {
+		t.Errorf("Expected dst size of 440x377 got %dx%d", dst.Cols(), dst.Rows())
+	}
+}


### PR DESCRIPTION
This one adds support for `cv::resize`. I left off a couple of values from the `InterpolationFlags` enum for now since they are only used in other geometric transformations.