### PR TITLE
return temp pointer fix

### DIFF
--- a/version.cpp
+++ b/version.cpp
@@ -1,12 +1,5 @@
 #include "version.h"
-#include <sstream>
-#include <string>
-#include <cstring>
-
-using namespace std;
 
 char *openCVVersion() {
-    ostringstream os;
-    os << CV_VERSION;
-    return const_cast<char*>(os.str().c_str());
+    return CV_VERSION;
 }


### PR DESCRIPTION
ostringstream.str() returns a temporary string object that's destroyed at the end of the function.
return the macro is just enough.