### PR TITLE
Add Mat ToBytes

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -38,6 +38,11 @@ void Mat_CopyTo(Mat m, Mat dst) {
     m->copyTo(*dst);
 }
 
+// Mat_ToBytes returns the bytes representation of the underlying data.
+struct ByteArray Mat_ToBytes(Mat m) {
+        return toByteArray(reinterpret_cast<const char*>(m->data), m->total() * m->elemSize());
+}
+
 // Mat_Region returns a Mat of a region of another Mat
 Mat Mat_Region(Mat m, Rect r) {
     return new cv::Mat(*m, cv::Rect(r.x, r.y, r.width, r.height));

--- a/core.go
+++ b/core.go
@@ -125,6 +125,16 @@ func (m *Mat) CopyTo(dst Mat) {
 	return
 }
 
+// ToBytes copies the underlying Mat data to a byte array.
+//
+// For further details, please see:
+// https://docs.opencv.org/3.3.1/d3/d63/classcv_1_1Mat.html#a4d33bed1c850265370d2af0ff02e1564
+func (m *Mat) ToBytes() []byte {
+	b := C.Mat_ToBytes(m.p)
+	defer C.ByteArray_Release(b)
+	return toGoBytes(b)
+}
+
 // Region returns a new Mat that points to a region of this Mat. Changes made to the
 // region Mat will affect the original Mat, since they are pointers to the underlying
 // OpenCV Mat object.

--- a/core.h
+++ b/core.h
@@ -155,6 +155,7 @@ void Mat_Close(Mat m);
 int Mat_Empty(Mat m);
 Mat Mat_Clone(Mat m);
 void Mat_CopyTo(Mat m, Mat dst);
+struct ByteArray Mat_ToBytes(Mat m);
 Mat Mat_Region(Mat m, Rect r);
 Mat Mat_Reshape(Mat m, int cn, int rows);
 Scalar Mat_Mean(Mat m);

--- a/core_test.go
+++ b/core_test.go
@@ -1,6 +1,7 @@
 package gocv
 
 import (
+	"bytes"
 	"image"
 	"testing"
 )
@@ -49,6 +50,29 @@ func TestMatCopyTo(t *testing.T) {
 
 	if copy.Cols() != 102 {
 		t.Errorf("Mat copy incorrect col count: %v\n", copy.Cols())
+	}
+}
+
+func TestMatToBytes(t *testing.T) {
+	mat := NewMatWithSize(101, 102, MatTypeCV8U)
+	b := mat.ToBytes()
+	if len(b) != 101*102 {
+		t.Errorf("Mat bytes incorrect length: %v\n", len(b))
+	}
+
+	mat = NewMatWithSize(101, 102, MatTypeCV16S)
+	b = mat.ToBytes()
+	if len(b) != 101*102*2 {
+		t.Errorf("Mat bytes incorrect length: %v\n", len(b))
+	}
+
+	mat = NewMatFromScalar(NewScalar(255.0, 105.0, 180.0, 0.0), MatTypeCV8UC3)
+	b = mat.ToBytes()
+	if len(b) != 3 {
+		t.Errorf("Mat bytes incorrect length: %v\n", len(b))
+	}
+	if bytes.Compare(b, []byte{255, 105, 180}) != 0 {
+		t.Errorf("Mat bytes unexpected values: %v\n", b)
 	}
 }
 


### PR DESCRIPTION
This provides access to the Mat data pointer. It is useful for converting OpenCV Mat objects to other image types.

This mirrors the ability to use "tostring()" in the Python bindings. See:
https://stackoverflow.com/questions/5825173/pipe-raw-opencv-images-to-ffmpeg

I've also verified this works with real data by implementing an FFmpeg pipe in my own project.