### PR TITLE
Support for non-brew installs of opencv on Darwin

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,9 +1,18 @@
 uname_val="$(uname)"
 if [[ "$uname_val" == "Darwin" ]]; then
   CVPATH=$(brew info opencv | grep -E "opencv/3\.([3-9]|[1-9]\d{1,})" | sed -e "s/ (.*//g")
-  export CGO_CPPFLAGS="-I$CVPATH/include -I$CVPATH/include/opencv2"
-  export CGO_CXXFLAGS="--std=c++1z -stdlib=libc++"
-  export CGO_LDFLAGS="-L$CVPATH/lib -lopencv_core -lopencv_face -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_xfeatures2d"
+  if [[ $CVPATH != "" ]]; then
+      echo "Brew install detected"
+      export CGO_CPPFLAGS="-I$CVPATH/include -I$CVPATH/include/opencv2"
+      export CGO_CXXFLAGS="--std=c++1z -stdlib=libc++"
+      export CGO_LDFLAGS="-L$CVPATH/lib -lopencv_core -lopencv_face -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_xfeatures2d"
+  else
+      echo "Non-Brew install detected"
+      export CGO_CPPFLAGS="-I/usr/local/include"
+      export CGO_CXXFLAGS="--std=c++1z -stdlib=libc++"
+      export CGO_LDFLAGS="-L/usr/local/lib -lopencv_core -lopencv_face -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_xfeatures2d"
+  fi
+
   echo "Environment variables configured for OSX"
 elif [[ "$uname_val" == "Linux" ]]; then
         if [[ -f /etc/pacman.conf ]]; then


### PR DESCRIPTION
If you need features not included in the brew install of OpenCV (like GStreamer) and build it yourself, then the env.sh script would not work on Mac. This change, after doing the check to get the brew path, checks if the path was found, if it doesn't return a path, assumes a non-brew install and sets the env variables to the default OpenCV install paths.