### PR TITLE
Add cv::arcLength() bindings.

### DIFF
--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -1,5 +1,13 @@
 #include "imgproc.h"
 
+double ArcLength(Contour curve, bool is_closed) {
+    std::vector<cv::Point> pts;
+    for (size_t i = 0; i < curve.length; i++) {
+        pts.push_back(cv::Point(curve.points[i].x, curve.points[i].y));
+    }
+    return cv::arcLength(pts, is_closed);
+}
+
 void CvtColor(Mat src, Mat dst, int code) {
     cv::cvtColor(*src, *dst, code);
 }

--- a/imgproc.go
+++ b/imgproc.go
@@ -12,6 +12,30 @@ import (
 	"unsafe"
 )
 
+// ArcLength calculates a contour perimeter or a curve length.
+//
+// For further details, please see:
+//
+// https://docs.opencv.org/3.4.0/d3/dc0/group__imgproc__shape.html#ga8d26483c636be6b35c3ec6335798a47c
+//
+func ArcLength(curve []image.Point, isClosed bool) float64 {
+	cPointSlice := make([]C.struct_Point, len(curve))
+	for i, point := range curve {
+		cPoint := C.struct_Point{
+			x: C.int(point.X),
+			y: C.int(point.Y),
+		}
+		cPointSlice[i] = cPoint
+	}
+
+	cPoints := C.struct_Points{
+		points: (*C.Point)(&cPointSlice[0]),
+		length: C.int(len(curve)),
+	}
+	arcLength := C.ArcLength(cPoints, C.bool(isClosed))
+	return float64(arcLength)
+}
+
 // CvtColor converts an image from one color space to another.
 // It converts the src Mat image to the dst Mat using the
 // code param containing the desired ColorConversionCode color space.

--- a/imgproc.h
+++ b/imgproc.h
@@ -10,6 +10,7 @@ extern "C" {
 
 #include "core.h"
 
+double ArcLength(Contour curve, bool is_closed);
 void CvtColor(Mat src, Mat dst, int code);
 void BilateralFilter(Mat src, Mat dst, int d, double sc, double ss);
 void Blur(Mat src, Mat dst, Size ps);

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -125,8 +125,18 @@ func TestFindContours(t *testing.T) {
 	}
 
 	r := BoundingRect(res[0])
-	if r.Min.X != 0 || r.Max.Y != 320 {
+	if !r.Eq(image.Rect(0, 0, 400, 320)) {
 		t.Errorf("Invalid BoundingRect test: %v", r)
+	}
+
+	length := ArcLength(res[0], true)
+	if int(length) != 1436 {
+		t.Errorf("Invalid ArcLength test: %f", length)
+	}
+
+	length = ArcLength(res[0], false)
+	if int(length) != 1037 {
+		t.Errorf("Invalid ArcLength test: %f", length)
 	}
 }
 


### PR DESCRIPTION
Fixes #74. This commit adds cv::arcLength() bindings.