### PR TITLE
core: add Type() method to Mat

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -97,6 +97,11 @@ int Mat_Channels(Mat m) {
     return m->channels();
 }
 
+// Mat_Type returns the type from this Mat.
+int Mat_Type(Mat m) {
+    return m->type();
+}
+
 // Mat_GetUChar returns a specific row/col value from this Mat expecting
 // each element to contain a schar aka CV_8U.
 uint8_t Mat_GetUChar(Mat m, int row, int col) {

--- a/core.go
+++ b/core.go
@@ -219,6 +219,11 @@ func (m *Mat) Channels() int {
 	return int(C.Mat_Channels(m.p))
 }
 
+// Type returns the type for this Mat.
+func (m *Mat) Type() int {
+	return int(C.Mat_Type(m.p))
+}
+
 // GetUCharAt returns a value from a specific row/col in this Mat expecting it to
 // be of type uchar aka CV_8U.
 func (m *Mat) GetUCharAt(row int, col int) int8 {

--- a/core.h
+++ b/core.h
@@ -165,6 +165,7 @@ Scalar Mat_Mean(Mat m);
 int Mat_Rows(Mat m);
 int Mat_Cols(Mat m);
 int Mat_Channels(Mat m);
+int Mat_Type(Mat m);
 uint8_t Mat_GetUChar(Mat m, int row, int col);
 int8_t Mat_GetSChar(Mat m, int row, int col);
 int16_t Mat_GetShort(Mat m, int row, int col);

--- a/core_test.go
+++ b/core_test.go
@@ -30,6 +30,10 @@ func TestMatWithSize(t *testing.T) {
 	if mat.Channels() != 1 {
 		t.Errorf("NewMatWithSize incorrect channels count: %v\n", mat.Channels())
 	}
+
+	if mat.Type() != 0 {
+		t.Errorf("NewMatWithSize incorrect type: %v\n", mat.Type())
+	}
 }
 
 func TestMatClone(t *testing.T) {


### PR DESCRIPTION
Noticed the NewMatFromBytes method took in a MatType object but there was no convenient way to save off that information from an existing Mat.