### PR TITLE
Add cv::approxPolyDP() bindings.

### DIFF
--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -8,6 +8,23 @@ double ArcLength(Contour curve, bool is_closed) {
     return cv::arcLength(pts, is_closed);
 }
 
+Contour ApproxPolyDP(Contour curve, double epsilon, bool closed) {
+    std::vector<cv::Point> curvePts;
+    for (size_t i = 0; i < curve.length; i++) {
+        curvePts.push_back(cv::Point(curve.points[i].x, curve.points[i].y));
+    }
+
+    std::vector<cv::Point> approxCurvePts;
+    cv::approxPolyDP(curvePts, approxCurvePts, epsilon, closed);
+
+    int length = approxCurvePts.size();
+    Point* points = new Point[length];
+    for (size_t i = 0; i < length; i++) {
+        points[i] = Point{approxCurvePts[i].x, approxCurvePts[i].y};
+    }
+    return Contour{points, length};
+}
+
 void CvtColor(Mat src, Mat dst, int code) {
     cv::cvtColor(*src, *dst, code);
 }

--- a/imgproc.h
+++ b/imgproc.h
@@ -11,6 +11,7 @@ extern "C" {
 #include "core.h"
 
 double ArcLength(Contour curve, bool is_closed);
+Contour ApproxPolyDP(Contour curve, double epsilon, bool closed);
 void CvtColor(Mat src, Mat dst, int code);
 void BilateralFilter(Mat src, Mat dst, int d, double sc, double ss);
 void Blur(Mat src, Mat dst, Size ps);


### PR DESCRIPTION
Fixes #73. This commit adds cv::approxPolyDP() bindings.

The test draws a hollow triangle and rectangle, then attempts to approximate the polygons' contours. In the event of a failure, a detailed message is printed:

```
$ go test -timeout 30s gocv.io/x/gocv -run ^TestApproxPolyDP$
--- FAIL: TestApproxPolyDP (0.00s)
	imgproc_test.go:27: Failed to approximate triangle.
		Actual:[(0,25) (25,75) (75,50)]
		Expect:[(25,25) (25,75) (75,50)]
FAIL
FAIL	gocv.io/x/gocv	0.054s
```