### PR TITLE
Add needed environment variables for Linux

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -20,6 +20,8 @@ elif [[ "$uname_val" == "Linux" ]]; then
                 export CGO_CXXFLAGS="--std=c++1z"
                 export CGO_LDFLAGS="-L/lib64 -lopencv_core -lopencv_face -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_xfeatures2d"
         else
+                export PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig"
+                export LD_LIBRARY_PATH="/usr/local/lib64"
                 export CGO_CPPFLAGS="-I/usr/local/include"
                 export CGO_CXXFLAGS="--std=c++1z"
                 export CGO_LDFLAGS="-L/usr/local/lib -lopencv_core -lopencv_face -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_xfeatures2d"


### PR DESCRIPTION
Some Linux distribution as Fedora need to add PKG_CONFIG_PATH and LD_LIBRARY_PATH to be sure to find libraries at compile time and execution time.
Because opencv is installed in `/usr/local`, we need to fix that paths.