### PR TITLE
Fixed unsigned int issue and added Mat.CopyToWithMask()

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -42,6 +42,11 @@ void Mat_CopyTo(Mat m, Mat dst) {
     m->copyTo(*dst);
 }
 
+// Mat_CopyToWithMask copies this Mat to another Mat while applying the mask
+void Mat_CopyToWithMask(Mat m, Mat dst, Mat mask) {
+    m->copyTo(*dst, *mask);
+}
+
 void Mat_ConvertTo(Mat m, Mat dst, int type) {
     m->convertTo(*dst, type);
 }

--- a/core.go
+++ b/core.go
@@ -226,8 +226,8 @@ func (m *Mat) Type() int {
 
 // GetUCharAt returns a value from a specific row/col in this Mat expecting it to
 // be of type uchar aka CV_8U.
-func (m *Mat) GetUCharAt(row int, col int) int8 {
-	return int8(C.Mat_GetUChar(m.p, C.int(row), C.int(col)))
+func (m *Mat) GetUCharAt(row int, col int) uint8 {
+	return uint8(C.Mat_GetUChar(m.p, C.int(row), C.int(col)))
 }
 
 // GetSCharAt returns a value from a specific row/col in this Mat expecting it to
@@ -262,7 +262,7 @@ func (m *Mat) GetDoubleAt(row int, col int) float64 {
 
 // SetUCharAt set a value from a specific row/col in this Mat expecting it to
 // be of type uchar aka CV_8U.
-func (m *Mat) SetUCharAt(row int, col int, val int8) {
+func (m *Mat) SetUCharAt(row int, col int, val uint8) {
 	C.Mat_SetUChar(m.p, C.int(row), C.int(col), C.uint8_t(val))
 }
 

--- a/core.go
+++ b/core.go
@@ -134,6 +134,16 @@ func (m *Mat) CopyTo(dst Mat) {
 	return
 }
 
+// CopyToWithMask copies Mat into destination Mat after applying the mask Mat.
+//
+// For further details, please see:
+// https://docs.opencv.org/3.4.0/d3/d63/classcv_1_1Mat.html#a626fe5f96d02525e2604d2ad46dd574f
+//
+func (m *Mat) CopyToWithMask(dst Mat, mask Mat) {
+	C.Mat_CopyToWithMask(m.p, dst.p, mask.p)
+	return
+}
+
 // ConvertTo converts Mat into destination Mat.
 //
 // For further details, please see:

--- a/core.h
+++ b/core.h
@@ -158,6 +158,7 @@ void Mat_Close(Mat m);
 int Mat_Empty(Mat m);
 Mat Mat_Clone(Mat m);
 void Mat_CopyTo(Mat m, Mat dst);
+void Mat_CopyToWithMask(Mat m, Mat dst, Mat mask);
 void Mat_ConvertTo(Mat m, Mat dst, int type);
 struct ByteArray Mat_ToBytes(Mat m);
 Mat Mat_Region(Mat m, Rect r);

--- a/core_test.go
+++ b/core_test.go
@@ -61,6 +61,32 @@ func TestMatCopyTo(t *testing.T) {
 	}
 }
 
+func TestMatCopyToWithMask(t *testing.T) {
+	mat := NewMatWithSize(101, 102, MatTypeCV8U)
+	mask := NewMatWithSize(101, 102, MatTypeCV8U)
+
+	mat.SetUCharAt(0, 0, 255)
+	mat.SetUCharAt(0, 1, 255)
+
+	mask.SetUCharAt(0, 0, 255)
+
+	copy := NewMat()
+
+	mat.CopyToWithMask(copy, mask)
+	if copy.Rows() != 101 {
+		t.Errorf("Mat copy incorrect row count: %v\n", copy.Rows())
+	}
+
+	if copy.Cols() != 102 {
+		t.Errorf("Mat copy incorrect col count: %v\n", copy.Cols())
+	}
+
+	if copy.GetUCharAt(0, 0) != 255 || copy.GetUCharAt(0, 1) != 0 {
+		t.Errorf("Mask failed to apply to source image")
+	}
+
+}
+
 func TestMatToBytes(t *testing.T) {
 	mat := NewMatWithSize(101, 102, MatTypeCV8U)
 	b := mat.ToBytes()


### PR DESCRIPTION
Two commits (dependent, because unsigned int issue blocked the test for CopyToWithMask()):
 * Updated type for Mat.GetUCharAt() and Mat.SetUCharAt() to reflect uint8 instead of int8
 * Added Mat.CopyToWithMask() per #47