### PR TITLE
Dnn updates

### DIFF
--- a/cmd/caffe-classifier/main.go
+++ b/cmd/caffe-classifier/main.go
@@ -14,7 +14,7 @@
 //
 // How to run:
 //
-// 		go run ./cmd/caffe-classifier/main.go 0 [protofile] [modelfile] [descriptionsfile]
+//    go run ./cmd/caffe-classifier/main.go 0 [protofile] [modelfile] [descriptionsfile]
 //
 // +build example
 
@@ -58,7 +58,22 @@ func main() {
 	deviceID, _ := strconv.Atoi(os.Args[1])
 	proto := os.Args[2]
 	model := os.Args[3]
-	descriptions, _ := readDescriptions(os.Args[4])
+	desc := os.Args[4]
+
+	//  read the descriptions file (the classnames)
+	descriptions, err := readDescriptions(desc)
+	if err != nil {
+		fmt.Printf("Error reading the descriptions file : %v\n", desc)
+		return
+	}
+
+	// read DNN classifier
+	net := gocv.ReadNetFromCaffe(proto, model)
+	if net.Empty() {
+		fmt.Printf("Error loading network from : %v %v\n", proto, model)
+		return
+	}
+	defer net.Close()
 
 	// open capture device
 	webcam, err := gocv.VideoCaptureDevice(int(deviceID))
@@ -73,10 +88,6 @@ func main() {
 
 	img := gocv.NewMat()
 	defer img.Close()
-
-	// open DNN classifier
-	net := gocv.ReadNetFromCaffe(proto, model)
-	defer net.Close()
 
 	status := "Ready"
 	statusColor := color.RGBA{0, 255, 0, 0}

--- a/cmd/tf-classifier/main.go
+++ b/cmd/tf-classifier/main.go
@@ -12,7 +12,7 @@
 //
 // How to run:
 //
-// 		go run ./cmd/tf-classifier/main.go 0 [modelfile] [descriptionsfile]
+//     go run ./cmd/tf-classifier/main.go 0 [modelfile] [descriptionsfile]
 //
 // +build example
 
@@ -55,7 +55,11 @@ func main() {
 	// parse args
 	deviceID, _ := strconv.Atoi(os.Args[1])
 	model := os.Args[2]
-	descriptions, _ := readDescriptions(os.Args[3])
+	descriptions, err := readDescriptions(os.Args[3])
+	if err != nil {
+		fmt.Printf("Error the descriptions file : %v\n", os.Args[3])
+		return
+	}
 
 	// open capture device
 	webcam, err := gocv.VideoCaptureDevice(deviceID)
@@ -73,6 +77,10 @@ func main() {
 
 	// open DNN classifier
 	net := gocv.ReadNetFromTensorflow(model)
+	if net.Empty() {
+		fmt.Printf("Error loading network from : %v\n", model)
+		return
+	}
 	defer net.Close()
 
 	status := "Ready"

--- a/dnn.cpp
+++ b/dnn.cpp
@@ -1,13 +1,38 @@
 #include "dnn.h"
 
 Net Net_ReadNetFromCaffe(const char* prototxt, const char* caffeModel) {
-    Net n = new cv::dnn::Net(cv::dnn::readNetFromCaffe(prototxt, caffeModel));
-    return n;
+    try {
+        return new cv::dnn::Net(cv::dnn::readNetFromCaffe(prototxt, caffeModel));
+    } catch(...) {}
+    return 0;
+}
+
+Net Net_ReadNetFromDarknet(const char* prototxt, const char* model) {
+    try {
+        return new cv::dnn::Net(cv::dnn::readNetFromDarknet(prototxt, model));
+    } catch(...) {}
+    return 0;
 }
 
 Net Net_ReadNetFromTensorflow(const char* model) {
-    Net n = new cv::dnn::Net(cv::dnn::readNetFromTensorflow(model));
-    return n;    
+    try {
+        return new cv::dnn::Net(cv::dnn::readNetFromTensorflow(model));
+    } catch(...) {}
+    return 0;
+}
+
+Net Net_ReadNetFromTensorflowProto(const char* model, const char* prototxt) {
+    try {
+        return new cv::dnn::Net(cv::dnn::readNetFromTensorflow(model, prototxt));
+    } catch(...) {}
+    return 0;
+}
+
+Net Net_ReadNetFromTorch(const char* model) {
+    try {
+        return new cv::dnn::Net(cv::dnn::readNetFromTorch(model));
+    } catch(...) {}
+    return 0;
 }
 
 void Net_Close(Net net) {

--- a/dnn.cpp
+++ b/dnn.cpp
@@ -7,30 +7,9 @@ Net Net_ReadNetFromCaffe(const char* prototxt, const char* caffeModel) {
     return 0;
 }
 
-Net Net_ReadNetFromDarknet(const char* prototxt, const char* model) {
-    try {
-        return new cv::dnn::Net(cv::dnn::readNetFromDarknet(prototxt, model));
-    } catch(...) {}
-    return 0;
-}
-
 Net Net_ReadNetFromTensorflow(const char* model) {
     try {
         return new cv::dnn::Net(cv::dnn::readNetFromTensorflow(model));
-    } catch(...) {}
-    return 0;
-}
-
-Net Net_ReadNetFromTensorflowProto(const char* model, const char* prototxt) {
-    try {
-        return new cv::dnn::Net(cv::dnn::readNetFromTensorflow(model, prototxt));
-    } catch(...) {}
-    return 0;
-}
-
-Net Net_ReadNetFromTorch(const char* model) {
-    try {
-        return new cv::dnn::Net(cv::dnn::readNetFromTorch(model));
     } catch(...) {}
     return 0;
 }

--- a/dnn.go
+++ b/dnn.go
@@ -34,7 +34,7 @@ func (net *Net) Close() error {
 //
 func (net *Net) Empty() bool {
 	if net.p == nil {
-		return true
+        return true
 	}
 	return bool(C.Net_Empty((C.Net)(net.p)))
 }
@@ -88,47 +88,6 @@ func ReadNetFromTensorflow(model string) Net {
 	cmodel := C.CString(model)
 	defer C.free(unsafe.Pointer(cmodel))
 	return Net{p: unsafe.Pointer(C.Net_ReadNetFromTensorflow(cmodel))}
-}
-
-// ReadNetFromTensorflowProto reads a network model stored in Tensorflow framework's format, and a (tweakable) prototxt.
-//   check net.Empty() for read failure
-//
-// For further details, please see:
-// https://docs.opencv.org/3.4.0/d6/d0f/group__dnn.html#gad820b280978d06773234ba6841e77e8d
-//
-func ReadNetFromTensorflowProto(model string, prototxt string) Net {
-	cprototxt := C.CString(prototxt)
-	defer C.free(unsafe.Pointer(cprototxt))
-
-	cmodel := C.CString(model)
-	defer C.free(unsafe.Pointer(cmodel))
-	return Net{p: unsafe.Pointer(C.Net_ReadNetFromTensorflowProto(cprototxt, cmodel))}
-}
-
-// ReadNetFromTorch reads a network model stored in Torch framework's format (t7).
-//   check net.Empty() for read failure
-//
-// For further details, please see:
-// https://docs.opencv.org/master/d6/d0f/group__dnn.html#gaaaed8c8530e9e92fe6647700c13d961e
-//
-func ReadNetFromTorch(model string) Net {
-	cmodel := C.CString(model)
-	defer C.free(unsafe.Pointer(cmodel))
-	return Net{p: unsafe.Pointer(C.Net_ReadNetFromTorch(cmodel))}
-}
-
-// ReadNetFromDarknet reads a network model stored in Darknet framework's format.
-//   check net.Empty() for read failure
-//
-// For further details, please see:
-// https://docs.opencv.org/master/d6/d0f/group__dnn.html#gafde362956af949cce087f3f25c6aff0d
-//
-func ReadNetFromDarknet(prototxt string, model string) Net {
-	cproto := C.CString(model)
-	defer C.free(unsafe.Pointer(cproto))
-	cmodel := C.CString(model)
-	defer C.free(unsafe.Pointer(cmodel))
-	return Net{p: unsafe.Pointer(C.Net_ReadNetFromDarknet(cproto, cmodel))}
 }
 
 // BlobFromImage creates 4-dimensional blob from image. Optionally resizes and crops

--- a/dnn.go
+++ b/dnn.go
@@ -33,6 +33,9 @@ func (net *Net) Close() error {
 // https://docs.opencv.org/3.4.0/db/d30/classcv_1_1dnn_1_1Net.html#a6a5778787d5b8770deab5eda6968e66c
 //
 func (net *Net) Empty() bool {
+	if net.p == nil {
+		return true
+	}
 	return bool(C.Net_Empty((C.Net)(net.p)))
 }
 
@@ -61,6 +64,7 @@ func (net *Net) Forward(outputName string) Mat {
 }
 
 // ReadNetFromCaffe reads a network model stored in Caffe framework's format.
+//   check net.Empty() for read failure
 //
 // For further details, please see:
 // https://docs.opencv.org/3.4.0/d6/d0f/group__dnn.html#ga946b342af1355185a7107640f868b64a
@@ -75,6 +79,7 @@ func ReadNetFromCaffe(prototxt string, caffeModel string) Net {
 }
 
 // ReadNetFromTensorflow reads a network model stored in Tensorflow framework's format.
+//   check net.Empty() for read failure
 //
 // For further details, please see:
 // https://docs.opencv.org/3.4.0/d6/d0f/group__dnn.html#gad820b280978d06773234ba6841e77e8d
@@ -83,6 +88,47 @@ func ReadNetFromTensorflow(model string) Net {
 	cmodel := C.CString(model)
 	defer C.free(unsafe.Pointer(cmodel))
 	return Net{p: unsafe.Pointer(C.Net_ReadNetFromTensorflow(cmodel))}
+}
+
+// ReadNetFromTensorflowProto reads a network model stored in Tensorflow framework's format, and a (tweakable) prototxt.
+//   check net.Empty() for read failure
+//
+// For further details, please see:
+// https://docs.opencv.org/3.4.0/d6/d0f/group__dnn.html#gad820b280978d06773234ba6841e77e8d
+//
+func ReadNetFromTensorflowProto(model string, prototxt string) Net {
+	cprototxt := C.CString(prototxt)
+	defer C.free(unsafe.Pointer(cprototxt))
+
+	cmodel := C.CString(model)
+	defer C.free(unsafe.Pointer(cmodel))
+	return Net{p: unsafe.Pointer(C.Net_ReadNetFromTensorflowProto(cprototxt, cmodel))}
+}
+
+// ReadNetFromTorch reads a network model stored in Torch framework's format (t7).
+//   check net.Empty() for read failure
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d6/d0f/group__dnn.html#gaaaed8c8530e9e92fe6647700c13d961e
+//
+func ReadNetFromTorch(model string) Net {
+	cmodel := C.CString(model)
+	defer C.free(unsafe.Pointer(cmodel))
+	return Net{p: unsafe.Pointer(C.Net_ReadNetFromTorch(cmodel))}
+}
+
+// ReadNetFromDarknet reads a network model stored in Darknet framework's format.
+//   check net.Empty() for read failure
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d6/d0f/group__dnn.html#gafde362956af949cce087f3f25c6aff0d
+//
+func ReadNetFromDarknet(prototxt string, model string) Net {
+	cproto := C.CString(model)
+	defer C.free(unsafe.Pointer(cproto))
+	cmodel := C.CString(model)
+	defer C.free(unsafe.Pointer(cmodel))
+	return Net{p: unsafe.Pointer(C.Net_ReadNetFromDarknet(cproto, cmodel))}
 }
 
 // BlobFromImage creates 4-dimensional blob from image. Optionally resizes and crops

--- a/dnn.h
+++ b/dnn.h
@@ -18,7 +18,10 @@ typedef void* Net;
 #endif
 
 Net Net_ReadNetFromCaffe(const char* prototxt, const char* caffeModel);
+Net Net_ReadNetFromDarknet(const char* prototxt, const char* model);
 Net Net_ReadNetFromTensorflow(const char* model);
+Net Net_ReadNetFromTensorflowProto(const char* model, const char* prototxt);
+Net Net_ReadNetFromTorch(const char* model);
 Mat Net_BlobFromImage(Mat image, double scalefactor, Size size, Scalar mean, bool swapRB, bool crop);
 void Net_Close(Net net);
 bool Net_Empty(Net net);

--- a/dnn.h
+++ b/dnn.h
@@ -18,10 +18,7 @@ typedef void* Net;
 #endif
 
 Net Net_ReadNetFromCaffe(const char* prototxt, const char* caffeModel);
-Net Net_ReadNetFromDarknet(const char* prototxt, const char* model);
 Net Net_ReadNetFromTensorflow(const char* model);
-Net Net_ReadNetFromTensorflowProto(const char* model, const char* prototxt);
-Net Net_ReadNetFromTorch(const char* model);
 Mat Net_BlobFromImage(Mat image, double scalefactor, Size size, Scalar mean, bool swapRB, bool crop);
 void Net_Close(Net net);
 bool Net_Empty(Net net);


### PR DESCRIPTION
opencv's dnn::readNetFrom* will throw cpp exceptions, if a prototxt or model was not found.

those have to be handled in the c++ code, so that users can check `net.Empty()` in their go code