### PR TITLE
cmd: check loading resources

### DIFF
--- a/cmd/caffe-classifier/main.go
+++ b/cmd/caffe-classifier/main.go
@@ -58,7 +58,12 @@ func main() {
 	deviceID, _ := strconv.Atoi(os.Args[1])
 	proto := os.Args[2]
 	model := os.Args[3]
-	descriptions, _ := readDescriptions(os.Args[4])
+	descr := os.Args[4]
+	descriptions, err := readDescriptions(descr)
+	if err != nil {
+		fmt.Printf("Error reading descriptions file: %v\n", descr)
+		return
+	}
 
 	// open capture device
 	webcam, err := gocv.VideoCaptureDevice(int(deviceID))
@@ -76,6 +81,10 @@ func main() {
 
 	// open DNN classifier
 	net := gocv.ReadNetFromCaffe(proto, model)
+	if net.Empty() {
+		fmt.Printf("Error reading network model from : %v %v\n", proto, model)
+		return
+	}
 	defer net.Close()
 
 	status := "Ready"

--- a/cmd/faceblur/main.go
+++ b/cmd/faceblur/main.go
@@ -53,7 +53,10 @@ func main() {
 	classifier := gocv.NewCascadeClassifier()
 	defer classifier.Close()
 
-	classifier.Load(xmlFile)
+	if !classifier.Load(xmlFile) {
+		fmt.Printf("Error reading cascade file: %v\n", xmlFile)
+		return
+	}
 
 	fmt.Printf("start reading camera device: %v\n", deviceID)
 	for {

--- a/cmd/facedetect/main.go
+++ b/cmd/facedetect/main.go
@@ -56,7 +56,10 @@ func main() {
 	classifier := gocv.NewCascadeClassifier()
 	defer classifier.Close()
 
-	classifier.Load(xmlFile)
+	if !classifier.Load(xmlFile) {
+		fmt.Printf("Error reading cascade file: %v\n", xmlFile)
+		return
+	}
 
 	fmt.Printf("start reading camera device: %v\n", deviceID)
 	for {

--- a/cmd/showimage/main.go
+++ b/cmd/showimage/main.go
@@ -12,16 +12,25 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"gocv.io/x/gocv"
 )
 
 func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("How to run:\n\tshowimage [imgfile]")
+		return
+	}
+
 	filename := os.Args[1]
 	window := gocv.NewWindow("Hello")
 	img := gocv.IMRead(filename, gocv.IMReadColor)
-
+	if img.Empty() {
+		fmt.Println("Error reading image from: %v", filename)
+		return
+	}
 	for {
 		window.IMShow(img)
 		if window.WaitKey(1) >= 0 {

--- a/cmd/tf-classifier/main.go
+++ b/cmd/tf-classifier/main.go
@@ -55,7 +55,12 @@ func main() {
 	// parse args
 	deviceID, _ := strconv.Atoi(os.Args[1])
 	model := os.Args[2]
-	descriptions, _ := readDescriptions(os.Args[3])
+	descr := os.Args[3]
+	descriptions, err := readDescriptions(descr)
+	if err != nil {
+		fmt.Printf("Error reading descriptions file: %v\n", descr)
+		return
+	}
 
 	// open capture device
 	webcam, err := gocv.VideoCaptureDevice(deviceID)
@@ -73,6 +78,10 @@ func main() {
 
 	// open DNN classifier
 	net := gocv.ReadNetFromTensorflow(model)
+	if net.Empty() {
+		fmt.Printf("Error reading network model : %v\n", model)
+		return
+	}
 	defer net.Close()
 
 	status := "Ready"


### PR DESCRIPTION
... murphy's law.

let's try to avoid panic situations like #72 . simply, every read or load call must be checked.

weird: the caffe-classifier example fails gracefully, the tf-classifier still panics (given a wrong filename).