### PR TITLE
Add WarpPerspective and GetPerspectiveTransform

### DIFF
--- a/core.go
+++ b/core.go
@@ -774,3 +774,18 @@ func toRectangles(ret C.Rects) []image.Rectangle {
 	}
 	return rects
 }
+
+func toCPoints(points []image.Point) C.struct_Points {
+	cPointSlice := make([]C.struct_Point, len(points))
+	for i, point := range points {
+		cPointSlice[i] = C.struct_Point{
+			x: C.int(point.X),
+			y: C.int(point.Y),
+		}
+	}
+
+	return C.struct_Points{
+		points: (*C.Point)(&cPointSlice[0]),
+		length: C.int(len(points)),
+	}
+}

--- a/core_test.go
+++ b/core_test.go
@@ -533,3 +533,16 @@ func TestScalar(t *testing.T) {
 		t.Error("Scalar has invalid value")
 	}
 }
+
+func TestToCPoints(t *testing.T) {
+	points := []image.Point{
+		image.Pt(0, 0),
+		image.Pt(1, 1),
+	}
+
+	cPoints := toCPoints(points)
+
+	if int(cPoints.length) != len(points) {
+		t.Error("Invalid C Points length")
+	}
+}

--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -245,10 +245,28 @@ void WarpAffineWithParams(Mat src, Mat dst, Mat rot_mat, Size dsize, int flags, 
   cv::warpAffine(*src, *dst, *rot_mat, sz, flags, borderMode, c);
 }
 
+void WarpPerspective(Mat src, Mat dst, Mat m, Size dsize) {
+  cv::Size sz(dsize.width, dsize.height);
+  cv::warpPerspective(*src, *dst, *m, sz);
+}
+
 void ApplyColorMap(Mat src, Mat dst, int colormap) {
   cv::applyColorMap(*src, *dst, colormap);
 }
 
 void ApplyCustomColorMap(Mat src, Mat dst, Mat colormap) {
   cv::applyColorMap(*src, *dst, *colormap);
+}
+
+Mat GetPerspectiveTransform(Contour src, Contour dst) {
+  std::vector<cv::Point2f> src_pts;
+  for (size_t i = 0; i < src.length; i++) {
+    src_pts.push_back(cv::Point2f(src.points[i].x, src.points[i].y));
+  }
+  std::vector<cv::Point2f> dst_pts;
+  for (size_t i = 0; i < dst.length; i++) {
+    dst_pts.push_back(cv::Point2f(dst.points[i].x, dst.points[i].y));
+  }
+
+  return new cv::Mat(cv::getPerspectiveTransform(src_pts, dst_pts));
 }

--- a/imgproc.go
+++ b/imgproc.go
@@ -19,19 +19,7 @@ import (
 // https://docs.opencv.org/3.4.0/d3/dc0/group__imgproc__shape.html#ga8d26483c636be6b35c3ec6335798a47c
 //
 func ArcLength(curve []image.Point, isClosed bool) float64 {
-	cPointSlice := make([]C.struct_Point, len(curve))
-	for i, point := range curve {
-		cPoint := C.struct_Point{
-			x: C.int(point.X),
-			y: C.int(point.Y),
-		}
-		cPointSlice[i] = cPoint
-	}
-
-	cPoints := C.struct_Points{
-		points: (*C.Point)(&cPointSlice[0]),
-		length: C.int(len(curve)),
-	}
+	cPoints := toCPoints(curve)
 	arcLength := C.ArcLength(cPoints, C.bool(isClosed))
 	return float64(arcLength)
 }
@@ -43,24 +31,18 @@ func ArcLength(curve []image.Point, isClosed bool) float64 {
 // https://docs.opencv.org/3.4.0/d3/dc0/group__imgproc__shape.html#ga0012a5fdaea70b8a9970165d98722b4c
 //
 func ApproxPolyDP(curve []image.Point, epsilon float64, closed bool) (approxCurve []image.Point) {
-	cPointArray := make([]C.struct_Point, len(curve))
-	for i, r := range curve {
-		cPointArray[i] = C.struct_Point{x: C.int(r.X), y: C.int(r.Y)}
-	}
-	cCurve := C.struct_Points{
-		points: (*C.Point)(&cPointArray[0]),
-		length: C.int(len(curve)),
-	}
+	cCurve := toCPoints(curve)
 
 	cApproxCurve := C.ApproxPolyDP(cCurve, C.double(epsilon), C.bool(closed))
 	defer C.Points_Close(cApproxCurve)
+
 	cApproxCurvePoints := (*[1 << 30]C.Point)(unsafe.Pointer(cApproxCurve.points))[:cApproxCurve.length:cApproxCurve.length]
 
 	approxCurve = make([]image.Point, cApproxCurve.length)
 	for i, cPoint := range cApproxCurvePoints {
 		approxCurve[i] = image.Pt(int(cPoint.x), int(cPoint.y))
 	}
-	return
+	return approxCurve
 }
 
 // ConvexHull finds the convex hull of a point set.
@@ -69,15 +51,7 @@ func ApproxPolyDP(curve []image.Point, epsilon float64, closed bool) (approxCurv
 // https://docs.opencv.org/3.4.0/d3/dc0/group__imgproc__shape.html#ga014b28e56cb8854c0de4a211cb2be656
 //
 func ConvexHull(points []image.Point, hull Mat, clockwise bool, returnPoints bool) {
-	cPointArray := make([]C.struct_Point, len(points))
-	for i, r := range points {
-		cPointArray[i] = C.struct_Point{x: C.int(r.X), y: C.int(r.Y)}
-	}
-	cPoints := C.struct_Points{
-		points: (*C.Point)(&cPointArray[0]),
-		length: C.int(len(points)),
-	}
-
+	cPoints := toCPoints(points)
 	C.ConvexHull(cPoints, hull.p, C.bool(clockwise), C.bool(returnPoints))
 }
 
@@ -87,15 +61,7 @@ func ConvexHull(points []image.Point, hull Mat, clockwise bool, returnPoints boo
 // https://docs.opencv.org/3.4.0/d3/dc0/group__imgproc__shape.html#gada4437098113fd8683c932e0567f47ba
 //
 func ConvexityDefects(contour []image.Point, hull Mat, result Mat) {
-	cPointArray := make([]C.struct_Point, len(contour))
-	for i, r := range contour {
-		cPointArray[i] = C.struct_Point{x: C.int(r.X), y: C.int(r.Y)}
-	}
-	cPoints := C.struct_Points{
-		points: (*C.Point)(&cPointArray[0]),
-		length: C.int(len(contour)),
-	}
-
+	cPoints := toCPoints(contour)
 	C.ConvexityDefects(cPoints, hull.p, result.p)
 }
 
@@ -214,20 +180,7 @@ const (
 // https://docs.opencv.org/3.3.0/d3/dc0/group__imgproc__shape.html#gacb413ddce8e48ff3ca61ed7cf626a366
 //
 func BoundingRect(contour []image.Point) image.Rectangle {
-	cPointArray := make([]C.struct_Point, len(contour))
-	for i, r := range contour {
-		cPoint := C.struct_Point{
-			x: C.int(r.X),
-			y: C.int(r.Y),
-		}
-		cPointArray[i] = cPoint
-	}
-
-	cContour := C.struct_Points{
-		points: (*C.Point)(&cPointArray[0]),
-		length: C.int(len(contour)),
-	}
-
+	cContour := toCPoints(contour)
 	r := C.BoundingRect(cContour)
 	rect := image.Rect(int(r.x), int(r.y), int(r.x+r.width), int(r.y+r.height))
 	return rect
@@ -239,20 +192,7 @@ func BoundingRect(contour []image.Point) image.Rectangle {
 // https://docs.opencv.org/3.3.0/d3/dc0/group__imgproc__shape.html#ga2c759ed9f497d4a618048a2f56dc97f1
 //
 func ContourArea(contour []image.Point) float64 {
-	cPointArray := make([]C.struct_Point, len(contour))
-	for i, r := range contour {
-		cPoint := C.struct_Point{
-			x: C.int(r.X),
-			y: C.int(r.Y),
-		}
-		cPointArray[i] = cPoint
-	}
-
-	cContour := C.struct_Points{
-		points: (*C.Point)(&cPointArray[0]),
-		length: C.int(len(contour)),
-	}
-
+	cContour := toCPoints(contour)
 	result := C.ContourArea(cContour)
 	return float64(result)
 }
@@ -985,32 +925,7 @@ func ApplyCustomColorMap(src, dst, customColormap Mat) {
 // For further details, please see:
 // https://docs.opencv.org/3.4.0/da/d54/group__imgproc__transform.html#ga8c1ae0e3589a9d77fffc962c49b22043
 func GetPerspectiveTransform(src, dst []image.Point) Mat {
-	srcPointSlice := make([]C.struct_Point, len(src))
-	dstPointSlice := make([]C.struct_Point, len(dst))
-
-	for i, point := range src {
-		cPoint := C.struct_Point{
-			x: C.int(point.X),
-			y: C.int(point.Y),
-		}
-		srcPointSlice[i] = cPoint
-	}
-	srcPoints := C.struct_Points{
-		points: (*C.Point)(&srcPointSlice[0]),
-		length: C.int(len(src)),
-	}
-
-	for i, point := range dst {
-		cPoint := C.struct_Point{
-			x: C.int(point.X),
-			y: C.int(point.Y),
-		}
-		dstPointSlice[i] = cPoint
-	}
-	dstPoints := C.struct_Points{
-		points: (*C.Point)(&dstPointSlice[0]),
-		length: C.int(len(dst)),
-	}
-
+	srcPoints := toCPoints(src)
+	dstPoints := toCPoints(dst)
 	return Mat{p: C.GetPerspectiveTransform(srcPoints, dstPoints)}
 }

--- a/imgproc.go
+++ b/imgproc.go
@@ -924,6 +924,19 @@ func WarpAffineWithParams(src, dst, m Mat, sz image.Point, flags InterpolationFl
 	C.WarpAffineWithParams(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv)
 }
 
+// WarpPerspective applies a perspective transformation to an image.
+//
+// For further details, please see:
+// https://docs.opencv.org/3.4.0/da/d54/group__imgproc__transform.html#gaf73673a7e8e18ec6963e3774e6a94b87
+func WarpPerspective(src, dst, m Mat, sz image.Point) {
+	pSize := C.struct_Size{
+		width:  C.int(sz.X),
+		height: C.int(sz.Y),
+	}
+
+	C.WarpPerspective(src.p, dst.p, m.p, pSize)
+}
+
 // ColormapTypes are the 12 GNU Octave/MATLAB equivalent colormaps.
 //
 // For further details, please see:
@@ -964,4 +977,40 @@ func ApplyColorMap(src, dst Mat, colormapType ColormapTypes) {
 // https://docs.opencv.org/3.4.0/d3/d50/group__imgproc__colormap.html#gacb22288ddccc55f9bd9e6d492b409cae
 func ApplyCustomColorMap(src, dst, customColormap Mat) {
 	C.ApplyCustomColorMap(src.p, dst.p, customColormap.p)
+}
+
+// GetPerspectiveTransform returns 3x3 perspective transformation for the
+// corresponding 4 point pairs.
+//
+// For further details, please see:
+// https://docs.opencv.org/3.4.0/da/d54/group__imgproc__transform.html#ga8c1ae0e3589a9d77fffc962c49b22043
+func GetPerspectiveTransform(src, dst []image.Point) Mat {
+	srcPointSlice := make([]C.struct_Point, len(src))
+	dstPointSlice := make([]C.struct_Point, len(dst))
+
+	for i, point := range src {
+		cPoint := C.struct_Point{
+			x: C.int(point.X),
+			y: C.int(point.Y),
+		}
+		srcPointSlice[i] = cPoint
+	}
+	srcPoints := C.struct_Points{
+		points: (*C.Point)(&srcPointSlice[0]),
+		length: C.int(len(src)),
+	}
+
+	for i, point := range dst {
+		cPoint := C.struct_Point{
+			x: C.int(point.X),
+			y: C.int(point.Y),
+		}
+		dstPointSlice[i] = cPoint
+	}
+	dstPoints := C.struct_Points{
+		points: (*C.Point)(&dstPointSlice[0]),
+		length: C.int(len(dst)),
+	}
+
+	return Mat{p: C.GetPerspectiveTransform(srcPoints, dstPoints)}
 }

--- a/imgproc.h
+++ b/imgproc.h
@@ -53,8 +53,10 @@ void Resize(Mat src, Mat dst, Size sz, double fx, double fy, int interp);
 Mat GetRotationMatrix2D(Point center, double angle, double scale);
 void WarpAffine(Mat src, Mat dst, Mat rot_mat, Size dsize);
 void WarpAffineWithParams(Mat src, Mat dst, Mat rot_mat, Size dsize, int flags, int borderMode, Scalar borderValue);
+void WarpPerspective(Mat src, Mat dst, Mat m, Size dsize);
 void ApplyColorMap(Mat src, Mat dst, int colormap);
 void ApplyCustomColorMap(Mat src, Mat dst, Mat colormap);
+Mat GetPerspectiveTransform(Contour src, Contour dst);
 #ifdef __cplusplus
 }
 #endif

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -724,3 +724,62 @@ func TestApplyCustomColorMap(t *testing.T) {
 		t.Errorf("TestApplyCustomColorMap() = %v, want %v", result, 0.0)
 	}
 }
+
+func TestGetPerspectiveTransform(t *testing.T) {
+	src := []image.Point{
+		image.Pt(0, 0),
+		image.Pt(10, 5),
+		image.Pt(10, 10),
+		image.Pt(5, 10),
+	}
+	dst := []image.Point{
+		image.Pt(0, 0),
+		image.Pt(10, 0),
+		image.Pt(10, 10),
+		image.Pt(0, 10),
+	}
+
+	m := GetPerspectiveTransform(src, dst)
+
+	if m.Cols() != 3 {
+		t.Errorf("TestWarpPerspective(): unexpected cols = %v, want = %v", m.Cols(), 3)
+	}
+	if m.Rows() != 3 {
+		t.Errorf("TestWarpPerspective(): unexpected rows = %v, want = %v", m.Rows(), 3)
+	}
+}
+
+func TestWarpPerspective(t *testing.T) {
+	img := IMRead("images/gocvlogo.jpg", IMReadUnchanged)
+	defer img.Close()
+
+	w := img.Cols()
+	h := img.Rows()
+
+	s := []image.Point{
+		image.Pt(0, 0),
+		image.Pt(10, 5),
+		image.Pt(10, 10),
+		image.Pt(5, 10),
+	}
+	d := []image.Point{
+		image.Pt(0, 0),
+		image.Pt(10, 0),
+		image.Pt(10, 10),
+		image.Pt(0, 10),
+	}
+	m := GetPerspectiveTransform(s, d)
+
+	dst := NewMat()
+	defer dst.Close()
+
+	WarpPerspective(img, dst, m, image.Pt(w, h))
+
+	if dst.Cols() != w {
+		t.Errorf("TestWarpPerspective(): unexpected cols = %v, want = %v", dst.Cols(), w)
+	}
+
+	if dst.Rows() != h {
+		t.Errorf("TestWarpPerspective(): unexpected rows = %v, want = %v", dst.Rows(), h)
+	}
+}


### PR DESCRIPTION
Hi,

I am learning OpenCV (like I started today) and chose your lib to write Go code. I am playing with image manipulation to be able to read content from pictures. I had to apply a perspective transformation, so I've added two new functions to the `gocv` API. I use these functions that way:

``` go
        // `corners` is also of type `[]image.Point` and contains the actual corners of the "thing" I am interested in the image.

	gridWidth := int(math.Max(widthTop, widthBottom))
	gridHeight := int(math.Max(heightLeft, heightRight))

	flatCorners := []image.Point{
		image.Pt(0, 0),
		image.Pt(gridWidth, 0),
		image.Pt(gridWidth, gridHeight),
		image.Pt(0, gridHeight),
	}

	m := gocv.GetPerspectiveTransform(corners, flatCorners)
	gocv.WarpPerspective(img, img, m, image.Pt(gridWidth, gridHeight))
```

~Because I am not entirely sure it is written correctly (did not find anything in the contributing file) and also because **I have to write tests** (but need to understand what to test exactly), **the PR is in WIP state**.~ Feel free to leave comments to help me/tell me what you'd expect.

Thanks,
William