### PR TITLE
Add DrawContours()

### DIFF
--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -270,3 +270,20 @@ Mat GetPerspectiveTransform(Contour src, Contour dst) {
 
   return new cv::Mat(cv::getPerspectiveTransform(src_pts, dst_pts));
 }
+
+void DrawContours(Mat src, Contours contours, int contourIdx, Scalar color, int thickness) {
+  std::vector<std::vector<cv::Point> > cntrs;
+  for (size_t i = 0; i < contours.length; i++) {
+    Contour contour = contours.contours[i];
+
+    std::vector<cv::Point> cntr;
+    for (size_t i = 0; i < contour.length; i++) {
+      cntr.push_back(cv::Point(contour.points[i].x, contour.points[i].y));
+    }
+
+    cntrs.push_back(cntr);
+  }
+
+  cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+  cv::drawContours(*src, cntrs, contourIdx, c, thickness);
+}

--- a/imgproc.h
+++ b/imgproc.h
@@ -57,6 +57,7 @@ void WarpPerspective(Mat src, Mat dst, Mat m, Size dsize);
 void ApplyColorMap(Mat src, Mat dst, int colormap);
 void ApplyCustomColorMap(Mat src, Mat dst, Mat colormap);
 Mat GetPerspectiveTransform(Contour src, Contour dst);
+void DrawContours(Mat src, Contours contours, int contourIdx, Scalar color, int thickness);
 #ifdef __cplusplus
 }
 #endif

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -783,3 +783,31 @@ func TestWarpPerspective(t *testing.T) {
 		t.Errorf("TestWarpPerspective(): unexpected rows = %v, want = %v", dst.Rows(), h)
 	}
 }
+
+func TestDrawContours(t *testing.T) {
+	img := NewMatWithSize(100, 200, MatTypeCV8UC1)
+	defer img.Close()
+
+	// Draw rectangle
+	white := color.RGBA{255, 255, 255, 255}
+	Rectangle(img, image.Rect(125, 25, 175, 75), white, 1)
+
+	contours := FindContours(img, RetrievalExternal, ChainApproxSimple)
+
+	if v := img.GetUCharAt(23, 123); v != 0 {
+		t.Errorf("TestDrawContours(): wrong pixel value = %v, want = %v", v, 0)
+	}
+	if v := img.GetUCharAt(25, 125); v != 206 {
+		t.Errorf("TestDrawContours(): wrong pixel value = %v, want = %v", v, 206)
+	}
+
+	DrawContours(img, contours, -1, white, 2)
+
+	// contour should be drawn with thickness = 2
+	if v := img.GetUCharAt(24, 124); v != 255 {
+		t.Errorf("TestDrawContours(): contour has not been drawn (value = %v, want = %v)", v, 255)
+	}
+	if v := img.GetUCharAt(25, 125); v != 255 {
+		t.Errorf("TestDrawContours(): contour has not been drawn (value = %v, want = %v)", v, 255)
+	}
+}


### PR DESCRIPTION
This PR adds the `DrawContours()` function.

The test case creates the following image:

![before](https://user-images.githubusercontent.com/217628/36888913-d7b6a018-1df7-11e8-8646-4d9acb54f766.jpg)

It finds the contours of the square and draws them with a larger border:

![after](https://user-images.githubusercontent.com/217628/36888912-d78c9156-1df7-11e8-9755-33d41cea4bfb.jpg)

---

~~This PR works only when disabling CGO checks (`GODEBUG=cgocheck=0`) because I
am passing a struct of structs (slice of slices) and it breaks one of the CGO
"rules" I guess.~~

~~I am not really sure to know how to fix this to be honest, maybe we would need
a different C structure to handle multidimensional arrays of `cv::Point` and
being able to pass such data structures from Go to C. In `FindContours()`, we
have done the opposite and it seems to work, so there must be a way, but I just
don't know what to do here right now.~~