### PR TITLE
Tracking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,9 @@ before_cache:
 
 script:
   - export CGO_CPPFLAGS="-I${HOME}/usr/include"
-  - export CGO_LDFLAGS="-L${HOME}/usr/lib -lopencv_core -lopencv_videoio -lopencv_face -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_xfeatures2d"
+  - export CGO_LDFLAGS="-L${HOME}/usr/lib -lopencv_core -lopencv_videoio -lopencv_face -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_xfeatures2d -lopencv_plot -lopencv_tracking"
   - export GOCV_CAFFE_TEST_FILES="${HOME}/testdata"
-  - export GOCV_TENSORFLOW_TEST_FILES="${HOME}/testdata"  
+  - export GOCV_TENSORFLOW_TEST_FILES="${HOME}/testdata"
   - echo "Ensuring code is well formatted"; ! gofmt -s -d . | read
   - go test -coverprofile=coverage.txt -covermode=atomic
   - go test ./contrib -coverprofile=contrib.txt -covermode=atomic; cat contrib.txt >> coverage.txt; rm contrib.txt;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   - cd c:\gopath\src\gocv.io\x\gocv
   - go get -d .
   - set CGO_CPPFLAGS=-IC:\opencv\build\install\include
-  - set CGO_LDFLAGS=-LC:\opencv\build\install\x64\mingw\lib -lopencv_core341 -lopencv_face341 -lopencv_videoio341 -lopencv_imgproc341 -lopencv_highgui341 -lopencv_imgcodecs341 -lopencv_objdetect341 -lopencv_features2d341 -lopencv_video341 -lopencv_dnn341 -lopencv_xfeatures2d341
+  - set CGO_LDFLAGS=-LC:\opencv\build\install\x64\mingw\lib -lopencv_core341 -lopencv_face341 -lopencv_videoio341 -lopencv_imgproc341 -lopencv_highgui341 -lopencv_imgcodecs341 -lopencv_objdetect341 -lopencv_features2d341 -lopencv_video341 -lopencv_dnn341 -lopencv_xfeatures2d341 -lopencv_plot341 -lopencv_tracking341
   - set GOCV_CAFFE_TEST_FILES=C:\opencv\testdata
   - set GOCV_TENSORFLOW_TEST_FILES=C:\opencv\testdata
   - go env

--- a/cmd/tracking/main.go
+++ b/cmd/tracking/main.go
@@ -1,0 +1,105 @@
+// What it does:
+//
+// This example uses one of the Tracker classes from opencv_contrib to track a region of interest (e.g. a face)
+// and draws a rectangle around it, before displaying it within a Window.
+//
+// in this example, users have to select an initial roi with the mouse, and press enter, to start the tracking
+// (but the roi could also come from e.g. a previous cascade based detection)
+//
+// also see https://docs.opencv.org/master/d2/d0a/tutorial_introduction_to_tracker.html for a tutorial
+//
+// How to run:
+//
+// tracking [camera ID]
+//
+// 		go run ./cmd/tracking/main.go 0
+//
+// +build example
+
+package main
+
+import (
+	"fmt"
+	"image/color"
+	"os"
+	"strconv"
+
+	"gocv.io/x/gocv"
+	"gocv.io/x/gocv/contrib"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("How to run:\n\ttracking [camera ID]")
+		return
+	}
+
+	// parse args
+	deviceID, _ := strconv.Atoi(os.Args[1])
+
+	// open webcam
+	webcam, err := gocv.VideoCaptureDevice(int(deviceID))
+	if err != nil {
+		fmt.Printf("error opening video capture device: %v\n", deviceID)
+		return
+	}
+	defer webcam.Close()
+
+	// open display window
+	window := gocv.NewWindow("Tracking")
+	defer window.Close()
+
+	// create a tracker instance
+	// (one of Mil,Kcf,Tld,MedianFlow,Boosting or Mosse)
+	tracker := contrib.NewTrackerMosse()
+	defer tracker.Close()
+
+	// prepare image matrix
+	img := gocv.NewMat()
+	defer img.Close()
+
+	// read an initial image
+	if ok := webcam.Read(img); !ok {
+		fmt.Printf("cannot read device %d\n", deviceID)
+		return
+	}
+
+	// let the user mark a ROI to track
+	rect := gocv.SelectROI("Tracking", img)
+	if rect.Max.X == 0 {
+		fmt.Printf("user cancelled roi selection\n")
+		return
+	}
+
+	// initialize the tracker with the image & the selected roi
+	init := tracker.Init(img, rect)
+	if !init {
+		fmt.Printf("Could not initialize the Tracker")
+		return
+	}
+
+	// color for the rect to draw
+	blue := color.RGBA{0, 0, 255, 0}
+	fmt.Printf("start reading camera device: %v\n", deviceID)
+	for {
+		if ok := webcam.Read(img); !ok {
+			fmt.Printf("cannot read device %d\n", deviceID)
+			return
+		}
+		if img.Empty() {
+			continue
+		}
+
+		// update the roi
+		rect, _ := tracker.Update(img)
+
+		// draw it.
+		gocv.Rectangle(img, rect, blue, 3)
+
+		// show the image in the window, and wait 10 millisecond
+		window.IMShow(img)
+		if window.WaitKey(10) >= 0 {
+			break
+		}
+	}
+}

--- a/cmd/tracking/main.go
+++ b/cmd/tracking/main.go
@@ -50,8 +50,8 @@ func main() {
 	defer window.Close()
 
 	// create a tracker instance
-	// (one of Mil,Kcf,Tld,MedianFlow,Boosting or Mosse)
-	tracker := contrib.NewTrackerMosse()
+	// (one of MIL, KCF, TLD, MedianFlow, Boosting, MOSSE or CSRT)
+	tracker := contrib.NewTrackerMOSSE()
 	defer tracker.Close()
 
 	// prepare image matrix

--- a/contrib/tracking.cpp
+++ b/contrib/tracking.cpp
@@ -3,34 +3,29 @@
 
 
 bool Tracker_Init(Tracker self, Mat image, Rect boundingBox) {
-    cv::Rect2d c_boundingBox(boundingBox.x, boundingBox.y, boundingBox.width, boundingBox.height);
+    cv::Rect2d bb(boundingBox.x, boundingBox.y, boundingBox.width, boundingBox.height);
 
-    bool ret = (*self)->init(*image, c_boundingBox);
+    bool ret = (*self)->init(*image, bb);
     return ret;
 }
-
 
 bool Tracker_Update(Tracker self, Mat image, Rect *boundingBox) {
-    cv::Rect2d cBox;
-    bool ret = (*self)->update(*image, cBox);
-    boundingBox->x = int(cBox.x);
-    boundingBox->y = int(cBox.y);
-    boundingBox->width = int(cBox.width);
-    boundingBox->height = int(cBox.height);
+    cv::Rect2d bb;
+    bool ret = (*self)->update(*image, bb);
+    boundingBox->x = int(bb.x);
+    boundingBox->y = int(bb.y);
+    boundingBox->width = int(bb.width);
+    boundingBox->height = int(bb.height);
     return ret;
 }
 
-
-
-
-TrackerMil TrackerMil_Create() {
+TrackerMIL TrackerMIL_Create() {
     return new cv::Ptr<cv::TrackerMIL>(cv::TrackerMIL::create());
 }
 
-void TrackerMil_Close(TrackerMil self){
+void TrackerMIL_Close(TrackerMIL self){
     delete self;
 }
-
 
 TrackerBoosting TrackerBoosting_Create() {
     return new cv::Ptr<cv::TrackerBoosting>(cv::TrackerBoosting::create());
@@ -40,7 +35,6 @@ void TrackerBoosting_Close(TrackerBoosting self){
 	delete self;
 }
 
-
 TrackerMedianFlow TrackerMedianFlow_Create() {
     return new cv::Ptr<cv::TrackerMedianFlow>(cv::TrackerMedianFlow::create());
 }
@@ -49,39 +43,34 @@ void TrackerMedianFlow_Close(TrackerMedianFlow self){
 	delete self;
 }
 
-
-TrackerTld TrackerTld_Create() {
+TrackerTLD TrackerTLD_Create() {
     return new cv::Ptr<cv::TrackerTLD>(cv::TrackerTLD::create());
 }
 
-void TrackerTld_Close(TrackerTld self){
+void TrackerTLD_Close(TrackerTLD self){
     delete self;
 }
 
-
-TrackerKcf TrackerKcf_Create() {
+TrackerKCF TrackerKCF_Create() {
     return new cv::Ptr<cv::TrackerKCF>(cv::TrackerKCF::create());
 }
 
-void TrackerKcf_Close(TrackerKcf self){
+void TrackerKCF_Close(TrackerKCF self){
     delete self;
 }
 
-
-TrackerMosse TrackerMosse_Create() {
+TrackerMOSSE TrackerMOSSE_Create() {
     return new cv::Ptr<cv::TrackerMOSSE>(cv::TrackerMOSSE::create());
 }
 
-void TrackerMosse_Close(TrackerMosse self){
+void TrackerMOSSE_Close(TrackerMOSSE self){
     delete self;
 }
 
-
-
-TrackerCsrt TrackerCsrt_Create() {
+TrackerCSRT TrackerCSRT_Create() {
     return new cv::Ptr<cv::TrackerCSRT>(cv::TrackerCSRT::create());
 }
 
-void TrackerCsrt_Close(TrackerCsrt self){
+void TrackerCSRT_Close(TrackerCSRT self){
     delete self;
 }

--- a/contrib/tracking.cpp
+++ b/contrib/tracking.cpp
@@ -1,0 +1,87 @@
+#include "tracking.h"
+#include <opencv2/opencv.hpp>
+
+
+bool Tracker_Init(Tracker self, Mat image, Rect boundingBox) {
+    cv::Rect2d c_boundingBox(boundingBox.x, boundingBox.y, boundingBox.width, boundingBox.height);
+
+    bool ret = (*self)->init(*image, c_boundingBox);
+    return ret;
+}
+
+
+bool Tracker_Update(Tracker self, Mat image, Rect *boundingBox) {
+    cv::Rect2d cBox;
+    bool ret = (*self)->update(*image, cBox);
+    boundingBox->x = int(cBox.x);
+    boundingBox->y = int(cBox.y);
+    boundingBox->width = int(cBox.width);
+    boundingBox->height = int(cBox.height);
+    return ret;
+}
+
+
+
+
+TrackerMil TrackerMil_Create() {
+    return new cv::Ptr<cv::TrackerMIL>(cv::TrackerMIL::create());
+}
+
+void TrackerMil_Close(TrackerMil self){
+    delete self;
+}
+
+
+TrackerBoosting TrackerBoosting_Create() {
+    return new cv::Ptr<cv::TrackerBoosting>(cv::TrackerBoosting::create());
+}
+
+void TrackerBoosting_Close(TrackerBoosting self){
+	delete self;
+}
+
+
+TrackerMedianFlow TrackerMedianFlow_Create() {
+    return new cv::Ptr<cv::TrackerMedianFlow>(cv::TrackerMedianFlow::create());
+}
+
+void TrackerMedianFlow_Close(TrackerMedianFlow self){
+	delete self;
+}
+
+
+TrackerTld TrackerTld_Create() {
+    return new cv::Ptr<cv::TrackerTLD>(cv::TrackerTLD::create());
+}
+
+void TrackerTld_Close(TrackerTld self){
+    delete self;
+}
+
+
+TrackerKcf TrackerKcf_Create() {
+    return new cv::Ptr<cv::TrackerKCF>(cv::TrackerKCF::create());
+}
+
+void TrackerKcf_Close(TrackerKcf self){
+    delete self;
+}
+
+
+TrackerMosse TrackerMosse_Create() {
+    return new cv::Ptr<cv::TrackerMOSSE>(cv::TrackerMOSSE::create());
+}
+
+void TrackerMosse_Close(TrackerMosse self){
+    delete self;
+}
+
+
+
+TrackerCsrt TrackerCsrt_Create() {
+    return new cv::Ptr<cv::TrackerCSRT>(cv::TrackerCSRT::create());
+}
+
+void TrackerCsrt_Close(TrackerCsrt self){
+    delete self;
+}

--- a/contrib/tracking.go
+++ b/contrib/tracking.go
@@ -1,0 +1,256 @@
+package contrib
+
+/*
+#include "tracking.h"
+*/
+import "C"
+import (
+	"image"
+
+	"gocv.io/x/gocv"
+)
+
+// Tracker - the base interface for object tracking
+//
+// s.a: https://docs.opencv.org/master/d0/d0a/classcv_1_1Tracker.html
+type Tracker interface {
+	// Init initializes the tracker with a known bounding box that surrounded the target
+	// note: this can only be called once. if you loose the object, you have to Close() the instance,
+	// create a new one, and call Init on it again
+	//
+	// https://docs.opencv.org/master/d0/d0a/classcv_1_1Tracker.html#a4d285747589b1bdd16d2e4f00c3255dc
+	Init(image gocv.Mat, boundingBox image.Rectangle) bool
+
+	// Update the tracker, return new bounding box and a bool, if it lost it.
+	//
+	// https://docs.opencv.org/master/d0/d0a/classcv_1_1Tracker.html#a549159bd0553e6a8de356f3866df1f18
+	Update(image gocv.Mat) (image.Rectangle, bool)
+}
+
+//
+// available implementations in gocv are:
+//
+// TrackerMil;
+// TrackerBoosting;
+// TrackerMedianFlow;
+// TrackerTld;
+// TrackerKcf;
+// TrackerMosse;
+// TrackerCsrt;
+//
+
+// (private) implementation helpers for init and update (saves some boilerplate code)
+func tracker_Init(trk C.Tracker, img gocv.Mat, boundingBox image.Rectangle) bool {
+	cBox := C.struct_Rect{
+		x:      C.int(boundingBox.Min.X),
+		y:      C.int(boundingBox.Min.Y),
+		width:  C.int(boundingBox.Size().X),
+		height: C.int(boundingBox.Size().Y),
+	}
+
+	ret := C.Tracker_Init(trk, C.Mat(img.Ptr()), cBox)
+	return bool(ret)
+}
+
+func tracker_Update(trk C.Tracker, img gocv.Mat) (image.Rectangle, bool) {
+	cBox := C.struct_Rect{}
+
+	ret := C.Tracker_Update(trk, C.Mat(img.Ptr()), &cBox)
+
+	rect := image.Rect(int(cBox.x), int(cBox.y), int(cBox.x+cBox.width), int(cBox.y+cBox.height))
+	return rect, bool(ret)
+}
+
+//
+// Mil
+// The MIL algorithm trains a classifier in an online manner to separate the object from the background.
+// Multiple Instance Learning avoids the drift problem for a robust tracking.
+//
+// s.a: https://docs.opencv.org/master/d0/d26/classcv_1_1TrackerMIL.html
+type TrackerMil struct {
+	p C.TrackerMil
+}
+
+func NewTrackerMil() TrackerMil {
+	return TrackerMil{p: C.TrackerMil_Create()}
+}
+
+func (self *TrackerMil) Close() error {
+	C.TrackerMil_Close(self.p)
+	self.p = nil
+	return nil
+}
+
+func (self TrackerMil) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+	return tracker_Init(C.Tracker(self.p), img, boundingBox)
+}
+
+func (self TrackerMil) Update(img gocv.Mat) (image.Rectangle, bool) {
+	return tracker_Update(C.Tracker(self.p), img)
+}
+
+//
+// Boosting
+// This is a real-time object tracking based on a novel on-line version of the AdaBoost algorithm.
+//
+// s.a: https://docs.opencv.org/master/d1/d1a/classcv_1_1TrackerBoosting.html
+type TrackerBoosting struct {
+	p C.TrackerBoosting
+}
+
+func NewTrackerBoosting() TrackerBoosting {
+	return TrackerBoosting{p: C.TrackerBoosting_Create()}
+}
+
+func (self *TrackerBoosting) Close() error {
+	C.TrackerBoosting_Close(self.p)
+	self.p = nil
+	return nil
+}
+
+func (self TrackerBoosting) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+	return tracker_Init(C.Tracker(self.p), img, boundingBox)
+}
+
+func (self TrackerBoosting) Update(img gocv.Mat) (image.Rectangle, bool) {
+	return tracker_Update(C.Tracker(self.p), img)
+}
+
+//
+// MedianFlow
+// The tracker is suitable for very smooth and predictable movements when object is visible throughout the whole sequence
+//
+// s.a: https://docs.opencv.org/master/d7/d86/classcv_1_1TrackerMedianFlow.html
+type TrackerMedianFlow struct {
+	p C.TrackerMedianFlow
+}
+
+func NewTrackerMedianFlow() TrackerMedianFlow {
+	return TrackerMedianFlow{p: C.TrackerMedianFlow_Create()}
+}
+
+func (self *TrackerMedianFlow) Close() error {
+	C.TrackerMedianFlow_Close(self.p)
+	self.p = nil
+	return nil
+}
+
+func (self TrackerMedianFlow) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+	return tracker_Init(C.Tracker(self.p), img, boundingBox)
+}
+
+func (self TrackerMedianFlow) Update(img gocv.Mat) (image.Rectangle, bool) {
+	return tracker_Update(C.Tracker(self.p), img)
+}
+
+//
+// Tld
+// TLD is a novel tracking framework that explicitly decomposes the long-term tracking task into tracking, learning and detection.
+//
+// s.a: https://docs.opencv.org/master/dc/d1c/classcv_1_1TrackerTLD.html
+type TrackerTld struct {
+	p C.TrackerTld
+}
+
+func NewTrackerTld() TrackerTld {
+	return TrackerTld{p: C.TrackerTld_Create()}
+}
+
+func (self *TrackerTld) Close() error {
+	C.TrackerTld_Close(self.p)
+	self.p = nil
+	return nil
+}
+
+func (self TrackerTld) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+	return tracker_Init(C.Tracker(self.p), img, boundingBox)
+}
+
+func (self TrackerTld) Update(img gocv.Mat) (image.Rectangle, bool) {
+	return tracker_Update(C.Tracker(self.p), img)
+}
+
+//
+// Kcf
+// KCF is a novel tracking framework that utilizes properties of circulant matrix to enhance the processing speed.
+//
+// s.a: https://docs.opencv.org/master/d2/dff/classcv_1_1TrackerKCF.html
+//
+type TrackerKcf struct {
+	p C.TrackerKcf
+}
+
+func NewTrackerKcf() TrackerKcf {
+	return TrackerKcf{p: C.TrackerKcf_Create()}
+}
+
+func (self *TrackerKcf) Close() error {
+	C.TrackerKcf_Close(self.p)
+	self.p = nil
+	return nil
+}
+
+func (self TrackerKcf) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+	return tracker_Init(C.Tracker(self.p), img, boundingBox)
+}
+
+func (self TrackerKcf) Update(img gocv.Mat) (image.Rectangle, bool) {
+	return tracker_Update(C.Tracker(self.p), img)
+}
+
+//
+// Mosse
+// based on: Visual Object Tracking using Adaptive Correlation Filters
+// note, that this tracker is working on graysccale images
+//
+// s.a: https://docs.opencv.org/master/d0/d02/classcv_1_1TrackerMOSSE.html
+//
+type TrackerMosse struct {
+	p C.TrackerMosse
+}
+
+func NewTrackerMosse() TrackerMosse {
+	return TrackerMosse{p: C.TrackerMosse_Create()}
+}
+
+func (self *TrackerMosse) Close() error {
+	C.TrackerMosse_Close(self.p)
+	self.p = nil
+	return nil
+}
+
+func (self TrackerMosse) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+	return tracker_Init(C.Tracker(self.p), img, boundingBox)
+}
+
+func (self TrackerMosse) Update(img gocv.Mat) (image.Rectangle, bool) {
+	return tracker_Update(C.Tracker(self.p), img)
+}
+
+//
+// Csrt
+// Discriminative Correlation Filter Tracker with Channel and Spatial Reliability.
+//
+// s.a: https://docs.opencv.org/master/d2/da2/classcv_1_1TrackerCSRT.html
+//
+type TrackerCsrt struct {
+	p C.TrackerCsrt
+}
+
+func NewTrackerCsrt() TrackerCsrt {
+	return TrackerCsrt{p: C.TrackerCsrt_Create()}
+}
+
+func (self *TrackerCsrt) Close() error {
+	C.TrackerCsrt_Close(self.p)
+	self.p = nil
+	return nil
+}
+
+func (self TrackerCsrt) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+	return tracker_Init(C.Tracker(self.p), img, boundingBox)
+}
+
+func (self TrackerCsrt) Update(img gocv.Mat) (image.Rectangle, bool) {
+	return tracker_Update(C.Tracker(self.p), img)
+}

--- a/contrib/tracking.go
+++ b/contrib/tracking.go
@@ -55,32 +55,36 @@ func tracker_Update(trk C.Tracker, img gocv.Mat) (image.Rectangle, bool) {
 	return rect, bool(ret)
 }
 
+type trackerMIL struct {
+	p C.TrackerMIL
+}
+
 //
 // The MIL algorithm trains a classifier in an online manner to separate the object from the background.
 // Multiple Instance Learning avoids the drift problem for a robust tracking.
 //
 // see: https://docs.opencv.org/master/d0/d26/classcv_1_1TrackerMIL.html
 //
-type TrackerMIL struct {
-	p C.TrackerMIL
+func NewTrackerMIL() Tracker {
+	return trackerMIL{p: C.TrackerMIL_Create()}
 }
 
-func NewTrackerMIL() TrackerMIL {
-	return TrackerMIL{p: C.TrackerMIL_Create()}
-}
-
-func (self TrackerMIL) Close() error {
+func (self trackerMIL) Close() error {
 	C.TrackerMIL_Close(self.p)
 	self.p = nil
 	return nil
 }
 
-func (self TrackerMIL) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+func (self trackerMIL) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
 	return tracker_Init(C.Tracker(self.p), img, boundingBox)
 }
 
-func (self TrackerMIL) Update(img gocv.Mat) (image.Rectangle, bool) {
+func (self trackerMIL) Update(img gocv.Mat) (image.Rectangle, bool) {
 	return tracker_Update(C.Tracker(self.p), img)
+}
+
+type trackerBoosting struct {
+	p C.TrackerBoosting
 }
 
 //
@@ -88,26 +92,26 @@ func (self TrackerMIL) Update(img gocv.Mat) (image.Rectangle, bool) {
 //
 // see: https://docs.opencv.org/master/d1/d1a/classcv_1_1TrackerBoosting.html
 //
-type TrackerBoosting struct {
-	p C.TrackerBoosting
+func NewTrackerBoosting() Tracker {
+	return trackerBoosting{p: C.TrackerBoosting_Create()}
 }
 
-func NewTrackerBoosting() TrackerBoosting {
-	return TrackerBoosting{p: C.TrackerBoosting_Create()}
-}
-
-func (self TrackerBoosting) Close() error {
+func (self trackerBoosting) Close() error {
 	C.TrackerBoosting_Close(self.p)
 	self.p = nil
 	return nil
 }
 
-func (self TrackerBoosting) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+func (self trackerBoosting) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
 	return tracker_Init(C.Tracker(self.p), img, boundingBox)
 }
 
-func (self TrackerBoosting) Update(img gocv.Mat) (image.Rectangle, bool) {
+func (self trackerBoosting) Update(img gocv.Mat) (image.Rectangle, bool) {
 	return tracker_Update(C.Tracker(self.p), img)
+}
+
+type trackerMedianFlow struct {
+	p C.TrackerMedianFlow
 }
 
 //
@@ -115,26 +119,26 @@ func (self TrackerBoosting) Update(img gocv.Mat) (image.Rectangle, bool) {
 //
 // see: https://docs.opencv.org/master/d7/d86/classcv_1_1TrackerMedianFlow.html
 //
-type TrackerMedianFlow struct {
-	p C.TrackerMedianFlow
+func NewTrackerMedianFlow() Tracker {
+	return trackerMedianFlow{p: C.TrackerMedianFlow_Create()}
 }
 
-func NewTrackerMedianFlow() TrackerMedianFlow {
-	return TrackerMedianFlow{p: C.TrackerMedianFlow_Create()}
-}
-
-func (self TrackerMedianFlow) Close() error {
+func (self trackerMedianFlow) Close() error {
 	C.TrackerMedianFlow_Close(self.p)
 	self.p = nil
 	return nil
 }
 
-func (self TrackerMedianFlow) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+func (self trackerMedianFlow) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
 	return tracker_Init(C.Tracker(self.p), img, boundingBox)
 }
 
-func (self TrackerMedianFlow) Update(img gocv.Mat) (image.Rectangle, bool) {
+func (self trackerMedianFlow) Update(img gocv.Mat) (image.Rectangle, bool) {
 	return tracker_Update(C.Tracker(self.p), img)
+}
+
+type trackerTLD struct {
+	p C.TrackerTLD
 }
 
 //
@@ -142,26 +146,26 @@ func (self TrackerMedianFlow) Update(img gocv.Mat) (image.Rectangle, bool) {
 //
 // see: https://docs.opencv.org/master/dc/d1c/classcv_1_1TrackerTLD.html
 //
-type TrackerTLD struct {
-	p C.TrackerTLD
+func NewTrackerTLD() Tracker {
+	return trackerTLD{p: C.TrackerTLD_Create()}
 }
 
-func NewTrackerTLD() TrackerTLD {
-	return TrackerTLD{p: C.TrackerTLD_Create()}
-}
-
-func (self TrackerTLD) Close() error {
+func (self trackerTLD) Close() error {
 	C.TrackerTLD_Close(self.p)
 	self.p = nil
 	return nil
 }
 
-func (self TrackerTLD) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+func (self trackerTLD) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
 	return tracker_Init(C.Tracker(self.p), img, boundingBox)
 }
 
-func (self TrackerTLD) Update(img gocv.Mat) (image.Rectangle, bool) {
+func (self trackerTLD) Update(img gocv.Mat) (image.Rectangle, bool) {
 	return tracker_Update(C.Tracker(self.p), img)
+}
+
+type trackerKCF struct {
+	p C.TrackerKCF
 }
 
 //
@@ -169,26 +173,26 @@ func (self TrackerTLD) Update(img gocv.Mat) (image.Rectangle, bool) {
 //
 // see: https://docs.opencv.org/master/d2/dff/classcv_1_1TrackerKCF.html
 //
-type TrackerKCF struct {
-	p C.TrackerKCF
+func NewTrackerKCF() Tracker {
+	return trackerKCF{p: C.TrackerKCF_Create()}
 }
 
-func NewTrackerKCF() TrackerKCF {
-	return TrackerKCF{p: C.TrackerKCF_Create()}
-}
-
-func (self TrackerKCF) Close() error {
+func (self trackerKCF) Close() error {
 	C.TrackerKCF_Close(self.p)
 	self.p = nil
 	return nil
 }
 
-func (self TrackerKCF) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+func (self trackerKCF) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
 	return tracker_Init(C.Tracker(self.p), img, boundingBox)
 }
 
-func (self TrackerKCF) Update(img gocv.Mat) (image.Rectangle, bool) {
+func (self trackerKCF) Update(img gocv.Mat) (image.Rectangle, bool) {
 	return tracker_Update(C.Tracker(self.p), img)
+}
+
+type trackerMOSSE struct {
+	p C.TrackerMOSSE
 }
 
 //
@@ -197,26 +201,26 @@ func (self TrackerKCF) Update(img gocv.Mat) (image.Rectangle, bool) {
 //
 // see: https://docs.opencv.org/master/d0/d02/classcv_1_1TrackerMOSSE.html
 //
-type TrackerMOSSE struct {
-	p C.TrackerMOSSE
+func NewTrackerMOSSE() Tracker {
+	return trackerMOSSE{p: C.TrackerMOSSE_Create()}
 }
 
-func NewTrackerMOSSE() TrackerMOSSE {
-	return TrackerMOSSE{p: C.TrackerMOSSE_Create()}
-}
-
-func (self TrackerMOSSE) Close() error {
+func (self trackerMOSSE) Close() error {
 	C.TrackerMOSSE_Close(self.p)
 	self.p = nil
 	return nil
 }
 
-func (self TrackerMOSSE) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+func (self trackerMOSSE) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
 	return tracker_Init(C.Tracker(self.p), img, boundingBox)
 }
 
-func (self TrackerMOSSE) Update(img gocv.Mat) (image.Rectangle, bool) {
+func (self trackerMOSSE) Update(img gocv.Mat) (image.Rectangle, bool) {
 	return tracker_Update(C.Tracker(self.p), img)
+}
+
+type trackerCSRT struct {
+	p C.TrackerCSRT
 }
 
 //
@@ -225,24 +229,20 @@ func (self TrackerMOSSE) Update(img gocv.Mat) (image.Rectangle, bool) {
 //
 // see: https://docs.opencv.org/master/d2/da2/classcv_1_1TrackerCSRT.html
 //
-type TrackerCSRT struct {
-	p C.TrackerCSRT
+func NewTrackerCSRT() Tracker {
+	return trackerCSRT{p: C.TrackerCSRT_Create()}
 }
 
-func NewTrackerCSRT() TrackerCSRT {
-	return TrackerCSRT{p: C.TrackerCSRT_Create()}
-}
-
-func (self TrackerCSRT) Close() error {
+func (self trackerCSRT) Close() error {
 	C.TrackerCSRT_Close(self.p)
 	self.p = nil
 	return nil
 }
 
-func (self TrackerCSRT) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+func (self trackerCSRT) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
 	return tracker_Init(C.Tracker(self.p), img, boundingBox)
 }
 
-func (self TrackerCSRT) Update(img gocv.Mat) (image.Rectangle, bool) {
+func (self trackerCSRT) Update(img gocv.Mat) (image.Rectangle, bool) {
 	return tracker_Update(C.Tracker(self.p), img)
 }

--- a/contrib/tracking.go
+++ b/contrib/tracking.go
@@ -10,36 +10,30 @@ import (
 	"gocv.io/x/gocv"
 )
 
-// Tracker - the base interface for object tracking
+// This is the base interface for object tracking.
 //
-// s.a: https://docs.opencv.org/master/d0/d0a/classcv_1_1Tracker.html
+// see: https://docs.opencv.org/master/d0/d0a/classcv_1_1Tracker.html
+//
 type Tracker interface {
-	// Init initializes the tracker with a known bounding box that surrounded the target
-	// note: this can only be called once. if you loose the object, you have to Close() the instance,
-	// create a new one, and call Init on it again
+	// Trackers need to be Closed manually.
 	//
-	// https://docs.opencv.org/master/d0/d0a/classcv_1_1Tracker.html#a4d285747589b1bdd16d2e4f00c3255dc
+	Close() error
+
+	// Init initializes the tracker with a known bounding box that surrounded the target.
+	// Note: this can only be called once. If you lose the object, you have to Close() the instance,
+	// create a new one, and call Init() on it again.
+	//
+	// see: https://docs.opencv.org/master/d0/d0a/classcv_1_1Tracker.html#a4d285747589b1bdd16d2e4f00c3255dc
+	//
 	Init(image gocv.Mat, boundingBox image.Rectangle) bool
 
-	// Update the tracker, return new bounding box and a bool, if it lost it.
+	// Update updates the tracker, returns a new bounding box and a boolean determining whether the tracker lost the target.
 	//
-	// https://docs.opencv.org/master/d0/d0a/classcv_1_1Tracker.html#a549159bd0553e6a8de356f3866df1f18
+	// see: https://docs.opencv.org/master/d0/d0a/classcv_1_1Tracker.html#a549159bd0553e6a8de356f3866df1f18
+	//
 	Update(image gocv.Mat) (image.Rectangle, bool)
 }
 
-//
-// available implementations in gocv are:
-//
-// TrackerMil;
-// TrackerBoosting;
-// TrackerMedianFlow;
-// TrackerTld;
-// TrackerKcf;
-// TrackerMosse;
-// TrackerCsrt;
-//
-
-// (private) implementation helpers for init and update (saves some boilerplate code)
 func tracker_Init(trk C.Tracker, img gocv.Mat, boundingBox image.Rectangle) bool {
 	cBox := C.struct_Rect{
 		x:      C.int(boundingBox.Min.X),
@@ -62,38 +56,38 @@ func tracker_Update(trk C.Tracker, img gocv.Mat) (image.Rectangle, bool) {
 }
 
 //
-// Mil
 // The MIL algorithm trains a classifier in an online manner to separate the object from the background.
 // Multiple Instance Learning avoids the drift problem for a robust tracking.
 //
-// s.a: https://docs.opencv.org/master/d0/d26/classcv_1_1TrackerMIL.html
-type TrackerMil struct {
-	p C.TrackerMil
+// see: https://docs.opencv.org/master/d0/d26/classcv_1_1TrackerMIL.html
+//
+type TrackerMIL struct {
+	p C.TrackerMIL
 }
 
-func NewTrackerMil() TrackerMil {
-	return TrackerMil{p: C.TrackerMil_Create()}
+func NewTrackerMIL() TrackerMIL {
+	return TrackerMIL{p: C.TrackerMIL_Create()}
 }
 
-func (self *TrackerMil) Close() error {
-	C.TrackerMil_Close(self.p)
+func (self TrackerMIL) Close() error {
+	C.TrackerMIL_Close(self.p)
 	self.p = nil
 	return nil
 }
 
-func (self TrackerMil) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+func (self TrackerMIL) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
 	return tracker_Init(C.Tracker(self.p), img, boundingBox)
 }
 
-func (self TrackerMil) Update(img gocv.Mat) (image.Rectangle, bool) {
+func (self TrackerMIL) Update(img gocv.Mat) (image.Rectangle, bool) {
 	return tracker_Update(C.Tracker(self.p), img)
 }
 
 //
-// Boosting
-// This is a real-time object tracking based on a novel on-line version of the AdaBoost algorithm.
+// This is a real-time object tracker based on a novel on-line version of the AdaBoost algorithm.
 //
-// s.a: https://docs.opencv.org/master/d1/d1a/classcv_1_1TrackerBoosting.html
+// see: https://docs.opencv.org/master/d1/d1a/classcv_1_1TrackerBoosting.html
+//
 type TrackerBoosting struct {
 	p C.TrackerBoosting
 }
@@ -102,7 +96,7 @@ func NewTrackerBoosting() TrackerBoosting {
 	return TrackerBoosting{p: C.TrackerBoosting_Create()}
 }
 
-func (self *TrackerBoosting) Close() error {
+func (self TrackerBoosting) Close() error {
 	C.TrackerBoosting_Close(self.p)
 	self.p = nil
 	return nil
@@ -117,10 +111,10 @@ func (self TrackerBoosting) Update(img gocv.Mat) (image.Rectangle, bool) {
 }
 
 //
-// MedianFlow
-// The tracker is suitable for very smooth and predictable movements when object is visible throughout the whole sequence
+// This Tracker implementation is suitable for very smooth and predictable movements when the object is visible throughout the whole sequence
 //
-// s.a: https://docs.opencv.org/master/d7/d86/classcv_1_1TrackerMedianFlow.html
+// see: https://docs.opencv.org/master/d7/d86/classcv_1_1TrackerMedianFlow.html
+//
 type TrackerMedianFlow struct {
 	p C.TrackerMedianFlow
 }
@@ -129,7 +123,7 @@ func NewTrackerMedianFlow() TrackerMedianFlow {
 	return TrackerMedianFlow{p: C.TrackerMedianFlow_Create()}
 }
 
-func (self *TrackerMedianFlow) Close() error {
+func (self TrackerMedianFlow) Close() error {
 	C.TrackerMedianFlow_Close(self.p)
 	self.p = nil
 	return nil
@@ -144,113 +138,111 @@ func (self TrackerMedianFlow) Update(img gocv.Mat) (image.Rectangle, bool) {
 }
 
 //
-// Tld
-// TLD is a novel tracking framework that explicitly decomposes the long-term tracking task into tracking, learning and detection.
+// This is a novel tracking framework that explicitly decomposes the long-term tracking task into tracking, learning and detection.
 //
-// s.a: https://docs.opencv.org/master/dc/d1c/classcv_1_1TrackerTLD.html
-type TrackerTld struct {
-	p C.TrackerTld
+// see: https://docs.opencv.org/master/dc/d1c/classcv_1_1TrackerTLD.html
+//
+type TrackerTLD struct {
+	p C.TrackerTLD
 }
 
-func NewTrackerTld() TrackerTld {
-	return TrackerTld{p: C.TrackerTld_Create()}
+func NewTrackerTLD() TrackerTLD {
+	return TrackerTLD{p: C.TrackerTLD_Create()}
 }
 
-func (self *TrackerTld) Close() error {
-	C.TrackerTld_Close(self.p)
+func (self TrackerTLD) Close() error {
+	C.TrackerTLD_Close(self.p)
 	self.p = nil
 	return nil
 }
 
-func (self TrackerTld) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+func (self TrackerTLD) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
 	return tracker_Init(C.Tracker(self.p), img, boundingBox)
 }
 
-func (self TrackerTld) Update(img gocv.Mat) (image.Rectangle, bool) {
+func (self TrackerTLD) Update(img gocv.Mat) (image.Rectangle, bool) {
 	return tracker_Update(C.Tracker(self.p), img)
 }
 
 //
-// Kcf
 // KCF is a novel tracking framework that utilizes properties of circulant matrix to enhance the processing speed.
 //
-// s.a: https://docs.opencv.org/master/d2/dff/classcv_1_1TrackerKCF.html
+// see: https://docs.opencv.org/master/d2/dff/classcv_1_1TrackerKCF.html
 //
-type TrackerKcf struct {
-	p C.TrackerKcf
+type TrackerKCF struct {
+	p C.TrackerKCF
 }
 
-func NewTrackerKcf() TrackerKcf {
-	return TrackerKcf{p: C.TrackerKcf_Create()}
+func NewTrackerKCF() TrackerKCF {
+	return TrackerKCF{p: C.TrackerKCF_Create()}
 }
 
-func (self *TrackerKcf) Close() error {
-	C.TrackerKcf_Close(self.p)
+func (self TrackerKCF) Close() error {
+	C.TrackerKCF_Close(self.p)
 	self.p = nil
 	return nil
 }
 
-func (self TrackerKcf) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+func (self TrackerKCF) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
 	return tracker_Init(C.Tracker(self.p), img, boundingBox)
 }
 
-func (self TrackerKcf) Update(img gocv.Mat) (image.Rectangle, bool) {
+func (self TrackerKCF) Update(img gocv.Mat) (image.Rectangle, bool) {
 	return tracker_Update(C.Tracker(self.p), img)
 }
 
 //
-// Mosse
-// based on: Visual Object Tracking using Adaptive Correlation Filters
-// note, that this tracker is working on graysccale images
+// Based on: Visual Object Tracking using Adaptive Correlation Filters.
+// Note, that this tracker is working on graysccale images.
 //
-// s.a: https://docs.opencv.org/master/d0/d02/classcv_1_1TrackerMOSSE.html
+// see: https://docs.opencv.org/master/d0/d02/classcv_1_1TrackerMOSSE.html
 //
-type TrackerMosse struct {
-	p C.TrackerMosse
+type TrackerMOSSE struct {
+	p C.TrackerMOSSE
 }
 
-func NewTrackerMosse() TrackerMosse {
-	return TrackerMosse{p: C.TrackerMosse_Create()}
+func NewTrackerMOSSE() TrackerMOSSE {
+	return TrackerMOSSE{p: C.TrackerMOSSE_Create()}
 }
 
-func (self *TrackerMosse) Close() error {
-	C.TrackerMosse_Close(self.p)
+func (self TrackerMOSSE) Close() error {
+	C.TrackerMOSSE_Close(self.p)
 	self.p = nil
 	return nil
 }
 
-func (self TrackerMosse) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+func (self TrackerMOSSE) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
 	return tracker_Init(C.Tracker(self.p), img, boundingBox)
 }
 
-func (self TrackerMosse) Update(img gocv.Mat) (image.Rectangle, bool) {
+func (self TrackerMOSSE) Update(img gocv.Mat) (image.Rectangle, bool) {
 	return tracker_Update(C.Tracker(self.p), img)
 }
 
 //
-// Csrt
+// An implementation of:
 // Discriminative Correlation Filter Tracker with Channel and Spatial Reliability.
 //
-// s.a: https://docs.opencv.org/master/d2/da2/classcv_1_1TrackerCSRT.html
+// see: https://docs.opencv.org/master/d2/da2/classcv_1_1TrackerCSRT.html
 //
-type TrackerCsrt struct {
-	p C.TrackerCsrt
+type TrackerCSRT struct {
+	p C.TrackerCSRT
 }
 
-func NewTrackerCsrt() TrackerCsrt {
-	return TrackerCsrt{p: C.TrackerCsrt_Create()}
+func NewTrackerCSRT() TrackerCSRT {
+	return TrackerCSRT{p: C.TrackerCSRT_Create()}
 }
 
-func (self *TrackerCsrt) Close() error {
-	C.TrackerCsrt_Close(self.p)
+func (self TrackerCSRT) Close() error {
+	C.TrackerCSRT_Close(self.p)
 	self.p = nil
 	return nil
 }
 
-func (self TrackerCsrt) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
+func (self TrackerCSRT) Init(img gocv.Mat, boundingBox image.Rectangle) bool {
 	return tracker_Init(C.Tracker(self.p), img, boundingBox)
 }
 
-func (self TrackerCsrt) Update(img gocv.Mat) (image.Rectangle, bool) {
+func (self TrackerCSRT) Update(img gocv.Mat) (image.Rectangle, bool) {
 	return tracker_Update(C.Tracker(self.p), img)
 }

--- a/contrib/tracking.h
+++ b/contrib/tracking.h
@@ -1,6 +1,6 @@
 
-#ifndef _OPENCV3_MY_H_
-#define _OPENCV3_MY_H_
+#ifndef _OPENCV3_TRACKING_H_
+#define _OPENCV3_TRACKING_H_
 
 #include "../core.h"
 
@@ -13,58 +13,51 @@ extern "C" {
 
 #ifdef __cplusplus
 typedef cv::Ptr<cv::Tracker>* Tracker;
-typedef cv::Ptr<cv::TrackerMIL>* TrackerMil;
+typedef cv::Ptr<cv::TrackerMIL>* TrackerMIL;
 typedef cv::Ptr<cv::TrackerBoosting>* TrackerBoosting;
 typedef cv::Ptr<cv::TrackerMedianFlow>* TrackerMedianFlow;
-typedef cv::Ptr<cv::TrackerTLD>* TrackerTld;
-typedef cv::Ptr<cv::TrackerKCF>* TrackerKcf;
-typedef cv::Ptr<cv::TrackerMOSSE>* TrackerMosse;
-typedef cv::Ptr<cv::TrackerCSRT>* TrackerCsrt;
+typedef cv::Ptr<cv::TrackerTLD>* TrackerTLD;
+typedef cv::Ptr<cv::TrackerKCF>* TrackerKCF;
+typedef cv::Ptr<cv::TrackerMOSSE>* TrackerMOSSE;
+typedef cv::Ptr<cv::TrackerCSRT>* TrackerCSRT;
 #else
 typedef void* Tracker;
-typedef void* TrackerMil;
+typedef void* TrackerMIL;
 typedef void* TrackerBoosting;
 typedef void* TrackerMedianFlow;
-typedef void* TrackerTld;
-typedef void* TrackerKcf;
-typedef void* TrackerMosse;
-typedef void* TrackerCsrt;
+typedef void* TrackerTLD;
+typedef void* TrackerKCF;
+typedef void* TrackerMOSSE;
+typedef void* TrackerCSRT;
 #endif
 
 bool Tracker_Init(Tracker self, Mat image, Rect boundingBox);
 bool Tracker_Update(Tracker self, Mat image, Rect *boundingBox);
 
-
-TrackerMil TrackerMil_Create();
-void TrackerMil_Close(TrackerMil self);
-
+TrackerMIL TrackerMIL_Create();
+void TrackerMIL_Close(TrackerMIL self);
 
 TrackerBoosting TrackerBoosting_Create();
 void TrackerBoosting_Close(TrackerBoosting self);
 
-
 TrackerMedianFlow TrackerMedianFlow_Create();
 void TrackerMedianFlow_Close(TrackerMedianFlow self);
 
+TrackerTLD TrackerTLD_Create();
+void TrackerTLD_Close(TrackerTLD self);
 
-TrackerTld TrackerTld_Create();
-void TrackerTld_Close(TrackerTld self);
+TrackerKCF TrackerKCF_Create();
+void TrackerKCF_Close(TrackerKCF self);
 
+TrackerMOSSE TrackerMOSSE_Create();
+void TrackerMOSSE_Close(TrackerMOSSE self);
 
-TrackerKcf TrackerKcf_Create();
-void TrackerKcf_Close(TrackerKcf self);
-
-
-TrackerMosse TrackerMosse_Create();
-void TrackerMosse_Close(TrackerMosse self);
-
-
-TrackerCsrt TrackerCsrt_Create();
-void TrackerCsrt_Close(TrackerCsrt self);
+TrackerCSRT TrackerCSRT_Create();
+void TrackerCSRT_Close(TrackerCSRT self);
 
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif //_OPENCV3_MY_H_
+#endif //_OPENCV3_TRACKING_H_

--- a/contrib/tracking.h
+++ b/contrib/tracking.h
@@ -1,0 +1,70 @@
+
+#ifndef _OPENCV3_MY_H_
+#define _OPENCV3_MY_H_
+
+#include "../core.h"
+
+#ifdef __cplusplus
+#include <opencv2/tracking/tracker.hpp>
+
+extern "C" {
+#endif
+
+
+#ifdef __cplusplus
+typedef cv::Ptr<cv::Tracker>* Tracker;
+typedef cv::Ptr<cv::TrackerMIL>* TrackerMil;
+typedef cv::Ptr<cv::TrackerBoosting>* TrackerBoosting;
+typedef cv::Ptr<cv::TrackerMedianFlow>* TrackerMedianFlow;
+typedef cv::Ptr<cv::TrackerTLD>* TrackerTld;
+typedef cv::Ptr<cv::TrackerKCF>* TrackerKcf;
+typedef cv::Ptr<cv::TrackerMOSSE>* TrackerMosse;
+typedef cv::Ptr<cv::TrackerCSRT>* TrackerCsrt;
+#else
+typedef void* Tracker;
+typedef void* TrackerMil;
+typedef void* TrackerBoosting;
+typedef void* TrackerMedianFlow;
+typedef void* TrackerTld;
+typedef void* TrackerKcf;
+typedef void* TrackerMosse;
+typedef void* TrackerCsrt;
+#endif
+
+bool Tracker_Init(Tracker self, Mat image, Rect boundingBox);
+bool Tracker_Update(Tracker self, Mat image, Rect *boundingBox);
+
+
+TrackerMil TrackerMil_Create();
+void TrackerMil_Close(TrackerMil self);
+
+
+TrackerBoosting TrackerBoosting_Create();
+void TrackerBoosting_Close(TrackerBoosting self);
+
+
+TrackerMedianFlow TrackerMedianFlow_Create();
+void TrackerMedianFlow_Close(TrackerMedianFlow self);
+
+
+TrackerTld TrackerTld_Create();
+void TrackerTld_Close(TrackerTld self);
+
+
+TrackerKcf TrackerKcf_Create();
+void TrackerKcf_Close(TrackerKcf self);
+
+
+TrackerMosse TrackerMosse_Create();
+void TrackerMosse_Close(TrackerMosse self);
+
+
+TrackerCsrt TrackerCsrt_Create();
+void TrackerCsrt_Close(TrackerCsrt self);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //_OPENCV3_MY_H_

--- a/contrib/tracking_test.go
+++ b/contrib/tracking_test.go
@@ -1,0 +1,65 @@
+package contrib
+
+import (
+	"gocv.io/x/gocv"
+	"image"
+	"testing"
+)
+
+func BaseTestTracker(t *testing.T, tracker Tracker, name string) {
+	if tracker == nil {
+		t.Error("TestTracker " + name + " should not be nil")
+	}
+	img := gocv.IMRead("../images/face.jpg", 1)
+	if img.Empty() {
+		t.Error("TestTracker " + name + " input img failed to load")
+	}
+	rect := image.Rect(250, 150, 250+200, 150+250)
+	init := tracker.Init(img, rect)
+	if !init {
+		t.Error("TestTracker " + name + " failed in Init")
+	}
+	_, ok := tracker.Update(img)
+	if !ok {
+		t.Error("TestTracker " + name + " lost object in Update")
+	}
+	img.Close()
+}
+
+func TestTrackerMil(t *testing.T) {
+	tracker := NewTrackerMil()
+	BaseTestTracker(t, tracker, "Mil")
+	tracker.Close()
+}
+func TestTrackerBoosting(t *testing.T) {
+	tracker := NewTrackerBoosting()
+	BaseTestTracker(t, tracker, "Boosting")
+	tracker.Close()
+}
+func TestTrackerMedianFlow(t *testing.T) {
+	tracker := NewTrackerMedianFlow()
+	BaseTestTracker(t, tracker, "MedianFlow")
+	tracker.Close()
+}
+func TestTrackerTld(t *testing.T) {
+	tracker := NewTrackerTld()
+	BaseTestTracker(t, tracker, "Tld")
+	tracker.Close()
+}
+func TestTrackerKcf(t *testing.T) {
+	tracker := NewTrackerKcf()
+	BaseTestTracker(t, tracker, "Kcf")
+	tracker.Close()
+}
+
+func TestTrackerMosse(t *testing.T) {
+	tracker := NewTrackerMosse()
+	BaseTestTracker(t, tracker, "Mosse")
+	tracker.Close()
+}
+
+func TestTrackerCsrt(t *testing.T) {
+	tracker := NewTrackerCsrt()
+	BaseTestTracker(t, tracker, "Csrt")
+	tracker.Close()
+}

--- a/contrib/tracking_test.go
+++ b/contrib/tracking_test.go
@@ -6,60 +6,42 @@ import (
 	"testing"
 )
 
-func BaseTestTracker(t *testing.T, tracker Tracker, name string) {
-	if tracker == nil {
-		t.Error("TestTracker " + name + " should not be nil")
+func TestSingleTrackers(t *testing.T) {
+	tab := []struct {
+		name    string
+		tracker Tracker
+	}{
+		{"MIL", NewTrackerMIL()},
+		{"Boosting", NewTrackerBoosting()},
+		{"MedianFlow", NewTrackerMedianFlow()},
+		{"TLD", NewTrackerTLD()},
+		{"KCF", NewTrackerKCF()},
+		{"MOSSE", NewTrackerMOSSE()},
+		{"CSRT", NewTrackerCSRT()},
 	}
-	img := gocv.IMRead("../images/face.jpg", 1)
-	if img.Empty() {
-		t.Error("TestTracker " + name + " input img failed to load")
-	}
-	rect := image.Rect(250, 150, 250+200, 150+250)
-	init := tracker.Init(img, rect)
-	if !init {
-		t.Error("TestTracker " + name + " failed in Init")
-	}
-	_, ok := tracker.Update(img)
-	if !ok {
-		t.Error("TestTracker " + name + " lost object in Update")
-	}
-	img.Close()
-}
 
-func TestTrackerMil(t *testing.T) {
-	tracker := NewTrackerMil()
-	BaseTestTracker(t, tracker, "Mil")
-	tracker.Close()
-}
-func TestTrackerBoosting(t *testing.T) {
-	tracker := NewTrackerBoosting()
-	BaseTestTracker(t, tracker, "Boosting")
-	tracker.Close()
-}
-func TestTrackerMedianFlow(t *testing.T) {
-	tracker := NewTrackerMedianFlow()
-	BaseTestTracker(t, tracker, "MedianFlow")
-	tracker.Close()
-}
-func TestTrackerTld(t *testing.T) {
-	tracker := NewTrackerTld()
-	BaseTestTracker(t, tracker, "Tld")
-	tracker.Close()
-}
-func TestTrackerKcf(t *testing.T) {
-	tracker := NewTrackerKcf()
-	BaseTestTracker(t, tracker, "Kcf")
-	tracker.Close()
-}
+	for _, test := range tab {
+		defer test.tracker.Close()
 
-func TestTrackerMosse(t *testing.T) {
-	tracker := NewTrackerMosse()
-	BaseTestTracker(t, tracker, "Mosse")
-	tracker.Close()
-}
+		if test.tracker == nil {
+			t.Error("TestTracker " + test.name + " should not be nil")
+		}
 
-func TestTrackerCsrt(t *testing.T) {
-	tracker := NewTrackerCsrt()
-	BaseTestTracker(t, tracker, "Csrt")
-	tracker.Close()
+		img := gocv.IMRead("../images/face.jpg", 1)
+		if img.Empty() {
+			t.Error("TestTracker " + test.name + " input img failed to load")
+		}
+		defer img.Close()
+
+		rect := image.Rect(250, 150, 250+200, 150+250)
+		init := test.tracker.Init(img, rect)
+		if !init {
+			t.Error("TestTracker " + test.name + " failed in Init")
+		}
+
+		_, ok := test.tracker.Update(img)
+		if !ok {
+			t.Error("TestTracker " + test.name + " lost object in Update")
+		}
+	}
 }

--- a/contrib/tracking_test.go
+++ b/contrib/tracking_test.go
@@ -6,6 +6,29 @@ import (
 	"testing"
 )
 
+func BaseTestTracker(t *testing.T, tracker Tracker, name string) {
+	if tracker == nil {
+		t.Error("TestTracker " + name + " should not be nil")
+	}
+
+	img := gocv.IMRead("../images/face.jpg", 1)
+	if img.Empty() {
+		t.Error("TestTracker " + name + " input img failed to load")
+	}
+	defer img.Close()
+
+	rect := image.Rect(250, 150, 250+200, 150+250)
+	init := tracker.Init(img, rect)
+	if !init {
+		t.Error("TestTracker " + name + " failed in Init")
+	}
+
+	_, ok := tracker.Update(img)
+	if !ok {
+		t.Error("TestTracker " + name + " lost object in Update")
+	}
+}
+
 func TestSingleTrackers(t *testing.T) {
 	tab := []struct {
 		name    string
@@ -23,25 +46,6 @@ func TestSingleTrackers(t *testing.T) {
 	for _, test := range tab {
 		defer test.tracker.Close()
 
-		if test.tracker == nil {
-			t.Error("TestTracker " + test.name + " should not be nil")
-		}
-
-		img := gocv.IMRead("../images/face.jpg", 1)
-		if img.Empty() {
-			t.Error("TestTracker " + test.name + " input img failed to load")
-		}
-		defer img.Close()
-
-		rect := image.Rect(250, 150, 250+200, 150+250)
-		init := test.tracker.Init(img, rect)
-		if !init {
-			t.Error("TestTracker " + test.name + " failed in Init")
-		}
-
-		_, ok := test.tracker.Update(img)
-		if !ok {
-			t.Error("TestTracker " + test.name + " lost object in Update")
-		}
+		BaseTestTracker(t, test.tracker, test.name)
 	}
 }

--- a/env.cmd
+++ b/env.cmd
@@ -2,7 +2,7 @@
 IF EXIST C:\opencv\build\install\include\ (
     ECHO Configuring GoCV env for OpenCV.
     set CGO_CPPFLAGS=-IC:\opencv\build\install\include
-    set CGO_LDFLAGS=-LC:\opencv\build\install\x64\mingw\lib -lopencv_core341 -lopencv_face341 -lopencv_videoio341 -lopencv_imgproc341 -lopencv_highgui341 -lopencv_imgcodecs341 -lopencv_objdetect341 -lopencv_features2d341 -lopencv_video341 -lopencv_dnn341 -lopencv_xfeatures2d341
+    set CGO_LDFLAGS=-LC:\opencv\build\install\x64\mingw\lib -lopencv_core341 -lopencv_face341 -lopencv_videoio341 -lopencv_imgproc341 -lopencv_highgui341 -lopencv_imgcodecs341 -lopencv_objdetect341 -lopencv_features2d341 -lopencv_video341 -lopencv_dnn341 -lopencv_xfeatures2d341 -lopencv_plot341 -lopencv_tracking341
 ) ELSE (
     ECHO ERROR: Unable to locate OpenCV for GoCV configuration.
 )

--- a/env.sh
+++ b/env.sh
@@ -5,12 +5,12 @@ if [[ "$uname_val" == "Darwin" ]]; then
       echo "Brew install detected"
       export CGO_CPPFLAGS="-I$CVPATH/include -I$CVPATH/include/opencv2"
       export CGO_CXXFLAGS="--std=c++1z -stdlib=libc++"
-      export CGO_LDFLAGS="-L$CVPATH/lib -lopencv_core -lopencv_face -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_xfeatures2d"
+      export CGO_LDFLAGS="-L$CVPATH/lib -lopencv_core -lopencv_face -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_xfeatures2d -lopencv_plot -lopencv_tracking"
   else
       echo "Non-Brew install detected"
       export CGO_CPPFLAGS="-I/usr/local/include"
       export CGO_CXXFLAGS="--std=c++1z -stdlib=libc++"
-      export CGO_LDFLAGS="-L/usr/local/lib -lopencv_core -lopencv_face -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_xfeatures2d"
+      export CGO_LDFLAGS="-L/usr/local/lib -lopencv_core -lopencv_face -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_xfeatures2d -lopencv_plot -lopencv_tracking"
   fi
 
   echo "Environment variables configured for OSX"
@@ -18,13 +18,13 @@ elif [[ "$uname_val" == "Linux" ]]; then
         if [[ -f /etc/pacman.conf ]]; then
                 export CGO_CPPFLAGS="-I/usr/include"
                 export CGO_CXXFLAGS="--std=c++1z"
-                export CGO_LDFLAGS="-L/lib64 -lopencv_core -lopencv_face -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_xfeatures2d"
+                export CGO_LDFLAGS="-L/lib64 -lopencv_core -lopencv_face -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_xfeatures2d -lopencv_plot -lopencv_tracking"
         else
                 export PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig"
                 export LD_LIBRARY_PATH="/usr/local/lib64"
                 export CGO_CPPFLAGS="-I/usr/local/include"
                 export CGO_CXXFLAGS="--std=c++1z"
-                export CGO_LDFLAGS="-L/usr/local/lib -lopencv_core -lopencv_face -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_xfeatures2d"
+                export CGO_LDFLAGS="-L/usr/local/lib -lopencv_core -lopencv_face -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_xfeatures2d -lopencv_plot -lopencv_tracking"
         fi
   echo "Environment variables configured for Linux"
 else


### PR DESCRIPTION
an attempt to wrap the tracking module from opencv_contrib

W I P , rfc.

this is making heavy use of c++ / go interfaces.

Tracker_Init() and Tracker_Update() only need to be implemented once (in c++), and can be reused for any go implentation of the Tracker interface, [saving a ton of boilerplate code](https://www.brainyquote.com/quotes/ken_thompson_254858)

if we'd use interfaces more often, properly, e.g, there'd be no need to do this [again](https://github.com/hybridgroup/gocv/blob/master/features2d.go#L52-L58) and [again](https://github.com/hybridgroup/gocv/blob/master/features2d.go#L133-L139) , and also have [all this boilerplate repetition here](https://github.com/hybridgroup/gocv/blob/master/features2d.go#L133-L139) and [here](https://github.com/hybridgroup/gocv/blob/master/features2d.cpp#L72-L98) and so on ..

@willdurand , may i challenge you / pick your mind on this idea, too ?

(it still needs a wrapper function on the go side, with the correct implementation type as self, to satisfy the go interface, but all we need to do there is to extract the C.Tracker from the go type, and pass it on to the shared c++ wrapper)

also tests can be rigorously simplified, if all we need to do is pass a different implementation instance to the same base test

some things did not make it:

* GOTURN:  needs a XXXmb pre-trained dnn, can't be tested without (throws exception)
<strike> * CSRT: only available in 3.4.1</strike> .. i'll just add it
* MultiTracker: i've made an attempt, but there are problems. i'll leave the code in comments (for now), maybe someone has an idea.
    a: i see no proper way to add new tracker instances to it. the way i tried, worked on my win box, but throws an exception on travis. it's also somewhat unclear, how & when to Close() the added trackers
   b: i'm unable to release a `C.struct_RECTS` in cgo, (can't access `Rects_Close` somehow)
   c: `gocv.toRectangles(ret)` would be very useful here, but it's private in gocv
all in all, opencv's MultiTracker is just a shallow wrapper around `vector<Ptr<Tracker>>`, maybe we're better off, building a mock class in pure go ?