### PR TITLE
imgcodecs: remove gif extension

### DIFF
--- a/imgcodecs.go
+++ b/imgcodecs.go
@@ -173,7 +173,6 @@ type FileExt string
 const (
 	PNGFileExt  FileExt = ".png"
 	JPEGFileExt FileExt = ".jpg"
-	GIFFileExt  FileExt = ".gif"
 )
 
 // IMEncode encodes an image Mat into a memory buffer.


### PR DESCRIPTION
it can neither read or write it (still a license problem), avoid confusion