### PR TITLE
Mat Type() should return MatType

### DIFF
--- a/core.go
+++ b/core.go
@@ -264,8 +264,8 @@ func (m *Mat) Channels() int {
 }
 
 // Type returns the type for this Mat.
-func (m *Mat) Type() int {
-	return int(C.Mat_Type(m.p))
+func (m *Mat) Type() MatType {
+	return MatType(C.Mat_Type(m.p))
 }
 
 // GetUCharAt returns a value from a specific row/col


### PR DESCRIPTION
Fix #130

---

I believe `Type()` should return a `MatType` because that's what we use
everywhere else, and it would make comparisons more natural. I stumbled upon
this while reviewing #125.

It could be since as a BC break even though we did not reach version `1.0.0` yet.