### PR TITLE
Add GetVecfAt() and GetVecifAt() functions to Mat

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -26,6 +26,10 @@ Captures video from a connected camera, then uses the CascadeClassifier to detec
 
 Captures video from a connected camera, then uses the CascadeClassifier to detect faces, and draw a rectangle around each of them, before displaying them within a Window
 
+## Find-circles
+
+Find circles in an image using the Hough transform.
+
 ## MJPEG-Streamer
 
 Opens a video capture device, then streams MJPEG from it that you can view in any browser.

--- a/cmd/find-circles/main.go
+++ b/cmd/find-circles/main.go
@@ -58,11 +58,11 @@ func main() {
 	blue := color.RGBA{0, 0, 255, 0}
 	red := color.RGBA{255, 0, 0, 0}
 
-	ch := circles.Channels()
 	for i := 0; i < circles.Cols(); i++ {
-		x := int(circles.GetFloatAt(0, i*ch))
-		y := int(circles.GetFloatAt(0, i*ch+1))
-		r := int(circles.GetFloatAt(0, i*ch+2))
+		v := circles.GetVecfAt(0, i)
+		x := int(v[0])
+		y := int(v[1])
+		r := int(v[2])
 
 		gocv.Circle(&cimg, image.Pt(x, y), r, blue, 2)
 		gocv.Circle(&cimg, image.Pt(x, y), 2, red, 3)

--- a/core.go
+++ b/core.go
@@ -1077,6 +1077,22 @@ type KeyPoint struct {
 	Octave, ClassID       int
 }
 
+// Vecf is a generic vector of floats.
+type Vecf []float32
+
+// GetVecfAt returns a vector of floats. Its size corresponds to the number of
+// channels of the Mat.
+func (m *Mat) GetVecfAt(row int, col int) Vecf {
+	ch := m.Channels()
+	v := make(Vecf, ch)
+
+	for c := 0; c < ch; c++ {
+		v[c] = m.GetFloatAt(row, col*ch+c)
+	}
+
+	return v
+}
+
 func toByteArray(b []byte) C.struct_ByteArray {
 	return C.struct_ByteArray{
 		data:   (*C.char)(unsafe.Pointer(&b[0])),

--- a/core.go
+++ b/core.go
@@ -1093,6 +1093,22 @@ func (m *Mat) GetVecfAt(row int, col int) Vecf {
 	return v
 }
 
+// Veci is a generic vector of integers.
+type Veci []int32
+
+// GetVeciAt returns a vector of integers. Its size corresponds to the number
+// of channels of the Mat.
+func (m *Mat) GetVeciAt(row int, col int) Veci {
+	ch := m.Channels()
+	v := make(Veci, ch)
+
+	for c := 0; c < ch; c++ {
+		v[c] = m.GetIntAt(row, col*ch+c)
+	}
+
+	return v
+}
+
 func toByteArray(b []byte) C.struct_ByteArray {
 	return C.struct_ByteArray{
 		data:   (*C.char)(unsafe.Pointer(&b[0])),

--- a/core_test.go
+++ b/core_test.go
@@ -936,3 +936,22 @@ func TestGetVecfAt(t *testing.T) {
 		}
 	}
 }
+
+func TestGetVeciAt(t *testing.T) {
+	var cases = []struct {
+		m            Mat
+		expectedSize int
+	}{
+		{NewMatWithSize(1, 1, MatTypeCV8UC1), 1},
+		{NewMatWithSize(1, 1, MatTypeCV8UC2), 2},
+		{NewMatWithSize(1, 1, MatTypeCV8UC3), 3},
+		{NewMatWithSize(1, 1, MatTypeCV8UC4), 4},
+	}
+
+	for _, c := range cases {
+		vec := c.m.GetVeciAt(0, 0)
+		if len := len(vec); len != c.expectedSize {
+			t.Errorf("TestGetVeciAt: expected %d, got: %d.", c.expectedSize, len)
+		}
+	}
+}

--- a/core_test.go
+++ b/core_test.go
@@ -917,3 +917,22 @@ func TestMatToImage(t *testing.T) {
 		t.Error("TestToImage expected error got nil.")
 	}
 }
+
+func TestGetVecfAt(t *testing.T) {
+	var cases = []struct {
+		m            Mat
+		expectedSize int
+	}{
+		{NewMatWithSize(1, 1, MatTypeCV8UC1), 1},
+		{NewMatWithSize(1, 1, MatTypeCV8UC2), 2},
+		{NewMatWithSize(1, 1, MatTypeCV8UC3), 3},
+		{NewMatWithSize(1, 1, MatTypeCV8UC4), 4},
+	}
+
+	for _, c := range cases {
+		vec := c.m.GetVecfAt(0, 0)
+		if len := len(vec); len != c.expectedSize {
+			t.Errorf("TestGetVecfAt: expected %d, got: %d.", c.expectedSize, len)
+		}
+	}
+}


### PR DESCRIPTION
This is a proposal to simplify the way we get data from `Mat`, which we use as
a general purpose data structure. I find it more convenient because when
looking on the Internet (for example, for Hough transforms), people talk about
`Vec` or `Vec3f` (and so on), not `Mat`. Of course, a matrix can be used as a
vector, but it is less simple than having an accessor for that.

It is still possible to use the `Mat` and do the maths by yourself, it is only
a nice helper. We could add `GetVecdAt()` for `double`/`float64`, `GetVeciAt()`
for `int`, etc.