### PR TITLE
Return Go Error for Read()/Write() operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import (
 
 func main() {
 	webcam, _ := gocv.VideoCaptureDevice(0)
-	window := gocv.NewWindow("Hello")	
+	window := gocv.NewWindow("Hello")
 	img := gocv.NewMat()
 
 	for {
@@ -87,7 +87,7 @@ func main() {
 
 	fmt.Printf("start reading camera device: %v\n", deviceID)
 	for {
-		if ok := webcam.Read(&img); !ok {
+		if err := webcam.Read(&img); err != nil {
 			fmt.Printf("cannot read device %d\n", deviceID)
 			return
 		}

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ func main() {
 	fmt.Printf("start reading camera device: %v\n", deviceID)
 	for {
 		if err := webcam.Read(&img); err != nil {
-			fmt.Printf("cannot read device %d\n", deviceID)
+			fmt.Println(err)
 			return
 		}
 		if img.Empty() {

--- a/cmd/caffe-classifier/main.go
+++ b/cmd/caffe-classifier/main.go
@@ -92,7 +92,7 @@ func main() {
 	fmt.Printf("Start reading camera device: %v\n", deviceID)
 
 	for {
-		if ok := webcam.Read(&img); !ok {
+		if err := webcam.Read(&img); err != nil {
 			fmt.Printf("Error cannot read device %d\n", deviceID)
 			return
 		}

--- a/cmd/caffe-classifier/main.go
+++ b/cmd/caffe-classifier/main.go
@@ -93,7 +93,7 @@ func main() {
 
 	for {
 		if err := webcam.Read(&img); err != nil {
-			fmt.Printf("Error cannot read device %d\n", deviceID)
+			fmt.Println(err)
 			return
 		}
 		if img.Empty() {

--- a/cmd/captest/main.go
+++ b/cmd/captest/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	fmt.Printf("Start reading camera device: %v\n", deviceID)
 	for i := 0; i < 100; i++ {
-		if ok := webcam.Read(&buf); !ok {
+		if err := webcam.Read(&buf); err != nil {
 			fmt.Printf("cannot read device %d\n", deviceID)
 			return
 		}

--- a/cmd/captest/main.go
+++ b/cmd/captest/main.go
@@ -42,7 +42,7 @@ func main() {
 	fmt.Printf("Start reading camera device: %v\n", deviceID)
 	for i := 0; i < 100; i++ {
 		if err := webcam.Read(&buf); err != nil {
-			fmt.Printf("cannot read device %d\n", deviceID)
+			fmt.Println(err)
 			return
 		}
 		if buf.Empty() {

--- a/cmd/capwindow/main.go
+++ b/cmd/capwindow/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	fmt.Printf("Start reading camera device: %v\n", deviceID)
 	for {
-		if ok := webcam.Read(&img); !ok {
+		if err := webcam.Read(&img); err != nil {
 			fmt.Printf("Error cannot read device %d\n", deviceID)
 			return
 		}

--- a/cmd/capwindow/main.go
+++ b/cmd/capwindow/main.go
@@ -44,7 +44,7 @@ func main() {
 	fmt.Printf("Start reading camera device: %v\n", deviceID)
 	for {
 		if err := webcam.Read(&img); err != nil {
-			fmt.Printf("Error cannot read device %d\n", deviceID)
+			fmt.Println(err)
 			return
 		}
 		if img.Empty() {

--- a/cmd/counter/main.go
+++ b/cmd/counter/main.go
@@ -59,7 +59,7 @@ func main() {
 
 	count := 0
 	for {
-		if ok := video.Read(&img); !ok {
+		if err := video.Read(&img); err != nil {
 			fmt.Printf("Error cannot read file %s\n", file)
 			return
 		}
@@ -84,13 +84,13 @@ func main() {
 				if x > 0 && x < img.Cols() && y > line && y < line+width {
 					count++
 				}
-				gocv.Line(img, image.Pt(0, line), image.Pt(img.Cols(), line), color.RGBA{255, 0, 0, 0}, 2)
+				gocv.Line(&img, image.Pt(0, line), image.Pt(img.Cols(), line), color.RGBA{255, 0, 0, 0}, 2)
 			}
 			if axis == "x" {
 				if y > 0 && y < img.Rows() && x > line && x < line+width {
 					count++
 				}
-				gocv.Line(img, image.Pt(line, 0), image.Pt(line, img.Rows()), color.RGBA{255, 0, 0, 0}, 2)
+				gocv.Line(&img, image.Pt(line, 0), image.Pt(line, img.Rows()), color.RGBA{255, 0, 0, 0}, 2)
 			}
 		}
 

--- a/cmd/counter/main.go
+++ b/cmd/counter/main.go
@@ -60,7 +60,7 @@ func main() {
 	count := 0
 	for {
 		if err := video.Read(&img); err != nil {
-			fmt.Printf("Error cannot read file %s\n", file)
+			fmt.Println(err)
 			return
 		}
 		if img.Empty() {

--- a/cmd/dnn-advanced/ssd-facedetect.go
+++ b/cmd/dnn-advanced/ssd-facedetect.go
@@ -78,7 +78,7 @@ func main() {
 	fmt.Printf("Start reading camera device: %v\n", deviceID)
 
 	for {
-		if ok := webcam.Read(&img); !ok {
+		if err := webcam.Read(&img); err != nil {
 			fmt.Printf("Error cannot read device %d\n", deviceID)
 			return
 		}

--- a/cmd/faceblur/main.go
+++ b/cmd/faceblur/main.go
@@ -61,7 +61,7 @@ func main() {
 	fmt.Printf("start reading camera device: %v\n", deviceID)
 	for {
 		if err := webcam.Read(&img); err != nil {
-			fmt.Printf("cannot read device %d\n", deviceID)
+			fmt.Println(err)
 			return
 		}
 		if img.Empty() {

--- a/cmd/faceblur/main.go
+++ b/cmd/faceblur/main.go
@@ -60,7 +60,7 @@ func main() {
 
 	fmt.Printf("start reading camera device: %v\n", deviceID)
 	for {
-		if ok := webcam.Read(&img); !ok {
+		if err := webcam.Read(&img); err != nil {
 			fmt.Printf("cannot read device %d\n", deviceID)
 			return
 		}

--- a/cmd/facedetect/main.go
+++ b/cmd/facedetect/main.go
@@ -64,7 +64,7 @@ func main() {
 	fmt.Printf("start reading camera device: %v\n", deviceID)
 	for {
 		if err := webcam.Read(&img); err != nil {
-			fmt.Printf("cannot read device %d\n", deviceID)
+			fmt.Println(err)
 			return
 		}
 		if img.Empty() {

--- a/cmd/facedetect/main.go
+++ b/cmd/facedetect/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	fmt.Printf("start reading camera device: %v\n", deviceID)
 	for {
-		if ok := webcam.Read(&img); !ok {
+		if err := webcam.Read(&img); err != nil {
 			fmt.Printf("cannot read device %d\n", deviceID)
 			return
 		}

--- a/cmd/mjpeg-streamer/main.go
+++ b/cmd/mjpeg-streamer/main.go
@@ -70,7 +70,7 @@ func capture() {
 	defer img.Close()
 
 	for {
-		if ok := webcam.Read(&img); !ok {
+		if err := webcam.Read(&img); err != nil {
 			fmt.Printf("cannot read device %d\n", deviceID)
 			return
 		}

--- a/cmd/mjpeg-streamer/main.go
+++ b/cmd/mjpeg-streamer/main.go
@@ -71,7 +71,7 @@ func capture() {
 
 	for {
 		if err := webcam.Read(&img); err != nil {
-			fmt.Printf("cannot read device %d\n", deviceID)
+			fmt.Println(err)
 			return
 		}
 		if img.Empty() {

--- a/cmd/motion-detect/main.go
+++ b/cmd/motion-detect/main.go
@@ -61,7 +61,7 @@ func main() {
 
 	fmt.Printf("Start reading camera device: %v\n", deviceID)
 	for {
-		if ok := webcam.Read(&img); !ok {
+		if err := webcam.Read(&img); err != nil {
 			fmt.Printf("Error cannot read device %d\n", deviceID)
 			return
 		}

--- a/cmd/motion-detect/main.go
+++ b/cmd/motion-detect/main.go
@@ -62,7 +62,7 @@ func main() {
 	fmt.Printf("Start reading camera device: %v\n", deviceID)
 	for {
 		if err := webcam.Read(&img); err != nil {
-			fmt.Printf("Error cannot read device %d\n", deviceID)
+			fmt.Println(err)
 			return
 		}
 		if img.Empty() {

--- a/cmd/pvl/faceblur/main.go
+++ b/cmd/pvl/faceblur/main.go
@@ -62,7 +62,7 @@ func main() {
 	fmt.Printf("start reading camera device: %v\n", deviceID)
 	for {
 		if err := webcam.Read(&img); err != nil {
-			fmt.Printf("cannot read device %d\n", deviceID)
+			fmt.Println(err)
 			return
 		}
 		if img.Empty() {

--- a/cmd/pvl/faceblur/main.go
+++ b/cmd/pvl/faceblur/main.go
@@ -61,7 +61,7 @@ func main() {
 
 	fmt.Printf("start reading camera device: %v\n", deviceID)
 	for {
-		if ok := webcam.Read(&img); !ok {
+		if err := webcam.Read(&img); err != nil {
 			fmt.Printf("cannot read device %d\n", deviceID)
 			return
 		}

--- a/cmd/pvl/facerecognizer/main.go
+++ b/cmd/pvl/facerecognizer/main.go
@@ -101,7 +101,7 @@ func main() {
 MainLoop:
 	for {
 		if err := webcam.Read(&img); err != nil {
-			fmt.Printf("cannot read device %d\n", deviceID)
+			fmt.Println(err)
 			return
 		}
 		if img.Empty() {

--- a/cmd/pvl/facerecognizer/main.go
+++ b/cmd/pvl/facerecognizer/main.go
@@ -100,7 +100,7 @@ func main() {
 	fmt.Printf("start reading camera device: %v\n", deviceID)
 MainLoop:
 	for {
-		if ok := webcam.Read(&img); !ok {
+		if err := webcam.Read(&img); err != nil {
 			fmt.Printf("cannot read device %d\n", deviceID)
 			return
 		}

--- a/cmd/pvl/smiledetect/main.go
+++ b/cmd/pvl/smiledetect/main.go
@@ -68,7 +68,7 @@ func main() {
 
 	fmt.Printf("start reading camera device: %v\n", deviceID)
 	for {
-		if ok := webcam.Read(&img); !ok {
+		if err := webcam.Read(&img); err != nil {
 			fmt.Printf("cannot read device %d\n", deviceID)
 			return
 		}

--- a/cmd/pvl/smiledetect/main.go
+++ b/cmd/pvl/smiledetect/main.go
@@ -69,7 +69,7 @@ func main() {
 	fmt.Printf("start reading camera device: %v\n", deviceID)
 	for {
 		if err := webcam.Read(&img); err != nil {
-			fmt.Printf("cannot read device %d\n", deviceID)
+			fmt.Println(err)
 			return
 		}
 		if img.Empty() {

--- a/cmd/saveimage/main.go
+++ b/cmd/saveimage/main.go
@@ -40,7 +40,7 @@ func main() {
 	img := gocv.NewMat()
 	defer img.Close()
 
-	if ok := webcam.Read(&img); !ok {
+	if err := webcam.Read(&img); err != nil {
 		fmt.Printf("cannot read device %d\n", deviceID)
 		return
 	}

--- a/cmd/saveimage/main.go
+++ b/cmd/saveimage/main.go
@@ -32,7 +32,7 @@ func main() {
 
 	webcam, err := gocv.VideoCaptureDevice(int(deviceID))
 	if err != nil {
-		fmt.Printf("error opening video capture device: %v\n", deviceID)
+		fmt.Println(err)
 		return
 	}
 	defer webcam.Close()
@@ -41,7 +41,7 @@ func main() {
 	defer img.Close()
 
 	if err := webcam.Read(&img); err != nil {
-		fmt.Printf("cannot read device %d\n", deviceID)
+		fmt.Println(err)
 		return
 	}
 	if img.Empty() {

--- a/cmd/savevideo/main.go
+++ b/cmd/savevideo/main.go
@@ -32,7 +32,7 @@ func main() {
 
 	webcam, err := gocv.VideoCaptureDevice(int(deviceID))
 	if err != nil {
-		fmt.Printf("error opening video capture device: %v\n", deviceID)
+		fmt.Println(err)
 		return
 	}
 	defer webcam.Close()
@@ -41,20 +41,20 @@ func main() {
 	defer img.Close()
 
 	if err := webcam.Read(&img); err != nil {
-		fmt.Printf("cannot read device %d\n", deviceID)
+		fmt.Println(err)
 		return
 	}
 
 	writer, err := gocv.VideoWriterFile(saveFile, "MJPG", 25, img.Cols(), img.Rows())
 	if err != nil {
-		fmt.Printf("error opening video writer device: %v\n", saveFile)
+		fmt.Println(err)
 		return
 	}
 	defer writer.Close()
 
 	for i := 0; i < 100; i++ {
 		if err := webcam.Read(&img); err != nil {
-			fmt.Printf("cannot read device %d\n", deviceID)
+			fmt.Println(err)
 			return
 		}
 		if img.Empty() {

--- a/cmd/savevideo/main.go
+++ b/cmd/savevideo/main.go
@@ -40,7 +40,7 @@ func main() {
 	img := gocv.NewMat()
 	defer img.Close()
 
-	if ok := webcam.Read(&img); !ok {
+	if err := webcam.Read(&img); err != nil {
 		fmt.Printf("cannot read device %d\n", deviceID)
 		return
 	}
@@ -53,7 +53,7 @@ func main() {
 	defer writer.Close()
 
 	for i := 0; i < 100; i++ {
-		if ok := webcam.Read(&img); !ok {
+		if err := webcam.Read(&img); err != nil {
 			fmt.Printf("cannot read device %d\n", deviceID)
 			return
 		}

--- a/cmd/showimage/main.go
+++ b/cmd/showimage/main.go
@@ -28,7 +28,7 @@ func main() {
 	window := gocv.NewWindow("Hello")
 	img, err := gocv.IMRead(filename, gocv.IMReadColor)
 	if err != nil {
-		fmt.Println("Error reading image from: %v", filename)
+		fmt.Println(err)
 		return
 	}
 	for {

--- a/cmd/showimage/main.go
+++ b/cmd/showimage/main.go
@@ -26,8 +26,8 @@ func main() {
 
 	filename := os.Args[1]
 	window := gocv.NewWindow("Hello")
-	img := gocv.IMRead(filename, gocv.IMReadColor)
-	if img.Empty() {
+	img, err := gocv.IMRead(filename, gocv.IMReadColor)
+	if err != nil {
 		fmt.Println("Error reading image from: %v", filename)
 		return
 	}

--- a/cmd/tf-classifier/main.go
+++ b/cmd/tf-classifier/main.go
@@ -89,7 +89,7 @@ func main() {
 	fmt.Printf("Start reading camera device: %v\n", deviceID)
 
 	for {
-		if ok := webcam.Read(&img); !ok {
+		if err := webcam.Read(&img); err != nil {
 			fmt.Printf("Error cannot read device %d\n", deviceID)
 			return
 		}
@@ -118,7 +118,7 @@ func main() {
 			desc = descriptions[maxLoc.X]
 		}
 		status = fmt.Sprintf("description: %v, maxVal: %v\n", desc, maxVal)
-		gocv.PutText(img, status, image.Pt(10, 20), gocv.FontHersheyPlain, 1.2, statusColor, 2)
+		gocv.PutText(&img, status, image.Pt(10, 20), gocv.FontHersheyPlain, 1.2, statusColor, 2)
 
 		blob.Close()
 		prob.Close()

--- a/cmd/tf-classifier/main.go
+++ b/cmd/tf-classifier/main.go
@@ -58,14 +58,14 @@ func main() {
 	descr := os.Args[3]
 	descriptions, err := readDescriptions(descr)
 	if err != nil {
-		fmt.Printf("Error reading descriptions file: %v\n", descr)
+		fmt.Println(err)
 		return
 	}
 
 	// open capture device
 	webcam, err := gocv.VideoCaptureDevice(deviceID)
 	if err != nil {
-		fmt.Printf("Error opening video capture device: %v\n", deviceID)
+		fmt.Println(err)
 		return
 	}
 	defer webcam.Close()
@@ -90,7 +90,7 @@ func main() {
 
 	for {
 		if err := webcam.Read(&img); err != nil {
-			fmt.Printf("Error cannot read device %d\n", deviceID)
+			fmt.Println(err)
 			return
 		}
 		if img.Empty() {

--- a/cmd/tracking/main.go
+++ b/cmd/tracking/main.go
@@ -40,7 +40,7 @@ func main() {
 	// open webcam
 	webcam, err := gocv.VideoCaptureDevice(int(deviceID))
 	if err != nil {
-		fmt.Printf("error opening video capture device: %v\n", deviceID)
+		fmt.Println(err)
 		return
 	}
 	defer webcam.Close()
@@ -60,7 +60,7 @@ func main() {
 
 	// read an initial image
 	if err := webcam.Read(&img); err != nil {
-		fmt.Printf("cannot read device %d\n", deviceID)
+		fmt.Println(err)
 		return
 	}
 
@@ -83,7 +83,7 @@ func main() {
 	fmt.Printf("start reading camera device: %v\n", deviceID)
 	for {
 		if err := webcam.Read(&img); err != nil {
-			fmt.Printf("cannot read device %d\n", deviceID)
+			fmt.Println(err)
 			return
 		}
 		if img.Empty() {

--- a/cmd/tracking/main.go
+++ b/cmd/tracking/main.go
@@ -59,7 +59,7 @@ func main() {
 	defer img.Close()
 
 	// read an initial image
-	if ok := webcam.Read(&img); !ok {
+	if err := webcam.Read(&img); err != nil {
 		fmt.Printf("cannot read device %d\n", deviceID)
 		return
 	}
@@ -82,7 +82,7 @@ func main() {
 	blue := color.RGBA{0, 0, 255, 0}
 	fmt.Printf("start reading camera device: %v\n", deviceID)
 	for {
-		if ok := webcam.Read(&img); !ok {
+		if err := webcam.Read(&img); err != nil {
 			fmt.Printf("cannot read device %d\n", deviceID)
 			return
 		}

--- a/contrib/face_test.go
+++ b/contrib/face_test.go
@@ -1,9 +1,10 @@
 package contrib
 
 import (
-	"gocv.io/x/gocv"
 	"math"
 	"testing"
+
+	"gocv.io/x/gocv"
 )
 
 func TestLBPHFaceRecognizer_Methods(t *testing.T) {
@@ -13,19 +14,27 @@ func TestLBPHFaceRecognizer_Methods(t *testing.T) {
 	}
 
 	labels := []int{1, 1, 1, 1, 2, 2, 2, 2}
-	images := []gocv.Mat{
-		gocv.IMRead("./att_faces/s1/1.pgm", gocv.IMReadGrayScale),
-		gocv.IMRead("./att_faces/s1/2.pgm", gocv.IMReadGrayScale),
-		gocv.IMRead("./att_faces/s1/3.pgm", gocv.IMReadGrayScale),
-		gocv.IMRead("./att_faces/s1/4.pgm", gocv.IMReadGrayScale),
-		gocv.IMRead("./att_faces/s2/1.pgm", gocv.IMReadGrayScale),
-		gocv.IMRead("./att_faces/s2/2.pgm", gocv.IMReadGrayScale),
-		gocv.IMRead("./att_faces/s2/3.pgm", gocv.IMReadGrayScale),
-		gocv.IMRead("./att_faces/s2/4.pgm", gocv.IMReadGrayScale),
-	}
+	images := []gocv.Mat{}
+	img, _ := gocv.IMRead("./att_faces/s1/1.pgm", gocv.IMReadGrayScale)
+	images = append(images, img)
+	img, _ = gocv.IMRead("./att_faces/s1/2.pgm", gocv.IMReadGrayScale)
+	images = append(images, img)
+	img, _ = gocv.IMRead("./att_faces/s1/3.pgm", gocv.IMReadGrayScale)
+	images = append(images, img)
+	img, _ = gocv.IMRead("./att_faces/s1/4.pgm", gocv.IMReadGrayScale)
+	images = append(images, img)
+	img, _ = gocv.IMRead("./att_faces/s2/1.pgm", gocv.IMReadGrayScale)
+	images = append(images, img)
+	img, _ = gocv.IMRead("./att_faces/s2/2.pgm", gocv.IMReadGrayScale)
+	images = append(images, img)
+	img, _ = gocv.IMRead("./att_faces/s2/3.pgm", gocv.IMReadGrayScale)
+	images = append(images, img)
+	img, _ = gocv.IMRead("./att_faces/s2/4.pgm", gocv.IMReadGrayScale)
+	images = append(images, img)
+
 	model.Train(images, labels)
 
-	sample := gocv.IMRead("./att_faces/s2/5.pgm", gocv.IMReadGrayScale)
+	sample, _ := gocv.IMRead("./att_faces/s2/5.pgm", gocv.IMReadGrayScale)
 	label := model.Predict(sample)
 	if label != 2 {
 		t.Errorf("Invalid simple predict! label: %d", label)
@@ -64,16 +73,28 @@ func TestLBPHFaceRecognizer_Methods(t *testing.T) {
 	}
 
 	// add new data
-	sample = gocv.IMRead("./att_faces/s3/10.pgm", gocv.IMReadGrayScale)
+	sample, _ = gocv.IMRead("./att_faces/s3/10.pgm", gocv.IMReadGrayScale)
 	newLabels := []int{3, 3, 3, 3, 3, 3}
-	newImages := []gocv.Mat{
-		gocv.IMRead("./att_faces/s3/1.pgm", gocv.IMReadGrayScale),
-		gocv.IMRead("./att_faces/s3/2.pgm", gocv.IMReadGrayScale),
-		gocv.IMRead("./att_faces/s3/3.pgm", gocv.IMReadGrayScale),
-		gocv.IMRead("./att_faces/s3/4.pgm", gocv.IMReadGrayScale),
-		gocv.IMRead("./att_faces/s3/5.pgm", gocv.IMReadGrayScale),
-		gocv.IMRead("./att_faces/s3/6.pgm", gocv.IMReadGrayScale),
-	}
+	newImages := []gocv.Mat{}
+
+	img, _ = gocv.IMRead("./att_faces/s3/1.pgm", gocv.IMReadGrayScale)
+	newImages = append(newImages, img)
+
+	img, _ = gocv.IMRead("./att_faces/s3/2.pgm", gocv.IMReadGrayScale)
+	newImages = append(newImages, img)
+
+	img, _ = gocv.IMRead("./att_faces/s3/3.pgm", gocv.IMReadGrayScale)
+	newImages = append(newImages, img)
+
+	img, _ = gocv.IMRead("./att_faces/s3/4.pgm", gocv.IMReadGrayScale)
+	newImages = append(newImages, img)
+
+	img, _ = gocv.IMRead("./att_faces/s3/5.pgm", gocv.IMReadGrayScale)
+	newImages = append(newImages, img)
+
+	img, _ = gocv.IMRead("./att_faces/s3/6.pgm", gocv.IMReadGrayScale)
+	newImages = append(newImages, img)
+
 	model.Update(newImages, newLabels)
 	label = model.Predict(sample)
 	if label != 3 {

--- a/contrib/tracking_test.go
+++ b/contrib/tracking_test.go
@@ -1,9 +1,10 @@
 package contrib
 
 import (
-	"gocv.io/x/gocv"
 	"image"
 	"testing"
+
+	"gocv.io/x/gocv"
 )
 
 func BaseTestTracker(t *testing.T, tracker Tracker, name string) {
@@ -11,8 +12,8 @@ func BaseTestTracker(t *testing.T, tracker Tracker, name string) {
 		t.Error("TestTracker " + name + " should not be nil")
 	}
 
-	img := gocv.IMRead("../images/face.jpg", 1)
-	if img.Empty() {
+	img, err := gocv.IMRead("../images/face.jpg", 1)
+	if err != nil {
 		t.Error("TestTracker " + name + " input img failed to load")
 	}
 	defer img.Close()

--- a/contrib/xfeatures2d_test.go
+++ b/contrib/xfeatures2d_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestSIFT(t *testing.T) {
-	img := gocv.IMRead("../images/face.jpg", gocv.IMReadGrayScale)
-	if img.Empty() {
+	img, err := gocv.IMRead("../images/face.jpg", gocv.IMReadGrayScale)
+	if err != nil {
 		t.Error("Invalid Mat in SIFT test")
 	}
 	defer img.Close()
@@ -38,8 +38,8 @@ func TestSIFT(t *testing.T) {
 }
 
 func TestSURF(t *testing.T) {
-	img := gocv.IMRead("../images/face.jpg", gocv.IMReadGrayScale)
-	if img.Empty() {
+	img, err := gocv.IMRead("../images/face.jpg", gocv.IMReadGrayScale)
+	if err != nil {
 		t.Error("Invalid Mat in SURF test")
 	}
 	defer img.Close()

--- a/core_test.go
+++ b/core_test.go
@@ -183,13 +183,13 @@ func TestMatMean(t *testing.T) {
 }
 
 func TestLUT(t *testing.T) {
-	src := IMRead("images/gocvlogo.jpg", IMReadColor)
+	src, _ := IMRead("images/gocvlogo.jpg", IMReadColor)
 	if src.Empty() {
 		t.Error("Invalid read of Source Mat in LUT test")
 	}
 	defer src.Close()
 
-	lut := IMRead("images/lut.png", IMReadColor)
+	lut, _ := IMRead("images/lut.png", IMReadColor)
 	if lut.Empty() {
 		t.Error("Invalid read of LUT Mat in LUT test")
 	}
@@ -510,7 +510,7 @@ func TestMatNormalize(t *testing.T) {
 }
 
 func TestMatSplit(t *testing.T) {
-	src := IMRead("images/face.jpg", 1)
+	src, _ := IMRead("images/face.jpg", 1)
 	chans := Split(src)
 	if len(chans) != src.Channels() {
 		t.Error("Split Channel count differs")
@@ -526,8 +526,8 @@ func TestMatSplit(t *testing.T) {
 }
 
 func TestMatSubtract(t *testing.T) {
-	src1 := IMRead("images/lut.png", 1)
-	src2 := IMRead("images/lut.png", 1)
+	src1, _ := IMRead("images/lut.png", 1)
+	src2, _ := IMRead("images/lut.png", 1)
 	dst := NewMat()
 	Subtract(src1, src2, &dst)
 	sum := dst.Sum()

--- a/dnn_test.go
+++ b/dnn_test.go
@@ -18,7 +18,7 @@ func TestCaffe(t *testing.T) {
 	}
 	defer net.Close()
 
-	img := IMRead("images/space_shuttle.jpg", IMReadColor)
+	img, _ := IMRead("images/space_shuttle.jpg", IMReadColor)
 	if img.Empty() {
 		t.Error("Invalid Mat in Caffe test")
 	}
@@ -64,7 +64,7 @@ func TestTensorflow(t *testing.T) {
 	}
 	defer net.Close()
 
-	img := IMRead("images/space_shuttle.jpg", IMReadColor)
+	img, _ := IMRead("images/space_shuttle.jpg", IMReadColor)
 	if img.Empty() {
 		t.Error("Invalid Mat in Tensorflow test")
 	}

--- a/features2d_test.go
+++ b/features2d_test.go
@@ -5,8 +5,8 @@ import (
 )
 
 func TestAKAZE(t *testing.T) {
-	img := IMRead("images/face.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in AKAZE test")
 	}
 	defer img.Close()
@@ -36,8 +36,8 @@ func TestAKAZE(t *testing.T) {
 }
 
 func TestAgastFeatureDetector(t *testing.T) {
-	img := IMRead("images/face.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in AgastFeatureDetector test")
 	}
 	defer img.Close()
@@ -55,8 +55,8 @@ func TestAgastFeatureDetector(t *testing.T) {
 }
 
 func TestBRISK(t *testing.T) {
-	img := IMRead("images/face.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in BRISK test")
 	}
 	defer img.Close()
@@ -86,8 +86,8 @@ func TestBRISK(t *testing.T) {
 }
 
 func TestFastFeatureDetector(t *testing.T) {
-	img := IMRead("images/face.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in FastFeatureDetector test")
 	}
 	defer img.Close()
@@ -105,8 +105,8 @@ func TestFastFeatureDetector(t *testing.T) {
 }
 
 func TestGFTTDetector(t *testing.T) {
-	img := IMRead("images/face.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in GFTTDetector test")
 	}
 	defer img.Close()
@@ -124,8 +124,8 @@ func TestGFTTDetector(t *testing.T) {
 }
 
 func TestKAZE(t *testing.T) {
-	img := IMRead("images/face.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in KAZE test")
 	}
 	defer img.Close()
@@ -155,8 +155,8 @@ func TestKAZE(t *testing.T) {
 }
 
 func TestMSER(t *testing.T) {
-	img := IMRead("images/face.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in MSER test")
 	}
 	defer img.Close()
@@ -174,8 +174,8 @@ func TestMSER(t *testing.T) {
 }
 
 func TestORB(t *testing.T) {
-	img := IMRead("images/face.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in AgastFeatureDetector test")
 	}
 	defer img.Close()
@@ -205,8 +205,8 @@ func TestORB(t *testing.T) {
 }
 
 func TestSimpleBlobDetector(t *testing.T) {
-	img := IMRead("images/face.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in SimpleBlobDetector test")
 	}
 	defer img.Close()

--- a/highgui_test.go
+++ b/highgui_test.go
@@ -45,8 +45,8 @@ func TestIMShow(t *testing.T) {
 		t.Error("Unable to create IMShow Window")
 	}
 
-	img := IMRead("images/face-detect.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in IMShow")
 	}
 	defer img.Close()

--- a/imgcodecs.go
+++ b/imgcodecs.go
@@ -6,6 +6,7 @@ package gocv
 */
 import "C"
 import (
+	"errors"
 	"unsafe"
 )
 
@@ -61,61 +62,64 @@ const (
 	// IMReadIgnoreOrientation do not rotate the image according to EXIF's orientation flag.
 	IMReadIgnoreOrientation = 128
 
-	// For JPEG, it can be a quality from 0 to 100 (the higher is the better). Default value is 95.
-	ImwriteJpegQuality = 1
+	// IMWriteJPEGQuality sets JPEG quality from 0 to 100 (the higher is the better). Default value is 95.
+	IMWriteJPEGQuality = 1
 
-	// Enable JPEG features, 0 or 1, default is False.
-	ImwriteJpegProgressive = 2
+	// IMWriteJPEGProgressive enables JPEG features, 0 or 1, default is False.
+	IMWriteJPEGProgressive = 2
 
-	// Enable JPEG features, 0 or 1, default is False.
-	ImwriteJpegOptimize = 3
+	// IMWriteJPEGOptimize enables JPEG features, 0 or 1, default is False.
+	IMWriteJPEGOptimize = 3
 
-	// JPEG restart interval, 0 - 65535, default is 0 - no restart.
-	ImwriteJpegRstInterval = 4
+	// IMWriteJPEGRstInterval sets JPEG restart interval, 0 - 65535, default is 0 - no restart.
+	IMWriteJPEGRstInterval = 4
 
-	// Separate luma quality level, 0 - 100, default is 0 - don't use.
-	ImwriteJpegLumaQuality = 5
+	// IMWriteJPEGLumaQuality sets separate luma quality level, 0 - 100, default is 0 - don't use.
+	IMWriteJPEGLumaQuality = 5
 
-	// Separate chroma quality level, 0 - 100, default is 0 - don't use.
-	ImwriteJpegChromaQuality = 6
+	// IMWriteJPEGChromaQuality sets separate chroma quality level, 0 - 100, default is 0 - don't use.
+	IMWriteJPEGChromaQuality = 6
 
-	// For PNG, it can be the compression level from 0 to 9. A higher value means a smaller size and longer compression time.
+	// IMWritePNGCompression for PNG, it can be the compression level from 0 to 9. A higher value
+	// means a smaller size and longer compression time.
 	// If specified, strategy is changed to IMWRITE_PNG_STRATEGY_DEFAULT (Z_DEFAULT_STRATEGY).
 	// Default value is 1 (best speed setting).
-	ImwritePngCompression = 16
+	IMWritePngCompression = 16
 
-	// One of cv::ImwritePNGFlags, default is IMWRITE_PNG_STRATEGY_RLE.
-	ImwritePngStrategy = 17
+	// IMWritePNGStrategy is one of IMWritePNGFlags, default is IMWRITE_PNG_STRATEGY_RLE.
+	IMWritePNGStrategy = 17
 
-	// Binary level PNG, 0 or 1, default is 0.
-	ImwritePngBilevel = 18
+	// IMWritePNGBilevel sets binary level PNG, 0 or 1, default is 0.
+	IMWritePNGBilevel = 18
 
-	// For PPM, PGM, or PBM, it can be a binary format flag, 0 or 1. Default value is 1.
-	ImwritePxmBinary = 32
+	// IMWritePxMBinary sets for PPM, PGM, or PBM, it can be a binary format flag, 0 or 1. Default value is 1.
+	IMWritePxMBinary = 32
 
-	// For WEBP, it can be a quality from 1 to 100 (the higher is the better).
+	// IMWriteWEBPQuality sets WEBP quality, it can be a quality from 1 to 100 (the higher is the better).
 	// By default (without any parameter) and for quality above 100 the lossless compression is used.
-	ImwriteWebpQuality = 64
+	IMWriteWEBPQuality = 64
 
-	// For PAM, sets the TUPLETYPE field to the corresponding string value that is defined for the format.
-	ImwritePamTupletype = 128
+	// IMWritePAMTupletype for PAM, sets the TUPLETYPE field to the corresponding string value
+	// that is defined for the format.
+	IMWritePAMTupletype = 128
 
-	// Use this value for normal data.
-	ImwritePngStrategyDefault = 0
+	// IMWritePNGStrategyDefault means use this value for normal data.
+	IMWritePNGStrategyDefault = 0
 
-	// Use this value for data produced by a filter (or predictor).
+	// IMWritePNGStrategyFiltered means use this value for data produced by a filter (or predictor).
 	// Filtered data consists mostly of small values with a somewhat random distribution.
 	// In this case, the compression algorithm is tuned to compress them better.
-	ImwritePngStrategyFiltered = 1
+	IMWritePNGStrategyFiltered = 1
 
-	// Use this value to force Huffman encoding only (no string match).
-	ImwritePngStrategyHuffmanOnly = 2
+	// IMWritePNGStrategyHuffmanOnly means use this value to force Huffman encoding only (no string match).
+	IMWritePNGStrategyHuffmanOnly = 2
 
-	// Use this value to limit match distances to one (run-length encoding).
-	ImwritePngStrategyRle = 3
+	// IMWritePNGStrategyRle means use this value to limit match distances to one (run-length encoding).
+	IMWritePNGStrategyRle = 3
 
-	// Using this value prevents the use of dynamic Huffman codes, allowing for a simpler decoder for special applications.
-	ImwritePngStrategyFixed = 4
+	// IMWritePNGStrategyFixed means using this value prevents the use of dynamic Huffman codes,
+	// allowing for a simpler decoder for special applications.
+	IMWritePNGStrategyFixed = 4
 )
 
 // IMRead reads an image from a file into a Mat.
@@ -126,32 +130,38 @@ const (
 // For further details, please see:
 // http://docs.opencv.org/master/d4/da8/group__imgcodecs.html#ga288b8b3da0892bd651fce07b3bbd3a56
 //
-func IMRead(name string, flags IMReadFlag) Mat {
+func IMRead(name string, flags IMReadFlag) (img Mat, err error) {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
-	return Mat{p: C.Image_IMRead(cName, C.int(flags))}
+	img = Mat{p: C.Image_IMRead(cName, C.int(flags))}
+	if img.Empty() {
+		err = errors.New("IMRead error")
+	}
+	return
 }
 
-// IMWrite writes a Mat to an image file.
+// IMWrite writes a Mat to an image file using default compression parameters.
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d4/da8/group__imgcodecs.html#gabbc7ef1aa2edfaa87772f1202d67e0ce
 //
-func IMWrite(name string, img Mat) bool {
+func IMWrite(name string, img Mat) (err error) {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
-	return bool(C.Image_IMWrite(cName, img.p))
+	if !bool(C.Image_IMWrite(cName, img.p)) {
+		err = errors.New("IMWrite write error")
+	}
+	return
 }
 
-// IMWrite writes a Mat to an image file.
-// With that func you can pass compression parameters
+// IMWriteWithParams writes a Mat to an image file using custom compression parameters.
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d4/da8/group__imgcodecs.html#gabbc7ef1aa2edfaa87772f1202d67e0ce
 //
-func IMWriteWithParams(name string, img Mat, params []int) bool {
+func IMWriteWithParams(name string, img Mat, params []int) (err error) {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
@@ -165,7 +175,10 @@ func IMWriteWithParams(name string, img Mat, params []int) bool {
 	paramsVector.val = (*C.int)(&cparams[0])
 	paramsVector.length = (C.int)(len(cparams))
 
-	return bool(C.Image_IMWrite_WithParams(cName, img.p, paramsVector))
+	if !bool(C.Image_IMWrite_WithParams(cName, img.p, paramsVector)) {
+		err = errors.New("IMWrite write error")
+	}
+	return
 }
 
 type FileExt string
@@ -200,7 +213,11 @@ func IMEncode(fileExt FileExt, img Mat) (buf []byte, err error) {
 // For further details, please see:
 // https://docs.opencv.org/master/d4/da8/group__imgcodecs.html#ga26a67788faa58ade337f8d28ba0eb19e
 //
-func IMDecode(buf []byte, flags IMReadFlag) Mat {
+func IMDecode(buf []byte, flags IMReadFlag) (img Mat, err error) {
 	data := toByteArray(buf)
-	return Mat{p: C.Image_IMDecode(data, C.int(flags))}
+	img = Mat{p: C.Image_IMDecode(data, C.int(flags))}
+	if img.Empty() {
+		err = errors.New("IMDecode error")
+	}
+	return
 }

--- a/imgcodecs_test.go
+++ b/imgcodecs_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestIMRead(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadColor)
+	img, _ := IMRead("images/face-detect.jpg", IMReadColor)
 	if img.Empty() {
 		t.Error("Invalid Mat in IMRead")
 	}
@@ -17,13 +17,13 @@ func TestIMWrite(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "gocvtests")
 	tmpfn := filepath.Join(dir, "test.jpg")
 
-	img := IMRead("images/face-detect.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid read of Mat in IMWrite test")
 	}
 
 	result := IMWrite(tmpfn, img)
-	if !result {
+	if result != nil {
 		t.Error("Invalid write of Mat in IMWrite test")
 	}
 }
@@ -32,20 +32,20 @@ func TestIMWriteWithParams(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "gocvtests")
 	tmpfn := filepath.Join(dir, "test.jpg")
 
-	img := IMRead("images/face-detect.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid read of Mat in IMWrite test")
 	}
 
-	result := IMWriteWithParams(tmpfn, img, []int{ImwriteJpegQuality, 60})
-	if !result {
+	result := IMWriteWithParams(tmpfn, img, []int{IMWriteJPEGQuality, 60})
+	if result != nil {
 		t.Error("Invalid write of Mat in IMWrite test")
 	}
 }
 
 func TestIMEncode(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in IMEncode test")
 	}
 
@@ -64,8 +64,8 @@ func TestIMDecode(t *testing.T) {
 		t.Error("Invalid ReadFile in IMDecode")
 	}
 
-	dec := IMDecode(content, IMReadColor)
-	if dec.Empty() {
+	_, err = IMDecode(content, IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in IMDecode")
 	}
 }

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -38,8 +38,8 @@ func TestApproxPolyDP(t *testing.T) {
 }
 
 func TestConvexity(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadGrayScale)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadGrayScale)
+	if err != nil {
 		t.Error("Invalid read of Mat in FindContours test")
 	}
 	defer img.Close()
@@ -72,8 +72,8 @@ func TestConvexity(t *testing.T) {
 }
 
 func TestCvtColor(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid read of Mat in CvtColor test")
 	}
 	defer img.Close()
@@ -88,8 +88,8 @@ func TestCvtColor(t *testing.T) {
 }
 
 func TestBilateralFilter(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid read of Mat in BilateralFilter test")
 	}
 	defer img.Close()
@@ -104,8 +104,8 @@ func TestBilateralFilter(t *testing.T) {
 }
 
 func TestBlur(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid read of Mat in GaussianBlur test")
 	}
 	defer img.Close()
@@ -120,8 +120,8 @@ func TestBlur(t *testing.T) {
 }
 
 func TestDilate(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid read of Mat in Dilate test")
 	}
 	defer img.Close()
@@ -138,14 +138,14 @@ func TestDilate(t *testing.T) {
 }
 
 func TestMatchTemplate(t *testing.T) {
-	imgScene := IMRead("images/face.jpg", IMReadGrayScale)
-	if imgScene.Empty() {
+	imgScene, err := IMRead("images/face.jpg", IMReadGrayScale)
+	if err != nil {
 		t.Error("Invalid read of face.jpg in MatchTemplate test")
 	}
 	defer imgScene.Close()
 
-	imgTemplate := IMRead("images/toy.jpg", IMReadGrayScale)
-	if imgTemplate.Empty() {
+	imgTemplate, err := IMRead("images/toy.jpg", IMReadGrayScale)
+	if err != nil {
 		t.Error("Invalid read of toy.jpg in MatchTemplate test")
 	}
 	defer imgTemplate.Close()
@@ -159,8 +159,8 @@ func TestMatchTemplate(t *testing.T) {
 }
 
 func TestMoments(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadGrayScale)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadGrayScale)
+	if err != nil {
 		t.Error("Invalid read of Mat in Moments test")
 	}
 	defer img.Close()
@@ -172,8 +172,8 @@ func TestMoments(t *testing.T) {
 }
 
 func TestPyrDown(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid read of Mat in PyrDown test")
 	}
 	defer img.Close()
@@ -188,8 +188,8 @@ func TestPyrDown(t *testing.T) {
 }
 
 func TestPyrUp(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid read of Mat in PyrUp test")
 	}
 	defer img.Close()
@@ -204,8 +204,8 @@ func TestPyrUp(t *testing.T) {
 }
 
 func TestFindContours(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadGrayScale)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadGrayScale)
+	if err != nil {
 		t.Error("Invalid read of Mat in FindContours test")
 	}
 	defer img.Close()
@@ -237,8 +237,8 @@ func TestFindContours(t *testing.T) {
 }
 
 func TestErode(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid read of Mat in Erode test")
 	}
 	defer img.Close()
@@ -255,8 +255,8 @@ func TestErode(t *testing.T) {
 }
 
 func TestMorphologyEx(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid read of Mat in MorphologyEx test")
 	}
 	defer img.Close()
@@ -273,8 +273,8 @@ func TestMorphologyEx(t *testing.T) {
 }
 
 func TestGaussianBlur(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid read of Mat in GaussianBlur test")
 	}
 	defer img.Close()
@@ -289,8 +289,8 @@ func TestGaussianBlur(t *testing.T) {
 }
 
 func TestLaplacian(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid read of Mat in Laplacian test")
 	}
 	defer img.Close()
@@ -305,8 +305,8 @@ func TestLaplacian(t *testing.T) {
 }
 
 func TestScharr(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid read of Mat in Scharr test")
 	}
 	defer img.Close()
@@ -321,8 +321,8 @@ func TestScharr(t *testing.T) {
 }
 
 func TestMedianBlur(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid read of Mat in MedianBlur test")
 	}
 	defer img.Close()
@@ -337,8 +337,8 @@ func TestMedianBlur(t *testing.T) {
 }
 
 func TestCanny(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadGrayScale)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadGrayScale)
+	if err != nil {
 		t.Error("Invalid read of Mat in HoughLines test")
 	}
 	defer img.Close()
@@ -359,8 +359,8 @@ func TestCanny(t *testing.T) {
 }
 
 func TestGoodFeaturesToTrackAndCornerSubPix(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadGrayScale)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadGrayScale)
+	if err != nil {
 		t.Error("Invalid read of Mat in GoodFeaturesToTrack test")
 	}
 	defer img.Close()
@@ -394,8 +394,8 @@ func TestGoodFeaturesToTrackAndCornerSubPix(t *testing.T) {
 }
 
 func TestHoughCircles(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadGrayScale)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadGrayScale)
+	if err != nil {
 		t.Error("Invalid read of Mat in HoughCircles test")
 	}
 	defer img.Close()
@@ -416,8 +416,8 @@ func TestHoughCircles(t *testing.T) {
 }
 
 func TestHoughCirclesWithParams(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadGrayScale)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadGrayScale)
+	if err != nil {
 		t.Error("Invalid read of Mat in HoughCircles test")
 	}
 	defer img.Close()
@@ -438,8 +438,8 @@ func TestHoughCirclesWithParams(t *testing.T) {
 }
 
 func TestHoughLines(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadGrayScale)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadGrayScale)
+	if err != nil {
 		t.Error("Invalid read of Mat in HoughLines test")
 	}
 	defer img.Close()
@@ -476,8 +476,8 @@ func TestHoughLines(t *testing.T) {
 }
 
 func TestHoughLinesP(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadGrayScale)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadGrayScale)
+	if err != nil {
 		t.Error("Invalid read of Mat in HoughLines test")
 	}
 	defer img.Close()
@@ -514,8 +514,8 @@ func TestHoughLinesP(t *testing.T) {
 }
 
 func TestThreshold(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid read of Mat in Erode test")
 	}
 	defer img.Close()
@@ -529,8 +529,8 @@ func TestThreshold(t *testing.T) {
 	}
 }
 func TestAdaptiveThreshold(t *testing.T) {
-	img := IMRead("images/face-detect.jpg", IMReadGrayScale)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadGrayScale)
+	if err != nil {
 		t.Error("Invalid read of Mat in AdaptiveThreshold test")
 	}
 	defer img.Close()
@@ -587,8 +587,8 @@ func TestPutText(t *testing.T) {
 }
 
 func TestResize(t *testing.T) {
-	src := IMRead("images/gocvlogo.jpg", IMReadColor)
-	if src.Empty() {
+	src, err := IMRead("images/gocvlogo.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid read of Mat in Resize test")
 	}
 	defer src.Close()
@@ -668,7 +668,7 @@ func TestWarpAffine(t *testing.T) {
 	if result != 0.0 {
 		t.Errorf("WarpAffine() = %v, want %v", result, 0.0)
 	}
-	src = IMRead("images/gocvlogo.jpg", IMReadUnchanged)
+	src, _ = IMRead("images/gocvlogo.jpg", IMReadUnchanged)
 	dst = src.Clone()
 	WarpAffine(src, &dst, rot, image.Point{343, 400})
 	result = Norm(dst, NormL2)
@@ -689,7 +689,7 @@ func TestWarpAffineWithParams(t *testing.T) {
 		t.Errorf("WarpAffineWithParams() = %v, want %v", result, 0.0)
 	}
 
-	src = IMRead("images/gocvlogo.jpg", IMReadUnchanged)
+	src, _ = IMRead("images/gocvlogo.jpg", IMReadUnchanged)
 	dst = src.Clone()
 	WarpAffineWithParams(src, &dst, rot, image.Point{343, 400}, InterpolationLinear, BorderConstant, color.RGBA{0, 0, 0, 0})
 	result = Norm(dst, NormL2)
@@ -721,7 +721,7 @@ func TestApplyColorMap(t *testing.T) {
 		{name: "COLORMAP_HOT", args: args{colormapType: ColormapHot, want: 124941.02475968412}},
 		{name: "COLORMAP_PARULA", args: args{colormapType: ColormapParula, want: 111483.33555738274}},
 	}
-	src := IMRead("images/gocvlogo.jpg", IMReadGrayScale)
+	src, _ := IMRead("images/gocvlogo.jpg", IMReadGrayScale)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -736,7 +736,7 @@ func TestApplyColorMap(t *testing.T) {
 }
 
 func TestApplyCustomColorMap(t *testing.T) {
-	src := IMRead("images/gocvlogo.jpg", IMReadGrayScale)
+	src, _ := IMRead("images/gocvlogo.jpg", IMReadGrayScale)
 	customColorMap := NewMatWithSize(256, 1, MatTypeCV8UC1)
 
 	dst := src.Clone()
@@ -772,7 +772,7 @@ func TestGetPerspectiveTransform(t *testing.T) {
 }
 
 func TestWarpPerspective(t *testing.T) {
-	img := IMRead("images/gocvlogo.jpg", IMReadUnchanged)
+	img, _ := IMRead("images/gocvlogo.jpg", IMReadUnchanged)
 	defer img.Close()
 
 	w := img.Cols()

--- a/objdetect_test.go
+++ b/objdetect_test.go
@@ -6,8 +6,8 @@ import (
 )
 
 func TestCascadeClassifier(t *testing.T) {
-	img := IMRead("images/face.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in CascadeClassifier test")
 	}
 	defer img.Close()
@@ -25,8 +25,8 @@ func TestCascadeClassifier(t *testing.T) {
 }
 
 func TestCascadeClassifierWithParams(t *testing.T) {
-	img := IMRead("images/face.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in CascadeClassifierWithParams test")
 	}
 	defer img.Close()
@@ -44,8 +44,8 @@ func TestCascadeClassifierWithParams(t *testing.T) {
 }
 
 func TestHOGDescriptor(t *testing.T) {
-	img := IMRead("images/face.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in HOGDescriptor test")
 	}
 	defer img.Close()
@@ -63,8 +63,8 @@ func TestHOGDescriptor(t *testing.T) {
 }
 
 func TestHOGDescriptorWithParams(t *testing.T) {
-	img := IMRead("images/face.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in HOGDescriptorWithParams test")
 	}
 	defer img.Close()

--- a/video_test.go
+++ b/video_test.go
@@ -6,8 +6,8 @@ import (
 )
 
 func TestMOG2(t *testing.T) {
-	img := IMRead("images/face.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in MOG2 test")
 	}
 	defer img.Close()
@@ -26,8 +26,8 @@ func TestMOG2(t *testing.T) {
 }
 
 func TestKNN(t *testing.T) {
-	img := IMRead("images/face.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in KNN test")
 	}
 	defer img.Close()
@@ -46,8 +46,8 @@ func TestKNN(t *testing.T) {
 }
 
 func TestCalcOpticalFlowFarneback(t *testing.T) {
-	img1 := IMRead("images/face.jpg", IMReadColor)
-	if img1.Empty() {
+	img1, err := IMRead("images/face.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in CalcOpticalFlowFarneback test")
 	}
 	defer img1.Close()
@@ -76,8 +76,8 @@ func TestCalcOpticalFlowFarneback(t *testing.T) {
 }
 
 func TestCalcOpticalFlowPyrLK(t *testing.T) {
-	img1 := IMRead("images/face.jpg", IMReadColor)
-	if img1.Empty() {
+	img1, err := IMRead("images/face.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid Mat in CalcOpticalFlowPyrLK test")
 	}
 	defer img1.Close()
@@ -98,8 +98,8 @@ func TestCalcOpticalFlowPyrLK(t *testing.T) {
 	status := NewMat()
 	defer status.Close()
 
-	err := NewMat()
-	defer err.Close()
+	errMat := NewMat()
+	defer errMat.Close()
 
 	corners := NewMat()
 	defer corners.Close()
@@ -108,7 +108,7 @@ func TestCalcOpticalFlowPyrLK(t *testing.T) {
 	tc := NewTermCriteria(Count|EPS, 20, 0.03)
 	CornerSubPix(dest, &corners, image.Pt(10, 10), image.Pt(-1, -1), tc)
 
-	CalcOpticalFlowPyrLK(dest, img2, corners, nextPts, &status, &err)
+	CalcOpticalFlowPyrLK(dest, img2, corners, nextPts, &status, &errMat)
 
 	if status.Empty() {
 		t.Error("Error in CalcOpticalFlowPyrLK test")

--- a/videoio.cpp
+++ b/videoio.cpp
@@ -48,10 +48,10 @@ void VideoWriter_Close(VideoWriter vw) {
     delete vw;
 }
 
-void VideoWriter_Open(VideoWriter vw, const char* name, const char* codec, double fps, int width,
+bool VideoWriter_Open(VideoWriter vw, const char* name, const char* codec, double fps, int width,
                       int height) {
     int codecCode = cv::VideoWriter::fourcc(codec[0], codec[1], codec[2], codec[3]);
-    vw->open(name, codecCode, fps, cv::Size(width, height), true);
+    return vw->open(name, codecCode, fps, cv::Size(width, height), true);
 }
 
 int VideoWriter_IsOpened(VideoWriter vw) {

--- a/videoio.go
+++ b/videoio.go
@@ -6,6 +6,7 @@ package gocv
 */
 import "C"
 import (
+	"errors"
 	"sync"
 	"unsafe"
 )
@@ -204,8 +205,11 @@ func (v *VideoCapture) IsOpened() bool {
 
 // Read reads the next frame from the VideoCapture to the Mat passed in
 // as the param. It returns false if the VideoCapture cannot read frame.
-func (v *VideoCapture) Read(m *Mat) bool {
-	return C.VideoCapture_Read(v.p, m.p) != 0
+func (v *VideoCapture) Read(m *Mat) (err error) {
+	if C.VideoCapture_Read(v.p, m.p) == 0 {
+		err = errors.New("VideoCapture Read error")
+	}
+	return
 }
 
 // Grab skips a specific number of frames.

--- a/videoio.go
+++ b/videoio.go
@@ -246,7 +246,9 @@ func VideoWriterFile(name string, codec string, fps float64, width int, height i
 	cCodec := C.CString(codec)
 	defer C.free(unsafe.Pointer(cCodec))
 
-	C.VideoWriter_Open(vw.p, cName, cCodec, C.double(fps), C.int(width), C.int(height))
+	if !bool(C.VideoWriter_Open(vw.p, cName, cCodec, C.double(fps), C.int(width), C.int(height))) {
+		err = errors.New("VideoWriterFile Open error")
+	}
 	return
 }
 

--- a/videoio.h
+++ b/videoio.h
@@ -30,7 +30,7 @@ void VideoCapture_Grab(VideoCapture v, int skip);
 // VideoWriter
 VideoWriter VideoWriter_New();
 void VideoWriter_Close(VideoWriter vw);
-void VideoWriter_Open(VideoWriter vw, const char* name, const char* codec, double fps, int width,
+bool VideoWriter_Open(VideoWriter vw, const char* name, const char* codec, double fps, int width,
                       int height);
 int VideoWriter_IsOpened(VideoWriter vw);
 void VideoWriter_Write(VideoWriter vw, Mat img);

--- a/videoio_test.go
+++ b/videoio_test.go
@@ -38,8 +38,8 @@ func TestVideoWriterFile(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "gocvtests")
 	tmpfn := filepath.Join(dir, "test.avi")
 
-	img := IMRead("images/face-detect.jpg", IMReadColor)
-	if img.Empty() {
+	img, err := IMRead("images/face-detect.jpg", IMReadColor)
+	if err != nil {
 		t.Error("Invalid read of Mat in VideoWriterFile test")
 	}
 	defer img.Close()
@@ -51,7 +51,7 @@ func TestVideoWriterFile(t *testing.T) {
 		t.Error("Unable to open VideoWriterFile")
 	}
 
-	err := vw.Write(img)
+	err = vw.Write(img)
 	if err != nil {
 		t.Error("Invalid Write() in VideoWriter")
 	}


### PR DESCRIPTION
As suggested by @maruel in #137 always return Go `Error` for all Read or Write operations instead of just `Bool`. This is the second breaking API change on the road to the 1.x API.

Here is an example of it in use:

```go
if err := webcam.Read(&img); err != nil {
    fmt.Printf("cannot read device %d\n", deviceID)
    return
}
```
