### PR TITLE
Add Ellipse() and FillPoly() functions

### DIFF
--- a/cmd/basic-drawing/main.go
+++ b/cmd/basic-drawing/main.go
@@ -1,0 +1,88 @@
+// What it does:
+//
+// This example draws two examples, an atom and a rook, based on:
+// https://docs.opencv.org/2.4/doc/tutorials/core/basic_geometric_drawing/basic_geometric_drawing.html.
+//
+// How to run:
+//
+// 		go run ./cmd/basic-drawing/main.go
+//
+// +build example
+
+package main
+
+import (
+	"image"
+	"image/color"
+
+	"gocv.io/x/gocv"
+)
+
+var w = 400
+
+func main() {
+	windowA := gocv.NewWindow("basic drawing: atom")
+	windowR := gocv.NewWindow("basic drawing: rook")
+	defer windowA.Close()
+	defer windowR.Close()
+
+	atom := gocv.NewMatWithSize(w, w, gocv.MatTypeCV8UC3)
+	defer atom.Close()
+
+	rook := gocv.NewMatWithSize(w, w, gocv.MatTypeCV8UC3)
+	defer rook.Close()
+
+	black := color.RGBA{0, 0, 0, 0}
+	blue := color.RGBA{0, 0, 255, 0}
+	red := color.RGBA{255, 0, 0, 0}
+	white := color.RGBA{255, 255, 255, 0}
+	yellow := color.RGBA{255, 255, 0, 0}
+
+	// draw the atom
+	gocv.Ellipse(&atom, image.Pt(w/2., w/2.), image.Pt(w/4.0, w/16.0), 90., 0, 360, blue, 2)
+	gocv.Ellipse(&atom, image.Pt(w/2., w/2.), image.Pt(w/4.0, w/16.0), 0., 0, 360, blue, 2)
+	gocv.Ellipse(&atom, image.Pt(w/2., w/2.), image.Pt(w/4.0, w/16.0), 45., 0, 360, blue, 2)
+	gocv.Ellipse(&atom, image.Pt(w/2., w/2.), image.Pt(w/4.0, w/16.0), -45., 0, 360, blue, 2)
+	gocv.Circle(&atom, image.Pt(w/2., w/2.), w/32., red, -1)
+
+	// draw the rook
+	points := [][]image.Point{
+		{
+			image.Pt(w/4., 7*w/8.),
+			image.Pt(3*w/4., 7*w/8.),
+			image.Pt(3*w/4., 13*w/16.),
+			image.Pt(11*w/16., 13*w/16.),
+			image.Pt(19*w/32., 3*w/8.),
+			image.Pt(3*w/4., 3*w/8.),
+			image.Pt(3*w/4., w/8.),
+			image.Pt(26*w/40., w/8.),
+			image.Pt(26*w/40., w/4.),
+			image.Pt(22*w/40., w/4.),
+			image.Pt(22*w/40., w/8.),
+			image.Pt(18*w/40., w/8.),
+			image.Pt(18*w/40., w/4.),
+			image.Pt(14*w/40., w/4.),
+			image.Pt(14*w/40., w/8.),
+			image.Pt(w/4., w/8.),
+			image.Pt(w/4., 3*w/8.),
+			image.Pt(13*w/32., 3*w/8.),
+			image.Pt(5*w/16., 13*w/16.),
+			image.Pt(w/4., 13*w/16.),
+		},
+	}
+	gocv.FillPoly(&rook, points, white)
+	gocv.Rectangle(&rook, image.Rect(0, 7*w/8.0, w, w), yellow, -1)
+	gocv.Line(&rook, image.Pt(0, 15*w/16), image.Pt(w, 15*w/16), black, 2)
+	gocv.Line(&rook, image.Pt(w/4, 7*w/8), image.Pt(w/4, w), black, 2)
+	gocv.Line(&rook, image.Pt(w/2, 7*w/8), image.Pt(w/2, w), black, 2)
+	gocv.Line(&rook, image.Pt(3*w/4, 7*w/8), image.Pt(3*w/4, w), black, 2)
+
+	for {
+		windowA.IMShow(atom)
+		windowR.IMShow(rook)
+
+		if windowA.WaitKey(10) >= 0 || windowR.WaitKey(10) >= 0 {
+			break
+		}
+	}
+}

--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -220,6 +220,15 @@ void Circle(Mat img, Point center, int radius, Scalar color, int thickness) {
     cv::circle(*img, p1, radius, c, thickness);
 }
 
+void Ellipse(Mat img, Point center, Point axes, double angle, double
+             startAngle, double endAngle, Scalar color, int thickness) {
+    cv::Point p1(center.x, center.y);
+    cv::Point p2(axes.x, axes.y);
+    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+
+    cv::ellipse(*img, p1, p2, angle, startAngle, endAngle, c, thickness);
+}
+
 void Line(Mat img, Point pt1, Point pt2, Scalar color, int thickness) {
     cv::Point p1(pt1.x, pt1.y);
     cv::Point p2(pt2.x, pt2.y);
@@ -230,8 +239,34 @@ void Line(Mat img, Point pt1, Point pt2, Scalar color, int thickness) {
 
 void Rectangle(Mat img, Rect r, Scalar color, int thickness) {
     cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
-    cv::rectangle(*img, cv::Point(r.x, r.y), cv::Point(r.x + r.width, r.y + r.height),
-                  c, thickness, CV_AA);
+    cv::rectangle(
+        *img,
+        cv::Point(r.x, r.y),
+        cv::Point(r.x + r.width, r.y + r.height),
+        c,
+        thickness,
+        CV_AA
+    );
+}
+
+void FillPoly(Mat img, Contours points, Scalar color) {
+    std::vector<std::vector<cv::Point> > pts;
+
+    for (size_t i = 0; i < points.length; i++) {
+        Contour contour = points.contours[i];
+
+        std::vector<cv::Point> cntr;
+
+        for (size_t i = 0; i < contour.length; i++) {
+            cntr.push_back(cv::Point(contour.points[i].x, contour.points[i].y));
+        }
+
+        pts.push_back(cntr);
+    }
+
+    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+
+    cv::fillPoly(*img, pts, c);
 }
 
 struct Size GetTextSize(const char* text, int fontFace, double fontScale, int thickness) {

--- a/imgproc.h
+++ b/imgproc.h
@@ -48,8 +48,11 @@ void AdaptiveThreshold(Mat src, Mat dst, double maxValue, int adaptiveTyp, int t
 
 void ArrowedLine(Mat img, Point pt1, Point pt2, Scalar color, int thickness);
 void Circle(Mat img, Point center, int radius, Scalar color, int thickness);
+void Ellipse(Mat img, Point center, Point axes, double angle, double
+             startAngle, double endAngle, Scalar color, int thickness);
 void Line(Mat img, Point pt1, Point pt2, Scalar color, int thickness);
 void Rectangle(Mat img, Rect rect, Scalar color, int thickness);
+void FillPoly(Mat img, Contours points, Scalar color);
 struct Size GetTextSize(const char* text, int fontFace, double fontScale, int thickness);
 void PutText(Mat img, const char* text, Point org, int fontFace, double fontScale,
              Scalar color, int thickness);

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -833,3 +833,35 @@ func TestDrawContours(t *testing.T) {
 		t.Errorf("TestDrawContours(): contour has not been drawn (value = %v, want = %v)", v, 255)
 	}
 }
+
+func TestEllipse(t *testing.T) {
+	img := NewMatWithSize(100, 100, MatTypeCV8UC1)
+	defer img.Close()
+
+	white := color.RGBA{255, 255, 255, 0}
+	Ellipse(&img, image.Pt(50., 50.), image.Pt(25., 25.), 0., 0, 360, white, 2)
+
+	if v := img.GetUCharAt(24, 50); v != 255 {
+		t.Errorf("TestEllipse(): wrong pixel value = %v, want = %v", v, 255)
+	}
+}
+
+func TestFillPoly(t *testing.T) {
+	img := NewMatWithSize(100, 100, MatTypeCV8UC1)
+	defer img.Close()
+
+	white := color.RGBA{255, 255, 255, 0}
+	pts := [][]image.Point{
+		{
+			image.Pt(10, 10),
+			image.Pt(10, 20),
+			image.Pt(20, 20),
+			image.Pt(20, 10),
+		},
+	}
+	FillPoly(&img, pts, white)
+
+	if v := img.GetUCharAt(10, 10); v != 255 {
+		t.Errorf("TestFillPoly(): wrong pixel value = %v, want = %v", v, 255)
+	}
+}


### PR DESCRIPTION
I wanted to reproduce [this tutorial](https://docs.opencv.org/2.4/doc/tutorials/core/basic_geometric_drawing/basic_geometric_drawing.html#drawing-1). Here are the screenshots for the two images created in the newly added example:

<img width="512" alt="screen shot 2018-03-23 at 20 56 54" src="https://user-images.githubusercontent.com/217628/37852111-a538122a-2ee1-11e8-806e-f48f5af51595.png">
<img width="512" alt="screen shot 2018-03-23 at 20 56 53" src="https://user-images.githubusercontent.com/217628/37852112-a59fb59c-2ee1-11e8-961b-2c8a6073e768.png">
