### PR TITLE
Fix example command.

### DIFF
--- a/cmd/ssd-facedetect/main.go
+++ b/cmd/ssd-facedetect/main.go
@@ -11,7 +11,7 @@
 //
 // How to run:
 //
-// 		go run ./cmd/dnn-ssd/main.go 0 [protofile] [modelfile]
+// 		go run ./cmd/ssd-facedetect/main.go 0 [protofile] [modelfile]
 //
 // +build example
 


### PR DESCRIPTION
Path within example command referred to a previous directory location. Update for current location.