### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ OPENCV_VERSION?=3.4.1
 TMP_DIR?=/tmp/
 
 # Package list for each well-known Linux distribution
-RPMS=make cmake git gtk2-devel pkg-config libpng-devel libjpeg-devel libtiff-devel tbb tbb-devel libdc1394-devel jasper-libs jasper-devel
-DEBS=unzip build-essential cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libjasper-dev libdc1394-22-dev
+RPMS=cmake git gtk2-devel pkg-config libpng-devel libjpeg-devel libtiff-devel tbb tbb-devel libdc1394-devel
+DEBS=unzip build-essential cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libdc1394-22-dev
 
 # Detect Linux distribution
 distro_deps=
@@ -25,10 +25,7 @@ endif
 endif
 endif
 
-test:
-	source ./env.sh
-	go test . ./contrib
-
+# Install all necessary dependencies.
 deps: $(distro_deps)
 
 deps_rh_centos:
@@ -58,9 +55,9 @@ build:
 	cd $(TMP_DIR)opencv/opencv-$(OPENCV_VERSION)
 	mkdir build
 	cd build
-	cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -D OPENCV_EXTRA_MODULES_PATH=$(TMP_DIR)opencv/opencv_contrib-$(OPENCV_VERSION)/modules -D BUILD_DOCS=OFF BUILD_EXAMPLES=OFF -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF -D BUILD_opencv_java=OFF -D BUILD_opencv_python=OFF -D BUILD_opencv_python2=OFF -D BUILD_opencv_python3=OFF ..
-	make -j
-	make preinstall
+	cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -D OPENCV_EXTRA_MODULES_PATH=$(TMP_DIR)opencv/opencv_contrib-$(OPENCV_VERSION)/modules -D BUILD_DOCS=OFF BUILD_EXAMPLES=OFF -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF -D BUILD_opencv_java=OFF -D BUILD_opencv_python=OFF -D BUILD_opencv_python2=OFF -D BUILD_opencv_python3=OFF WITH_JASPER=OFF ..
+	$(MAKE) -j
+	$(MAKE) preinstall
 	cd -
 
 # Cleanup temporary build files.
@@ -68,14 +65,25 @@ clean:
 	rm -rf $(TMP_DIR)opencv
 
 # Do everything.
-install: deps download build sudo_install clean
+install: deps download build sudo_install clean verify
 
 # Install system wide.
 sudo_install:
 	cd $(TMP_DIR)opencv/opencv-$(OPENCV_VERSION)/build
-	sudo make install
+	sudo $(MAKE) install
 	sudo ldconfig
 	cd -
+
+# Build a minimal Go app to confirm gocv works.
+verify:
+	/bin/bash -c "source ./env.sh && go run ./cmd/version/main.go"
+
+# Runs tests.
+# This assumes env.sh was already sourced.
+# pvt is not tested here since it requires additional depenedences.
+test:
+	go test . ./contrib
+
 
 astyle:
 	astyle --project=.astylerc --recursive *.cpp,*.h


### PR DESCRIPTION
- The distro detection didn't work on Ubuntu, it defaulted to Fedora.
- Change it to not be recursive and just be a normal make dependency instead.
- Do not lock make paralelism to 4, some systems may have a LOT of CPUs. :)
- Make the opencv version a variable, so it can be updated easily and overridden
  at the command line.
- Make the temporary directory configurable.
- Move the sudo commands into sudo_install.
- Run make preinstall explicitly first so sudo make install doesn't create root
  owned file in the temporary directory, which made the directory undeletable as
  a user.
- Change test to run tests for ./contrib too

Additional notes:
- Installing pvl is not done here, as this change is already large enough.
- TestVideoCaptureFile fails on systems without a web cam; it still exists :)
  That would require a concept of smoke tests but that's out of scope here.
- The instructions could now read:
    make install
- The defaults can now easily be updated. For example, one can download, build
  and install OpenCV 3.4 (instead of 3.4.1) using the current directory as the
  temporary directory with:
    OPENCV_VERSION=3.4 TMP_DIR= make install