### PR TITLE
Feature: CodecString()

### DIFF
--- a/videoio.go
+++ b/videoio.go
@@ -214,6 +214,16 @@ func (v *VideoCapture) Grab(skip int) {
 	C.VideoCapture_Grab(v.p, C.int(skip))
 }
 
+// CodecString returns a string representation of FourCC bytes, i.e. the name of a codec
+func (v *VideoCapture) CodecString() string {
+	res := ""
+	hexes := []int64{0xff, 0xff00, 0xff0000, 0xff000000}
+	for i, h := range hexes {
+		res += string(int64(v.Get(VideoCaptureFOURCC)) & h >> (uint(i * 8)))
+	}
+	return res
+}
+
 // VideoWriter is a wrapper around the OpenCV VideoWriter`class.
 //
 // For further details, please see:

--- a/videoio_test.go
+++ b/videoio_test.go
@@ -19,6 +19,16 @@ func TestVideoCaptureEmptyNumericalParameters(t *testing.T) {
 	}
 }
 
+func TestVideoCaptureCodecString(t *testing.T) {
+	vc, err := VideoCaptureFile("images/small.mp4")
+	if err != nil {
+		t.Errorf("TestVideoCaptureCodecString: error loading a file: %v", err)
+	}
+	if vc.CodecString() == "" {
+		t.Fatal("TestVideoCaptureCodecString: empty codec string")
+	}
+}
+
 func TestVideoCaptureFile(t *testing.T) {
 	vc, _ := VideoCaptureFile("images/small.mp4")
 	defer vc.Close()


### PR DESCRIPTION
New API: CodecString() returns a string representation of FourCC bytes from OpenCV video options.

Closes: #192