### PR TITLE
Add ReadNetFromTensorflowWithConfig() method.

### DIFF
--- a/dnn.cpp
+++ b/dnn.cpp
@@ -10,6 +10,11 @@ Net Net_ReadNetFromTensorflow(const char* model) {
     return n;
 }
 
+Net Net_ReadNetFromTensorflowWithConfig(const char* model, const char* config) {
+	Net n = new cv::dnn::Net(cv::dnn::readNetFromTensorflow(model, config));
+	return n;
+}
+
 void Net_Close(Net net) {
     delete net;
 }

--- a/dnn.go
+++ b/dnn.go
@@ -85,6 +85,16 @@ func ReadNetFromTensorflow(model string) Net {
 	return Net{p: unsafe.Pointer(C.Net_ReadNetFromTensorflow(cmodel))}
 }
 
+// ReadNetFromTensorflowWithConfig reads a network model and config stored in Tensorflow framework's format.
+func ReadNetFromTensorflowWithConfig(model string, config string) Net {
+	cmodel := C.CString(model)
+	defer C.free(unsafe.Pointer(cmodel))
+	
+	cconfig := C.CString(config)
+	defer C.free(unsafe.Pointer(cconfig))
+	return Net{p: unsafe.Pointer(C.Net_ReadNetFromTensorflowWithConfig(cmodel, cconfig))}
+}
+
 // BlobFromImage creates 4-dimensional blob from image. Optionally resizes and crops
 // image from center, subtract mean values, scales values by scalefactor,
 // swap Blue and Red channels.

--- a/dnn.go
+++ b/dnn.go
@@ -89,7 +89,7 @@ func ReadNetFromTensorflow(model string) Net {
 func ReadNetFromTensorflowWithConfig(model string, config string) Net {
 	cmodel := C.CString(model)
 	defer C.free(unsafe.Pointer(cmodel))
-	
+
 	cconfig := C.CString(config)
 	defer C.free(unsafe.Pointer(cconfig))
 	return Net{p: unsafe.Pointer(C.Net_ReadNetFromTensorflowWithConfig(cmodel, cconfig))}

--- a/dnn.h
+++ b/dnn.h
@@ -19,6 +19,7 @@ typedef void* Net;
 
 Net Net_ReadNetFromCaffe(const char* prototxt, const char* caffeModel);
 Net Net_ReadNetFromTensorflow(const char* model);
+Net Net_ReadNetFromTensorflowWithConfig(const char* model, const char* config);
 Mat Net_BlobFromImage(Mat image, double scalefactor, Size size, Scalar mean, bool swapRB,
                       bool crop);
 void Net_Close(Net net);


### PR DESCRIPTION
Add ReadNetFromTensorflowWithConfig() method which allows passing a prototxt aside with the protobuf.
#195 