### PR TITLE
Added opencv::calcHist implementation

### DIFF
--- a/core.h
+++ b/core.h
@@ -20,6 +20,12 @@ typedef struct IntVector {
     int length;
 } IntVector;
 
+// Wrapper for std::vector<float>
+typedef struct FloatVector {
+    float* val;
+    int length;
+} FloatVector;
+
 #ifdef __cplusplus
 #include <opencv2/opencv.hpp>
 extern "C" {

--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -38,6 +38,36 @@ void EqualizeHist(Mat src, Mat dst) {
     cv::equalizeHist(*src, *dst);
 }
 
+void CalcHist(struct Mats mats, IntVector chans, Mat mask, Mat hist, IntVector sz, FloatVector rng, bool acc) {
+        std::vector<cv::Mat> images;
+
+        for (int i = 0; i < mats.length; ++i) {
+            images.push_back(*mats.mats[i]);
+        }
+
+        std::vector<int> channels;
+
+        for (int i = 0, *v = chans.val; i < chans.length; ++v, ++i) {
+            channels.push_back(*v);
+        }
+
+        std::vector<int> histSize;
+
+        for (int i = 0, *v = sz.val; i < sz.length; ++v, ++i) {
+            histSize.push_back(*v);
+        }
+
+        std::vector<float> ranges;
+
+        float* f;
+        int i;
+        for (i = 0, f = rng.val; i < rng.length; ++f, ++i) {
+            ranges.push_back(*f);
+        }
+
+        cv::calcHist(images, channels, *mask, *hist, histSize, ranges, acc);
+}
+
 void ConvexHull(Contour points, Mat hull, bool clockwise, bool returnPoints) {
     std::vector<cv::Point> pts;
 

--- a/imgproc.go
+++ b/imgproc.go
@@ -89,48 +89,6 @@ func EqualizeHist(src Mat, dst *Mat) {
 	C.EqualizeHist(src.p, dst.p)
 }
 
-// CalcHist Calculates a histogram of a set of images applying a mask
-//
-// For futher details, please see:
-// https://docs.opencv.org/master/d6/dc7/group__imgproc__hist.html#ga6ca1876785483836f72a77ced8ea759a
-func CalcHistWithMask(src []Mat, channels []int, mask Mat, hist *Mat, size []int, ranges []float64, acc bool) {
-	cMatArray := make([]C.Mat, len(src))
-	for i, r := range src {
-		cMatArray[i] = r.p
-	}
-
-	cMats := C.struct_Mats{
-		mats:   (*C.Mat)(&cMatArray[0]),
-		length: C.int(len(src)),
-	}
-
-	chansInts := []C.int{}
-	for _, v := range channels {
-		chansInts = append(chansInts, C.int(v))
-	}
-	chansVector := C.struct_IntVector{}
-	chansVector.val = (*C.int)(&chansInts[0])
-	chansVector.length = (C.int)(len(chansInts))
-
-	sizeInts := []C.int{}
-	for _, v := range size {
-		sizeInts = append(sizeInts, C.int(v))
-	}
-	sizeVector := C.struct_IntVector{}
-	sizeVector.val = (*C.int)(&sizeInts[0])
-	sizeVector.length = (C.int)(len(sizeInts))
-
-	rangeFloats := []C.float{}
-	for _, v := range ranges {
-		rangeFloats = append(rangeFloats, C.float(v))
-	}
-	rangeVector := C.struct_FloatVector{}
-	rangeVector.val = (*C.float)(&rangeFloats[0])
-	rangeVector.length = (C.int)(len(rangeFloats))
-
-	C.CalcHist(cMats, chansVector, mask.p, hist.p, sizeVector, rangeVector, C.bool(acc))
-}
-
 // CalcHist Calculates a histogram of a set of images
 //
 // For futher details, please see:

--- a/imgproc.go
+++ b/imgproc.go
@@ -89,6 +89,90 @@ func EqualizeHist(src Mat, dst *Mat) {
 	C.EqualizeHist(src.p, dst.p)
 }
 
+// CalcHist Calculates a histogram of a set of images applying a mask
+//
+// For futher details, please see:
+// https://docs.opencv.org/master/d6/dc7/group__imgproc__hist.html#ga6ca1876785483836f72a77ced8ea759a
+func CalcHistWithMask(src []Mat, channels []int, mask Mat, hist *Mat, size []int, ranges []float64, acc bool) {
+	cMatArray := make([]C.Mat, len(src))
+	for i, r := range src {
+		cMatArray[i] = r.p
+	}
+
+	cMats := C.struct_Mats{
+		mats:   (*C.Mat)(&cMatArray[0]),
+		length: C.int(len(src)),
+	}
+
+	chansInts := []C.int{}
+	for _, v := range channels {
+		chansInts = append(chansInts, C.int(v))
+	}
+	chansVector := C.struct_IntVector{}
+	chansVector.val = (*C.int)(&chansInts[0])
+	chansVector.length = (C.int)(len(chansInts))
+
+	sizeInts := []C.int{}
+	for _, v := range size {
+		sizeInts = append(sizeInts, C.int(v))
+	}
+	sizeVector := C.struct_IntVector{}
+	sizeVector.val = (*C.int)(&sizeInts[0])
+	sizeVector.length = (C.int)(len(sizeInts))
+
+	rangeFloats := []C.float{}
+	for _, v := range ranges {
+		rangeFloats = append(rangeFloats, C.float(v))
+	}
+	rangeVector := C.struct_FloatVector{}
+	rangeVector.val = (*C.float)(&rangeFloats[0])
+	rangeVector.length = (C.int)(len(rangeFloats))
+
+	C.CalcHist(cMats, chansVector, mask.p, hist.p, sizeVector, rangeVector, C.bool(acc))
+}
+
+// CalcHist Calculates a histogram of a set of images
+//
+// For futher details, please see:
+// https://docs.opencv.org/master/d6/dc7/group__imgproc__hist.html#ga6ca1876785483836f72a77ced8ea759a
+func CalcHist(src []Mat, channels []int, mask Mat, hist *Mat, size []int, ranges []float64, acc bool) {
+	cMatArray := make([]C.Mat, len(src))
+	for i, r := range src {
+		cMatArray[i] = r.p
+	}
+
+	cMats := C.struct_Mats{
+		mats:   (*C.Mat)(&cMatArray[0]),
+		length: C.int(len(src)),
+	}
+
+	chansInts := []C.int{}
+	for _, v := range channels {
+		chansInts = append(chansInts, C.int(v))
+	}
+	chansVector := C.struct_IntVector{}
+	chansVector.val = (*C.int)(&chansInts[0])
+	chansVector.length = (C.int)(len(chansInts))
+
+	sizeInts := []C.int{}
+	for _, v := range size {
+		sizeInts = append(sizeInts, C.int(v))
+	}
+	sizeVector := C.struct_IntVector{}
+	sizeVector.val = (*C.int)(&sizeInts[0])
+	sizeVector.length = (C.int)(len(sizeInts))
+
+	rangeFloats := []C.float{}
+	for _, v := range ranges {
+		rangeFloats = append(rangeFloats, C.float(v))
+	}
+	rangeVector := C.struct_FloatVector{}
+	rangeVector.val = (*C.float)(&rangeFloats[0])
+	rangeVector.length = (C.int)(len(rangeFloats))
+
+	C.CalcHist(cMats, chansVector, mask.p, hist.p, sizeVector, rangeVector, C.bool(acc))
+}
+
 // BilateralFilter applies a bilateral filter to an image.
 //
 // Bilateral filtering is described here:

--- a/imgproc.h
+++ b/imgproc.h
@@ -14,6 +14,7 @@ double ArcLength(Contour curve, bool is_closed);
 Contour ApproxPolyDP(Contour curve, double epsilon, bool closed);
 void CvtColor(Mat src, Mat dst, int code);
 void EqualizeHist(Mat src, Mat dst);
+void CalcHist(struct Mats mats, IntVector chans, Mat mask, Mat hist, IntVector sz, FloatVector rng, bool acc);
 void ConvexHull(Contour points, Mat hull, bool clockwise, bool returnPoints);
 void ConvexityDefects(Contour points, Mat hull, Mat result);
 void BilateralFilter(Mat src, Mat dst, int d, double sc, double ss);

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -630,6 +630,28 @@ func TestEqualizeHist(t *testing.T) {
 	}
 }
 
+func TestCalcHist(t *testing.T) {
+	img := IMRead("images/face-detect.jpg", IMReadGrayScale)
+	if img.Empty() {
+		t.Error("Invalid read of Mat in EqualizeHist test")
+	}
+	defer img.Close()
+
+	gray := NewMat()
+	CvtColor(img, &gray, ColorBGRToGray)
+
+	hist := NewMat()
+	defer hist.Close()
+
+	mask := NewMat()
+	defer mask.Close()
+
+	CalcHist([]Mat{gray}, []int{0}, mask, &hist, []int{256}, []float64{0.0, 256.0}, false)
+	if hist.Empty() || hist.Rows() != 256 || img.Cols() != 1 {
+		t.Error("Invalid CalcHist test")
+	}
+}
+
 func TestDrawing(t *testing.T) {
 	img := NewMatWithSize(150, 150, MatTypeCV8U)
 	if img.Empty() {

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -637,17 +637,14 @@ func TestCalcHist(t *testing.T) {
 	}
 	defer img.Close()
 
-	gray := NewMat()
-	CvtColor(img, &gray, ColorBGRToGray)
-
 	hist := NewMat()
 	defer hist.Close()
 
 	mask := NewMat()
 	defer mask.Close()
 
-	CalcHist([]Mat{gray}, []int{0}, mask, &hist, []int{256}, []float64{0.0, 256.0}, false)
-	if hist.Empty() || hist.Rows() != 256 || img.Cols() != 1 {
+	CalcHist([]Mat{img}, []int{0}, mask, &hist, []int{256}, []float64{0.0, 256.0}, false)
+	if hist.Empty() || hist.Rows() != 256 || hist.Cols() != 1 {
 		t.Error("Invalid CalcHist test")
 	}
 }


### PR DESCRIPTION
This adds `CalcHist` function which brings in support for [calcHist](https://docs.opencv.org/3.4.1/d6/dc7/group__imgproc__hist.html#ga6ca1876785483836f72a77ced8ea759a) opencv function to gocv.

I need to add test to it -- I've verified the implementation on some basic examples in one of my personal projects, but I need to come up with a few simple test cases for `gocv`.