### PR TITLE
Add Mat.DataPtr methods for direct access to OpenCV data

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -66,6 +66,10 @@ struct ByteArray Mat_ToBytes(Mat m) {
     return toByteArray(reinterpret_cast<const char*>(m->data), m->total() * m->elemSize());
 }
 
+struct DataPtr Mat_DataPtr(Mat m) {
+    return DataPtr {reinterpret_cast<const char*>(m->data), m->total() * m->elemSize()};
+}
+
 // Mat_Region returns a Mat of a region of another Mat
 Mat Mat_Region(Mat m, Rect r) {
     return new cv::Mat(*m, cv::Rect(r.x, r.y, r.width, r.height));

--- a/core.cpp
+++ b/core.cpp
@@ -66,8 +66,8 @@ struct ByteArray Mat_ToBytes(Mat m) {
     return toByteArray(reinterpret_cast<const char*>(m->data), m->total() * m->elemSize());
 }
 
-struct DataPtr Mat_DataPtr(Mat m) {
-    return DataPtr {reinterpret_cast<const char*>(m->data), m->total() * m->elemSize()};
+struct ByteArray Mat_DataPtr(Mat m) {
+    return ByteArray {reinterpret_cast<char*>(m->data), static_cast<int>(m->total() * m->elemSize())};
 }
 
 // Mat_Region returns a Mat of a region of another Mat

--- a/core.go
+++ b/core.go
@@ -246,6 +246,112 @@ func (m *Mat) ToBytes() []byte {
 	return toGoBytes(b)
 }
 
+// DataPtrUint8 returns a slice that references the OpenCV allocated data.
+//
+// The data is no longer valid once the Mat has been closed. Any data that
+// needs to be accessed after the Mat is closed must be copied into Go memory.
+func (m *Mat) DataPtrUint8() []uint8 {
+	b := C.Mat_ToBytes(m.p)
+	h := &reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(b.data)),
+		Len:  int(b.length),
+		Cap:  int(b.length),
+	}
+	C.ByteArray_Release(b)
+	return *(*[]uint8)(unsafe.Pointer(h))
+}
+
+// DataPtrInt8 returns a slice that references the OpenCV allocated data.
+//
+// The data is no longer valid once the Mat has been closed. Any data that
+// needs to be accessed after the Mat is closed must be copied into Go memory.
+func (m *Mat) DataPtrInt8() []int8 {
+	b := C.Mat_ToBytes(m.p)
+	h := &reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(b.data)),
+		Len:  int(b.length),
+		Cap:  int(b.length),
+	}
+	C.ByteArray_Release(b)
+	return *(*[]int8)(unsafe.Pointer(h))
+}
+
+// DataPtrUint16 returns a slice that references the OpenCV allocated data.
+//
+// The data is no longer valid once the Mat has been closed. Any data that
+// needs to be accessed after the Mat is closed must be copied into Go memory.
+func (m *Mat) DataPtrUint16() ([]uint16, error) {
+	if m.Type()&MatTypeCV16U != MatTypeCV16U {
+		return nil, errors.New("DataPtrUint16 only supports MatTypeCV16U")
+	}
+
+	b := C.Mat_ToBytes(m.p)
+	h := &reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(b.data)),
+		Len:  int(b.length) / 2,
+		Cap:  int(b.length) / 2,
+	}
+	C.ByteArray_Release(b)
+	return *(*[]uint16)(unsafe.Pointer(h)), nil
+}
+
+// DataPtrInt16 returns a slice that references the OpenCV allocated data.
+//
+// The data is no longer valid once the Mat has been closed. Any data that
+// needs to be accessed after the Mat is closed must be copied into Go memory.
+func (m *Mat) DataPtrInt16() ([]int16, error) {
+	if m.Type()&MatTypeCV16S != MatTypeCV16S {
+		return nil, errors.New("DataPtrInt16 only supports MatTypeCV16S")
+	}
+
+	b := C.Mat_ToBytes(m.p)
+	h := &reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(b.data)),
+		Len:  int(b.length) / 2,
+		Cap:  int(b.length) / 2,
+	}
+	C.ByteArray_Release(b)
+	return *(*[]int16)(unsafe.Pointer(h)), nil
+}
+
+// DataPtrFloat32 returns a slice that references the OpenCV allocated data.
+//
+// The data is no longer valid once the Mat has been closed. Any data that
+// needs to be accessed after the Mat is closed must be copied into Go memory.
+func (m *Mat) DataPtrFloat32() ([]float32, error) {
+	if m.Type()&MatTypeCV32F != MatTypeCV32F {
+		return nil, errors.New("DataPtrUint16 only supports MatTypeCV32F")
+	}
+
+	b := C.Mat_ToBytes(m.p)
+	h := &reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(b.data)),
+		Len:  int(b.length) / 4,
+		Cap:  int(b.length) / 4,
+	}
+	C.ByteArray_Release(b)
+	return *(*[]float32)(unsafe.Pointer(h)), nil
+}
+
+// DataPtrFloat64 returns a slice that references the OpenCV allocated data.
+//
+// The data is no longer valid once the Mat has been closed. Any data that
+// needs to be accessed after the Mat is closed must be copied into Go memory.
+func (m *Mat) DataPtrFloat64() ([]float64, error) {
+	if m.Type()&MatTypeCV64F != MatTypeCV64F {
+		return nil, errors.New("DataPtrUint16 only supports MatTypeCV64F")
+	}
+
+	b := C.Mat_ToBytes(m.p)
+	h := &reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(b.data)),
+		Len:  int(b.length) / 8,
+		Cap:  int(b.length) / 8,
+	}
+	C.ByteArray_Release(b)
+	return *(*[]float64)(unsafe.Pointer(h)), nil
+}
+
 // Region returns a new Mat that points to a region of this Mat. Changes made to the
 // region Mat will affect the original Mat, since they are pointers to the underlying
 // OpenCV Mat object.

--- a/core.go
+++ b/core.go
@@ -241,8 +241,7 @@ func (m *Mat) Size() (dims []int) {
 // For further details, please see:
 // https://docs.opencv.org/3.3.1/d3/d63/classcv_1_1Mat.html#a4d33bed1c850265370d2af0ff02e1564
 func (m *Mat) ToBytes() []byte {
-	b := C.Mat_ToBytes(m.p)
-	defer C.ByteArray_Release(b)
+	b := C.Mat_DataPtr(m.p)
 	return toGoBytes(b)
 }
 

--- a/core.go
+++ b/core.go
@@ -251,13 +251,12 @@ func (m *Mat) ToBytes() []byte {
 // The data is no longer valid once the Mat has been closed. Any data that
 // needs to be accessed after the Mat is closed must be copied into Go memory.
 func (m *Mat) DataPtrUint8() []uint8 {
-	b := C.Mat_ToBytes(m.p)
+	p := C.Mat_DataPtr(m.p)
 	h := &reflect.SliceHeader{
-		Data: uintptr(unsafe.Pointer(b.data)),
-		Len:  int(b.length),
-		Cap:  int(b.length),
+		Data: uintptr(unsafe.Pointer(p.data)),
+		Len:  int(p.length),
+		Cap:  int(p.length),
 	}
-	C.ByteArray_Release(b)
 	return *(*[]uint8)(unsafe.Pointer(h))
 }
 
@@ -266,13 +265,12 @@ func (m *Mat) DataPtrUint8() []uint8 {
 // The data is no longer valid once the Mat has been closed. Any data that
 // needs to be accessed after the Mat is closed must be copied into Go memory.
 func (m *Mat) DataPtrInt8() []int8 {
-	b := C.Mat_ToBytes(m.p)
+	p := C.Mat_DataPtr(m.p)
 	h := &reflect.SliceHeader{
-		Data: uintptr(unsafe.Pointer(b.data)),
-		Len:  int(b.length),
-		Cap:  int(b.length),
+		Data: uintptr(unsafe.Pointer(p.data)),
+		Len:  int(p.length),
+		Cap:  int(p.length),
 	}
-	C.ByteArray_Release(b)
 	return *(*[]int8)(unsafe.Pointer(h))
 }
 
@@ -285,13 +283,12 @@ func (m *Mat) DataPtrUint16() ([]uint16, error) {
 		return nil, errors.New("DataPtrUint16 only supports MatTypeCV16U")
 	}
 
-	b := C.Mat_ToBytes(m.p)
+	p := C.Mat_DataPtr(m.p)
 	h := &reflect.SliceHeader{
-		Data: uintptr(unsafe.Pointer(b.data)),
-		Len:  int(b.length) / 2,
-		Cap:  int(b.length) / 2,
+		Data: uintptr(unsafe.Pointer(p.data)),
+		Len:  int(p.length) / 2,
+		Cap:  int(p.length) / 2,
 	}
-	C.ByteArray_Release(b)
 	return *(*[]uint16)(unsafe.Pointer(h)), nil
 }
 
@@ -304,13 +301,12 @@ func (m *Mat) DataPtrInt16() ([]int16, error) {
 		return nil, errors.New("DataPtrInt16 only supports MatTypeCV16S")
 	}
 
-	b := C.Mat_ToBytes(m.p)
+	p := C.Mat_DataPtr(m.p)
 	h := &reflect.SliceHeader{
-		Data: uintptr(unsafe.Pointer(b.data)),
-		Len:  int(b.length) / 2,
-		Cap:  int(b.length) / 2,
+		Data: uintptr(unsafe.Pointer(p.data)),
+		Len:  int(p.length) / 2,
+		Cap:  int(p.length) / 2,
 	}
-	C.ByteArray_Release(b)
 	return *(*[]int16)(unsafe.Pointer(h)), nil
 }
 
@@ -323,13 +319,12 @@ func (m *Mat) DataPtrFloat32() ([]float32, error) {
 		return nil, errors.New("DataPtrUint16 only supports MatTypeCV32F")
 	}
 
-	b := C.Mat_ToBytes(m.p)
+	p := C.Mat_DataPtr(m.p)
 	h := &reflect.SliceHeader{
-		Data: uintptr(unsafe.Pointer(b.data)),
-		Len:  int(b.length) / 4,
-		Cap:  int(b.length) / 4,
+		Data: uintptr(unsafe.Pointer(p.data)),
+		Len:  int(p.length) / 4,
+		Cap:  int(p.length) / 4,
 	}
-	C.ByteArray_Release(b)
 	return *(*[]float32)(unsafe.Pointer(h)), nil
 }
 
@@ -342,13 +337,12 @@ func (m *Mat) DataPtrFloat64() ([]float64, error) {
 		return nil, errors.New("DataPtrUint16 only supports MatTypeCV64F")
 	}
 
-	b := C.Mat_ToBytes(m.p)
+	p := C.Mat_DataPtr(m.p)
 	h := &reflect.SliceHeader{
-		Data: uintptr(unsafe.Pointer(b.data)),
-		Len:  int(b.length) / 8,
-		Cap:  int(b.length) / 8,
+		Data: uintptr(unsafe.Pointer(p.data)),
+		Len:  int(p.length) / 8,
+		Cap:  int(p.length) / 8,
 	}
-	C.ByteArray_Release(b)
 	return *(*[]float64)(unsafe.Pointer(h)), nil
 }
 

--- a/core.h
+++ b/core.h
@@ -15,11 +15,6 @@ typedef struct ByteArray {
     int length;
 } ByteArray;
 
-typedef struct DataPtr {
-    const char* data;
-    unsigned long length;
-} DataPtr;
-
 // Wrapper for std::vector<int>
 typedef struct IntVector {
     int* val;
@@ -203,7 +198,7 @@ void Mat_Size(Mat m, IntVector* res);
 void Mat_CopyToWithMask(Mat m, Mat dst, Mat mask);
 void Mat_ConvertTo(Mat m, Mat dst, int type);
 struct ByteArray Mat_ToBytes(Mat m);
-struct DataPtr Mat_DataPtr(Mat m);
+struct ByteArray Mat_DataPtr(Mat m);
 Mat Mat_Region(Mat m, Rect r);
 Mat Mat_Reshape(Mat m, int cn, int rows);
 void Mat_PatchNaNs(Mat m);

--- a/core.h
+++ b/core.h
@@ -15,6 +15,11 @@ typedef struct ByteArray {
     int length;
 } ByteArray;
 
+typedef struct DataPtr {
+    const char* data;
+    unsigned long length;
+} DataPtr;
+
 // Wrapper for std::vector<int>
 typedef struct IntVector {
     int* val;
@@ -198,6 +203,7 @@ void Mat_Size(Mat m, IntVector* res);
 void Mat_CopyToWithMask(Mat m, Mat dst, Mat mask);
 void Mat_ConvertTo(Mat m, Mat dst, int type);
 struct ByteArray Mat_ToBytes(Mat m);
+struct DataPtr Mat_DataPtr(Mat m);
 Mat Mat_Region(Mat m, Rect r);
 Mat Mat_Reshape(Mat m, int cn, int rows);
 void Mat_PatchNaNs(Mat m);

--- a/core_test.go
+++ b/core_test.go
@@ -214,11 +214,34 @@ func TestMatToBytes(t *testing.T) {
 }
 
 func TestMatDataPtr(t *testing.T) {
+	const (
+		rows = 101
+		cols = 102
+	)
 	t.Run("Uint8", func(t *testing.T) {
-		mat := NewMatWithSize(101, 102, MatTypeCV8U)
+		testPoints := []struct {
+			row int
+			col int
+			val uint8
+		}{
+			{row: 0, col: 0, val: 10},
+			{row: 30, col: 31, val: 20},
+			{row: rows - 1, col: cols - 1, val: 30},
+		}
+
+		mat := NewMatWithSize(rows, cols, MatTypeCV8U)
+
 		b := mat.DataPtrUint8()
 		if len(b) != 101*102 {
 			t.Errorf("Mat bytes incorrect length: %v\n", len(b))
+		}
+
+		for _, p := range testPoints {
+			mat.SetUCharAt(p.row, p.col, p.val)
+
+			if got := b[p.row*cols+p.col]; got != p.val {
+				t.Errorf("Expected %d,%d = %d, but it was %d", p.row, p.col, p.val, got)
+			}
 		}
 
 		mat = NewMatWithSize(3, 9, MatTypeCV32F)
@@ -228,10 +251,29 @@ func TestMatDataPtr(t *testing.T) {
 		}
 	})
 	t.Run("Int8", func(t *testing.T) {
+		testPoints := []struct {
+			row int
+			col int
+			val int8
+		}{
+			{row: 0, col: 0, val: 10},
+			{row: 30, col: 31, val: 20},
+			{row: rows - 1, col: cols - 1, val: 30},
+		}
+
 		mat := NewMatWithSize(101, 102, MatTypeCV8S)
+
 		b := mat.DataPtrInt8()
-		if len(b) != 101*102 {
+		if len(b) != rows*cols {
 			t.Errorf("Mat bytes incorrect length: %v\n", len(b))
+		}
+
+		for _, p := range testPoints {
+			mat.SetSCharAt(p.row, p.col, p.val)
+
+			if got := b[p.row*cols+p.col]; got != p.val {
+				t.Errorf("Expected %d,%d = %d, but it was %d", p.row, p.col, p.val, got)
+			}
 		}
 
 		mat = NewMatWithSize(3, 9, MatTypeCV32F)
@@ -241,13 +283,32 @@ func TestMatDataPtr(t *testing.T) {
 		}
 	})
 	t.Run("Uint16", func(t *testing.T) {
-		mat := NewMatWithSize(101, 102, MatTypeCV16U)
+		testPoints := []struct {
+			row int
+			col int
+			val uint16
+		}{
+			{row: 0, col: 0, val: 10},
+			{row: 30, col: 31, val: 20},
+			{row: rows - 1, col: cols - 1, val: 30},
+		}
+
+		mat := NewMatWithSize(rows, cols, MatTypeCV16U)
+
 		b, err := mat.DataPtrUint16()
 		if err != nil {
 			t.Error(err)
 		}
-		if len(b) != 101*102 {
+		if len(b) != rows*cols {
 			t.Errorf("Mat bytes incorrect length: %v\n", len(b))
+		}
+
+		for _, p := range testPoints {
+			mat.SetShortAt(p.row, p.col, int16(p.val))
+
+			if got := b[p.row*cols+p.col]; got != p.val {
+				t.Errorf("Expected %d,%d = %d, but it was %d", p.row, p.col, p.val, got)
+			}
 		}
 
 		mat = NewMatWithSize(3, 9, MatTypeCV32F)
@@ -257,13 +318,32 @@ func TestMatDataPtr(t *testing.T) {
 		}
 	})
 	t.Run("Int16", func(t *testing.T) {
-		mat := NewMatWithSize(101, 102, MatTypeCV16S)
+		testPoints := []struct {
+			row int
+			col int
+			val int16
+		}{
+			{row: 0, col: 0, val: 10},
+			{row: 30, col: 31, val: 20},
+			{row: rows - 1, col: cols - 1, val: 30},
+		}
+
+		mat := NewMatWithSize(rows, cols, MatTypeCV16S)
+
 		b, err := mat.DataPtrInt16()
 		if err != nil {
 			t.Error(err)
 		}
-		if len(b) != 101*102 {
+		if len(b) != rows*cols {
 			t.Errorf("Mat bytes incorrect length: %v\n", len(b))
+		}
+
+		for _, p := range testPoints {
+			mat.SetShortAt(p.row, p.col, p.val)
+
+			if got := b[p.row*cols+p.col]; got != p.val {
+				t.Errorf("Expected %d,%d = %d, but it was %d", p.row, p.col, p.val, got)
+			}
 		}
 
 		mat = NewMatWithSize(3, 9, MatTypeCV32F)
@@ -273,13 +353,32 @@ func TestMatDataPtr(t *testing.T) {
 		}
 	})
 	t.Run("Float32", func(t *testing.T) {
-		mat := NewMatWithSize(101, 102, MatTypeCV32F)
+		testPoints := []struct {
+			row int
+			col int
+			val float32
+		}{
+			{row: 0, col: 0, val: 10.5},
+			{row: 30, col: 31, val: 20.5},
+			{row: rows - 1, col: cols - 1, val: 30.5},
+		}
+
+		mat := NewMatWithSize(rows, cols, MatTypeCV32F)
+
 		b, err := mat.DataPtrFloat32()
 		if err != nil {
 			t.Error(err)
 		}
-		if len(b) != 101*102 {
+		if len(b) != rows*cols {
 			t.Errorf("Mat bytes incorrect length: %v\n", len(b))
+		}
+
+		for _, p := range testPoints {
+			mat.SetFloatAt(p.row, p.col, p.val)
+
+			if got := b[p.row*cols+p.col]; got != p.val {
+				t.Errorf("Expected %d,%d = %f, but it was %f", p.row, p.col, p.val, got)
+			}
 		}
 
 		mat = NewMatWithSize(3, 9, MatTypeCV16S)
@@ -289,13 +388,32 @@ func TestMatDataPtr(t *testing.T) {
 		}
 	})
 	t.Run("Float64", func(t *testing.T) {
-		mat := NewMatWithSize(101, 102, MatTypeCV64F)
+		testPoints := []struct {
+			row int
+			col int
+			val float64
+		}{
+			{row: 0, col: 0, val: 10.5},
+			{row: 30, col: 31, val: 20.5},
+			{row: rows - 1, col: cols - 1, val: 30.5},
+		}
+
+		mat := NewMatWithSize(rows, cols, MatTypeCV64F)
+
 		b, err := mat.DataPtrFloat64()
 		if err != nil {
 			t.Error(err)
 		}
-		if len(b) != 101*102 {
+		if len(b) != rows*cols {
 			t.Errorf("Mat bytes incorrect length: %v\n", len(b))
+		}
+
+		for _, p := range testPoints {
+			mat.SetDoubleAt(p.row, p.col, p.val)
+
+			if got := b[p.row*cols+p.col]; got != p.val {
+				t.Errorf("Expected %d,%d = %f, but it was %f", p.row, p.col, p.val, got)
+			}
 		}
 
 		mat = NewMatWithSize(3, 9, MatTypeCV16S)

--- a/core_test.go
+++ b/core_test.go
@@ -213,6 +213,99 @@ func TestMatToBytes(t *testing.T) {
 	}
 }
 
+func TestMatDataPtr(t *testing.T) {
+	t.Run("Uint8", func(t *testing.T) {
+		mat := NewMatWithSize(101, 102, MatTypeCV8U)
+		b := mat.DataPtrUint8()
+		if len(b) != 101*102 {
+			t.Errorf("Mat bytes incorrect length: %v\n", len(b))
+		}
+
+		mat = NewMatWithSize(3, 9, MatTypeCV32F)
+		b = mat.DataPtrUint8()
+		if len(b) != 3*9*4 {
+			t.Errorf("Mat bytes incorrect length: %v\n", len(b))
+		}
+	})
+	t.Run("Int8", func(t *testing.T) {
+		mat := NewMatWithSize(101, 102, MatTypeCV8S)
+		b := mat.DataPtrInt8()
+		if len(b) != 101*102 {
+			t.Errorf("Mat bytes incorrect length: %v\n", len(b))
+		}
+
+		mat = NewMatWithSize(3, 9, MatTypeCV32F)
+		b = mat.DataPtrInt8()
+		if len(b) != 3*9*4 {
+			t.Errorf("Mat bytes incorrect length: %v\n", len(b))
+		}
+	})
+	t.Run("Uint16", func(t *testing.T) {
+		mat := NewMatWithSize(101, 102, MatTypeCV16U)
+		b, err := mat.DataPtrUint16()
+		if err != nil {
+			t.Error(err)
+		}
+		if len(b) != 101*102 {
+			t.Errorf("Mat bytes incorrect length: %v\n", len(b))
+		}
+
+		mat = NewMatWithSize(3, 9, MatTypeCV32F)
+		_, err = mat.DataPtrUint16()
+		if err == nil {
+			t.Errorf("Expected error.")
+		}
+	})
+	t.Run("Int16", func(t *testing.T) {
+		mat := NewMatWithSize(101, 102, MatTypeCV16S)
+		b, err := mat.DataPtrInt16()
+		if err != nil {
+			t.Error(err)
+		}
+		if len(b) != 101*102 {
+			t.Errorf("Mat bytes incorrect length: %v\n", len(b))
+		}
+
+		mat = NewMatWithSize(3, 9, MatTypeCV32F)
+		_, err = mat.DataPtrInt16()
+		if err == nil {
+			t.Errorf("Expected error.")
+		}
+	})
+	t.Run("Float32", func(t *testing.T) {
+		mat := NewMatWithSize(101, 102, MatTypeCV32F)
+		b, err := mat.DataPtrFloat32()
+		if err != nil {
+			t.Error(err)
+		}
+		if len(b) != 101*102 {
+			t.Errorf("Mat bytes incorrect length: %v\n", len(b))
+		}
+
+		mat = NewMatWithSize(3, 9, MatTypeCV16S)
+		_, err = mat.DataPtrFloat32()
+		if err == nil {
+			t.Errorf("Expected error.")
+		}
+	})
+	t.Run("Float64", func(t *testing.T) {
+		mat := NewMatWithSize(101, 102, MatTypeCV64F)
+		b, err := mat.DataPtrFloat64()
+		if err != nil {
+			t.Error(err)
+		}
+		if len(b) != 101*102 {
+			t.Errorf("Mat bytes incorrect length: %v\n", len(b))
+		}
+
+		mat = NewMatWithSize(3, 9, MatTypeCV16S)
+		_, err = mat.DataPtrFloat64()
+		if err == nil {
+			t.Errorf("Expected error.")
+		}
+	})
+}
+
 func TestMatRegion(t *testing.T) {
 	mat := NewMatWithSize(100, 100, MatTypeCV8U)
 	region := mat.Region(image.Rect(20, 25, 80, 75))


### PR DESCRIPTION
@deadprogram It doesn't seem necessary to return an error for the single byte variants. The int8 version probably isn't that useful, but I could imagine a scenario where someone wants to access the raw bytes even if the Mat is of a different type.

Resolves #250 