### PR TITLE
Fix package names for CentOS 7 and Fedora 28

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OPENCV_VERSION?=3.4.2
 TMP_DIR?=/tmp/
 
 # Package list for each well-known Linux distribution
-RPMS=cmake git gtk2-devel libpng-devel libjpeg-devel libtiff-devel tbb tbb-devel libdc1394-devel
+RPMS=cmake git gtk2-devel libpng-devel libjpeg-devel libtiff-devel tbb tbb-devel libdc1394-devel unzip
 DEBS=unzip build-essential cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libdc1394-22-dev
 
 # Detect Linux distribution
@@ -43,9 +43,9 @@ deps_debian:
 download:
 	mkdir $(TMP_DIR)opencv
 	cd $(TMP_DIR)opencv
-	wget --quiet -O opencv.zip https://github.com/opencv/opencv/archive/$(OPENCV_VERSION).zip
+	curl -Lo opencv.zip https://github.com/opencv/opencv/archive/$(OPENCV_VERSION).zip
 	unzip -q opencv.zip
-	wget --quiet -O opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/$(OPENCV_VERSION).zip
+	curl -Lo opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/$(OPENCV_VERSION).zip
 	unzip -q opencv_contrib.zip
 	rm opencv.zip opencv_contrib.zip
 	cd -

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OPENCV_VERSION?=3.4.2
 TMP_DIR?=/tmp/
 
 # Package list for each well-known Linux distribution
-RPMS=cmake git gtk2-devel pkg-config libpng-devel libjpeg-devel libtiff-devel tbb tbb-devel libdc1394-devel
+RPMS=cmake git gtk2-devel libpng-devel libjpeg-devel libtiff-devel tbb tbb-devel libdc1394-devel
 DEBS=unzip build-essential cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libdc1394-22-dev
 
 # Detect Linux distribution
@@ -29,10 +29,10 @@ endif
 deps: $(distro_deps)
 
 deps_rh_centos:
-	sudo yum -y install $(RPMS)
+	sudo yum -y install pkgconfig $(RPMS)
 
 deps_fedora:
-	sudo dnf install $(RPMS) -y
+	sudo dnf -y install pkgconf-pkg-config $(RPMS)
 
 deps_debian:
 	sudo apt-get -y update
@@ -43,9 +43,9 @@ deps_debian:
 download:
 	mkdir $(TMP_DIR)opencv
 	cd $(TMP_DIR)opencv
-	wget --show-progress --quiet -O opencv.zip https://github.com/opencv/opencv/archive/$(OPENCV_VERSION).zip
+	wget --quiet -O opencv.zip https://github.com/opencv/opencv/archive/$(OPENCV_VERSION).zip
 	unzip -q opencv.zip
-	wget --show-progress --quiet -O opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/$(OPENCV_VERSION).zip
+	wget --quiet -O opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/$(OPENCV_VERSION).zip
 	unzip -q opencv_contrib.zip
 	rm opencv.zip opencv_contrib.zip
 	cd -


### PR DESCRIPTION
The present Makefile has a typo in the (RPMS) package name, for CentOS 7 and Fedora 28.

This PR fixes that, and also addresses the wget problem in #282. :smile:

It also adds `unzip` to the package list for CentOS and Fedora, as that's needed and isn't part of the general base system.