### PR TITLE
add condition to handle no circle found in circle detection example

### DIFF
--- a/cmd/find-circles/main.go
+++ b/cmd/find-circles/main.go
@@ -60,12 +60,15 @@ func main() {
 
 	for i := 0; i < circles.Cols(); i++ {
 		v := circles.GetVecfAt(0, i)
-		x := int(v[0])
-		y := int(v[1])
-		r := int(v[2])
+		// if circles are found
+		if len(v) > 2 {
+			x := int(v[0])
+			y := int(v[1])
+			r := int(v[2])
 
-		gocv.Circle(&cimg, image.Pt(x, y), r, blue, 2)
-		gocv.Circle(&cimg, image.Pt(x, y), 2, red, 3)
+			gocv.Circle(&cimg, image.Pt(x, y), r, blue, 2)
+			gocv.Circle(&cimg, image.Pt(x, y), 2, red, 3)
+		}
 	}
 
 	for {


### PR DESCRIPTION
When the image has no circles, the following error is thrown: `runtime error: index out of range` this is because v in https://github.com/hybridgroup/gocv/blob/master/cmd/find-circles/main.go#L62 has length 1 or 0. Adding a lenght check fixes the issue