### PR TITLE
Added IMEncodeWithParams function

### DIFF
--- a/imgcodecs.cpp
+++ b/imgcodecs.cpp
@@ -27,6 +27,18 @@ struct ByteArray Image_IMEncode(const char* fileExt, Mat img) {
     return toByteArray(reinterpret_cast<const char*>(&data[0]), data.size());
 }
 
+struct ByteArray Image_IMEncode_WithParams(const char* fileExt, Mat img, IntVector params) {
+    std::vector<uchar> data;
+    std::vector<int> compression_params;
+
+    for (int i = 0, *v = params.val; i < params.length; ++v, ++i) {
+        compression_params.push_back(*v);
+    }
+
+    cv::imencode(fileExt, *img, data, compression_params);
+    return toByteArray(reinterpret_cast<const char*>(&data[0]), data.size());
+}
+
 Mat Image_IMDecode(ByteArray buf, int flags) {
     std::vector<char> data;
 

--- a/imgcodecs.go
+++ b/imgcodecs.go
@@ -202,6 +202,35 @@ func IMEncode(fileExt FileExt, img Mat) (buf []byte, err error) {
 	return toGoBytes(b), nil
 }
 
+// IMEncodeWithParams encodes an image Mat into a memory buffer.
+// This function compresses the image and stores it in the returned memory buffer,
+// using the image format passed in in the form of a file extension string.
+//
+// Usage example:
+//  buffer, err := gocv.IMEncodeWithParams(gocv.JPEGFileExt, img, []int{gocv.IMWriteJpegQuality, quality})
+//
+// For further details, please see:
+// http://docs.opencv.org/master/d4/da8/group__imgcodecs.html#ga461f9ac09887e47797a54567df3b8b63
+//
+func IMEncodeWithParams(fileExt FileExt, img Mat, params []int) (buf []byte, err error) {
+	cfileExt := C.CString(string(fileExt))
+	defer C.free(unsafe.Pointer(cfileExt))
+
+	cparams := []C.int{}
+
+	for _, v := range params {
+		cparams = append(cparams, C.int(v))
+	}
+
+	paramsVector := C.struct_IntVector{}
+	paramsVector.val = (*C.int)(&cparams[0])
+	paramsVector.length = (C.int)(len(cparams))
+
+	b := C.Image_IMEncode_WithParams(cfileExt, img.Ptr(), paramsVector)
+	defer C.ByteArray_Release(b)
+	return toGoBytes(b), nil
+}
+
 // IMDecode reads an image from a buffer in memory.
 // The function IMDecode reads an image from the specified buffer in memory.
 // If the buffer is too short or contains invalid data, the function

--- a/imgcodecs.h
+++ b/imgcodecs.h
@@ -14,6 +14,7 @@ Mat Image_IMRead(const char* filename, int flags);
 bool Image_IMWrite(const char* filename, Mat img);
 bool Image_IMWrite_WithParams(const char* filename, Mat img, IntVector params);
 struct ByteArray Image_IMEncode(const char* fileExt, Mat img);
+struct ByteArray Image_IMEncode_WithParams(const char* fileExt, Mat img, IntVector params);
 Mat Image_IMDecode(ByteArray buf, int flags);
 
 #ifdef __cplusplus

--- a/imgcodecs_test.go
+++ b/imgcodecs_test.go
@@ -1,8 +1,15 @@
 package gocv
 
 import (
+	"fmt"
+	"io"
 	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path"
 	"path/filepath"
+	"strconv"
 	"testing"
 )
 
@@ -55,6 +62,60 @@ func TestIMEncode(t *testing.T) {
 	}
 	if len(buf) < 43000 {
 		t.Errorf("Wrong buffer size in IMEncode test. Should have been %v\n", len(buf))
+	}
+}
+
+func ExampleIMEncodeWithParams() {
+	img := IMRead(path.Join(os.Getenv("GOPATH"), "src/gocv.io/x/gocv/images/face-detect.jpg"), IMReadColor)
+	if img.Empty() {
+		log.Fatal("Invalid Mat")
+	}
+
+	imgHandler := func(w http.ResponseWriter, req *http.Request) {
+		quality := 75
+		if q, err := strconv.Atoi(req.URL.Query().Get("q")); err == nil {
+			quality = q
+		}
+		buffer, err := IMEncodeWithParams(JPEGFileExt, img, []int{IMWriteJpegQuality, quality})
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			io.WriteString(w, err.Error())
+			return
+		}
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.WriteHeader(http.StatusOK)
+		w.Write(buffer)
+	}
+
+	http.HandleFunc("/img", imgHandler)
+	fmt.Println("Open in browser http://127.0.0.1:8080/img?q=10 where q is a JPEG quality parameter")
+	log.Fatal(http.ListenAndServe("127.0.0.1:8080", nil))
+}
+
+func TestIMEncodeWithParams(t *testing.T) {
+	img := IMRead("images/face-detect.jpg", IMReadColor)
+	if img.Empty() {
+		t.Error("Invalid Mat in IMEncode test")
+	}
+
+	buf, err := IMEncodeWithParams(JPEGFileExt, img, []int{IMWriteJpegQuality, 75})
+	if err != nil {
+		t.Error(err)
+	}
+	if len(buf) < 18000 {
+		t.Errorf("Wrong buffer size in IMEncode test. Should have been %v\n", len(buf))
+	}
+
+	buf2, err := IMEncodeWithParams(JPEGFileExt, img, []int{IMWriteJpegQuality, 100})
+	if err != nil {
+		t.Error(err)
+	}
+	if len(buf2) < 18000 {
+		t.Errorf("Wrong buffer size in IMEncode test. Should have been %v\n", len(buf))
+	}
+
+	if len(buf) >= len(buf2) {
+		t.Errorf("Jpeg quality parameter does not work correctly\n")
 	}
 }
 


### PR DESCRIPTION
Usage example
`data, err := gocv.IMEncodeWithParams(".jpg", img, []int{gocv.IMWriteJpegQuality, 95})`