### PR TITLE
Add required curl package to the RPM and DEBS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ OPENCV_VERSION?=3.4.2
 TMP_DIR?=/tmp/
 
 # Package list for each well-known Linux distribution
-RPMS=cmake git gtk2-devel libpng-devel libjpeg-devel libtiff-devel tbb tbb-devel libdc1394-devel unzip
-DEBS=unzip build-essential cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libdc1394-22-dev
+RPMS=cmake curl git gtk2-devel libpng-devel libjpeg-devel libtiff-devel tbb tbb-devel libdc1394-devel unzip
+DEBS=unzip build-essential cmake curl git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libdc1394-22-dev
 
 # Detect Linux distribution
 distro_deps=


### PR DESCRIPTION
This is my first ever pull request on an open source project so bear with me.

I noticed an issue on a fresh Ubuntu 16.04 64bit machine when trying to use the "make install" command for gocv.  If curl is not installed on the machine, then the installer ends up in a looping state.

Below is the looping output I was seeing prior to this change.

sudo make install
sudo ldconfig
cd -
/bin/sh: 1: cd: can't cd to /tmp/opencv/opencv-3.4.2/build
sudo apt-get -y update
sudo apt-get -y install unzip build-essential cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libdc1394-22-dev
Hit:1 http://us.archive.ubuntu.com/ubuntu xenial InRelease
Hit:2 http://us.archive.ubuntu.com/ubuntu xenial-updates InRelease             
Get:3 http://us.archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]  
Get:4 http://security.ubuntu.com/ubuntu xenial-security InRelease [107 kB]     
Fetched 214 kB in 0s (331 kB/s)                              
Reading package lists... Done
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'libpng12-dev' instead of 'libpng-dev'
Note, selecting 'libtiff5-dev' instead of 'libtiff-dev'
build-essential is already the newest version (12.1ubuntu2).
libjpeg-dev is already the newest version (8c-2ubuntu8).
pkg-config is already the newest version (0.29.1-0ubuntu1).
unzip is already the newest version (6.0-20ubuntu1).
libdc1394-22-dev is already the newest version (2.2.4-1).
libtbb-dev is already the newest version (4.4~20151115-0ubuntu3).
libtbb2 is already the newest version (4.4~20151115-0ubuntu3).
cmake is already the newest version (3.5.1-1ubuntu3).
git is already the newest version (1:2.7.4-0ubuntu1.5).
libgtk2.0-dev is already the newest version (2.24.30-1ubuntu1.16.04.2).
libpng12-dev is already the newest version (1.2.54-1ubuntu1.1).
libtiff5-dev is already the newest version (4.0.6-1ubuntu0.4).
libavcodec-dev is already the newest version (7:2.8.15-0ubuntu0.16.04.1).
libavformat-dev is already the newest version (7:2.8.15-0ubuntu0.16.04.1).
libswscale-dev is already the newest version (7:2.8.15-0ubuntu0.16.04.1).
The following package was automatically installed and is no longer required:
  libllvm5.0
Use 'sudo apt autoremove' to remove it.
0 upgraded, 0 newly installed, 0 to remove and 56 not upgraded.
rm -rf /tmp/opencv
mkdir /tmp/opencv
cd /tmp/opencv
curl -Lo opencv.zip https://github.com/opencv/opencv/archive/3.4.2.zip
unzip -q opencv.zip
curl -Lo opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/3.4.2.zip
unzip -q opencv_contrib.zip
rm opencv.zip opencv_contrib.zip
cd -
/bin/sh: 4: curl: not found
unzip:  cannot find or open opencv.zip, opencv.zip.zip or opencv.zip.ZIP.
/bin/sh: 6: curl: not found
unzip:  cannot find or open opencv_contrib.zip, opencv_contrib.zip.zip or opencv_contrib.zip.ZIP.
rm: cannot remove 'opencv.zip': No such file or directory
rm: cannot remove 'opencv_contrib.zip': No such file or directory
/home/rugrat/GIT/go/src/gocv.io/x/gocv
cd /tmp/opencv/opencv-3.4.2
mkdir build
cd build
cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -D OPENCV_EXTRA_MODULES_PATH=/tmp/opencv/opencv_contrib-3.4.2/modules -D BUILD_DOCS=OFF BUILD_EXAMPLES=OFF -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF -D BUILD_opencv_java=OFF -D BUILD_opencv_python=OFF -D BUILD_opencv_python2=OFF -D BUILD_opencv_python3=OFF WITH_JASPER=OFF ..
make -j 4
make preinstall
cd -
/bin/sh: 1: cd: can't cd to /tmp/opencv/opencv-3.4.2
mkdir: cannot create directory ‘build’: File exists
CMake Error: The source directory "/home/rugrat/GIT/go/src/gocv.io/x/gocv" does not appear to contain CMakeLists.txt.
Specify --help for usage, or press the help button on the CMake GUI.
make[1]: Entering directory '/home/rugrat/GIT/go/src/gocv.io/x/gocv/build'
make[1]: *** No targets specified and no makefile found.  Stop.
make[1]: Leaving directory '/home/rugrat/GIT/go/src/gocv.io/x/gocv/build'
make[1]: Entering directory '/home/rugrat/GIT/go/src/gocv.io/x/gocv/build'
make[1]: *** No rule to make target 'preinstall'.  Stop.
make[1]: Leaving directory '/home/rugrat/GIT/go/src/gocv.io/x/gocv/build'
/home/rugrat/GIT/go/src/gocv.io/x/gocv
cd /tmp/opencv/opencv-3.4.2/build
