### PR TITLE
Improve accuracy of hand gesture finger count

### DIFF
--- a/cmd/hand-gestures/main.go
+++ b/cmd/hand-gestures/main.go
@@ -104,7 +104,7 @@ func main() {
 			}
 		}
 
-		status := fmt.Sprintf("defectCount: %d", defectCount)
+		status := fmt.Sprintf("defectCount: %d", defectCount+1)
 
 		rect := gocv.BoundingRect(c)
 		gocv.Rectangle(&img, rect, color.RGBA{255, 255, 255, 0}, 2)


### PR DESCRIPTION
The process of "cleaning up image" concomitant with the process of "find biggest contour", both with their respective functions and equations, results in data, that are converted into green dots in the image; therefore, these points represent areas, or rather vertices resulting from the equations, which, contrary to what the code shows, aren't the number of fingers. The number of fingers is the number of vertices found plus one, because every 2 large areas with contours(fingers), we have 1 vertex, formed by 2 contours with angle less than 90.
I modified the code and my results turn on a little better. I ask for apologies if I understand wrong. Thank you.