### PR TITLE
VideoCapture now populates error if it fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ OPENCV_VERSION?=3.4.2
 TMP_DIR?=/tmp/
 
 # Package list for each well-known Linux distribution
-RPMS=cmake git gtk2-devel libpng-devel libjpeg-devel libtiff-devel tbb tbb-devel libdc1394-devel unzip
-DEBS=unzip build-essential cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libdc1394-22-dev
+RPMS=cmake curl git gtk2-devel libpng-devel libjpeg-devel libtiff-devel tbb tbb-devel libdc1394-devel unzip
+DEBS=unzip build-essential cmake curl git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libdc1394-22-dev
 
 # Detect Linux distribution
 distro_deps=

--- a/cmd/hand-gestures/main.go
+++ b/cmd/hand-gestures/main.go
@@ -104,7 +104,7 @@ func main() {
 			}
 		}
 
-		status := fmt.Sprintf("defectCount: %d", defectCount)
+		status := fmt.Sprintf("defectCount: %d", defectCount+1)
 
 		rect := gocv.BoundingRect(c)
 		gocv.Rectangle(&img, rect, color.RGBA{255, 255, 255, 0}, 2)

--- a/core.cpp
+++ b/core.cpp
@@ -554,6 +554,10 @@ void Mat_Repeat(Mat src, int nY, int nX, Mat dst) {
     cv::repeat(*src, nY, nX, *dst);
 }
 
+void Mat_ScaleAdd(Mat src1, double alpha, Mat src2, Mat dst) {
+    cv::scaleAdd(*src1, alpha, *src2, *dst);
+}
+
 void Mat_Sort(Mat src, Mat dst, int flags) {
     cv::sort(*src, *dst, flags);
 }

--- a/core.go
+++ b/core.go
@@ -1497,6 +1497,15 @@ func Repeat(src Mat, nY int, nX int, dst *Mat) {
 	C.Mat_Repeat(src.p, C.int(nY), C.int(nX), dst.p)
 }
 
+// Calculates the sum of a scaled array and another array.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d2/de8/group__core__array.html#ga9e0845db4135f55dcf20227402f00d98
+//
+func ScaleAdd(src1 Mat, alpha float64, src2 Mat, dst *Mat) {
+	C.Mat_ScaleAdd(src1.p, C.double(alpha), src2.p, dst.p)
+}
+
 type SortFlags int
 
 const (

--- a/core.h
+++ b/core.h
@@ -317,6 +317,7 @@ int Mat_SolveCubic(Mat coeffs, Mat roots);
 double Mat_SolvePoly(Mat coeffs, Mat roots, int maxIters);
 void Mat_Reduce(Mat src, Mat dst, int dim, int rType, int dType);
 void Mat_Repeat(Mat src, int nY, int nX, Mat dst);
+void Mat_ScaleAdd(Mat src1, double alpha, Mat src2, Mat dst);
 void Mat_Sort(Mat src, Mat dst, int flags);
 void Mat_SortIdx(Mat src, Mat dst, int flags);
 void Mat_Split(Mat src, struct Mats* mats);

--- a/core_test.go
+++ b/core_test.go
@@ -1109,6 +1109,45 @@ func TestRepeat(t *testing.T) {
 	}
 }
 
+func TestScaleAdd(t *testing.T) {
+	rows := 2
+	cols := 3
+	src1 := NewMatWithSize(rows, cols, MatTypeCV64F)
+
+	for row := 0; row < rows; row++ {
+		for col := 0; col < cols; col++ {
+			src1.SetDoubleAt(row, col, float64(col))
+		}
+	}
+
+	src2 := NewMatWithSize(rows, cols, MatTypeCV64F)
+
+	for row := 0; row < rows; row++ {
+		for col := 0; col < cols; col++ {
+			src2.SetDoubleAt(row, col, 1.0)
+		}
+	}
+
+	dst := NewMat()
+
+	alpha := 1.5
+	ScaleAdd(src1, alpha, src2, &dst)
+
+	if dst.Empty() {
+		t.Error("TestScaleAdd dst should not be empty.")
+	}
+
+	for row := 0; row < rows; row++ {
+		for col := 0; col < cols; col++ {
+			expected := float64(col)*alpha + 1.0
+			result := dst.GetDoubleAt(row, col)
+			if result != expected {
+				t.Errorf("TestScaleAdd dst at row=%d col=%d should be %f and got %f.", row, col, expected, result)
+			}
+		}
+	}
+}
+
 func TestMatSortEveryRowDescending(t *testing.T) {
 	rows := 2
 	cols := 3

--- a/videoio.cpp
+++ b/videoio.cpp
@@ -9,11 +9,11 @@ void VideoCapture_Close(VideoCapture v) {
     delete v;
 }
 
-int VideoCapture_Open(VideoCapture v, const char* uri) {
+bool VideoCapture_Open(VideoCapture v, const char* uri) {
     return v->open(uri);
 }
 
-int VideoCapture_OpenDevice(VideoCapture v, int device) {
+bool VideoCapture_OpenDevice(VideoCapture v, int device) {
     return v->open(device);
 }
 

--- a/videoio.go
+++ b/videoio.go
@@ -169,7 +169,10 @@ func VideoCaptureFile(uri string) (vc *VideoCapture, err error) {
 	cURI := C.CString(uri)
 	defer C.free(unsafe.Pointer(cURI))
 
-	C.VideoCapture_Open(vc.p, cURI)
+	if !C.VideoCapture_Open(vc.p, cURI) {
+		err = fmt.Errorf("Error opening file: %s", uri)
+	}
+
 	return
 }
 
@@ -177,7 +180,11 @@ func VideoCaptureFile(uri string) (vc *VideoCapture, err error) {
 // to start capturing.
 func VideoCaptureDevice(device int) (vc *VideoCapture, err error) {
 	vc = &VideoCapture{p: C.VideoCapture_New()}
-	C.VideoCapture_OpenDevice(vc.p, C.int(device))
+
+	if !C.VideoCapture_OpenDevice(vc.p, C.int(device)) {
+		err = fmt.Errorf("Error opening device: %d", device)
+	}
+
 	return
 }
 

--- a/videoio.h
+++ b/videoio.h
@@ -19,8 +19,8 @@ typedef void* VideoWriter;
 // VideoCapture
 VideoCapture VideoCapture_New();
 void VideoCapture_Close(VideoCapture v);
-int VideoCapture_Open(VideoCapture v, const char* uri);
-int VideoCapture_OpenDevice(VideoCapture v, int device);
+bool VideoCapture_Open(VideoCapture v, const char* uri);
+bool VideoCapture_OpenDevice(VideoCapture v, int device);
 void VideoCapture_Set(VideoCapture v, int prop, double param);
 double VideoCapture_Get(VideoCapture v, int prop);
 int VideoCapture_IsOpened(VideoCapture v);

--- a/videoio_test.go
+++ b/videoio_test.go
@@ -37,8 +37,12 @@ func TestVideoCaptureInvalid(t *testing.T) {
 }
 
 func TestVideoCaptureFile(t *testing.T) {
-	vc, _ := VideoCaptureFile("images/small.mp4")
+	vc, err := VideoCaptureFile("images/small.mp4")
 	defer vc.Close()
+
+	if err != nil {
+		t.Errorf("%s", err)
+	}
 
 	if !vc.IsOpened() {
 		t.Error("Unable to open VideoCaptureFile")
@@ -61,6 +65,13 @@ func TestVideoCaptureFile(t *testing.T) {
 	vc.Read(&img)
 	if img.Empty() {
 		t.Error("Unable to read VideoCaptureFile")
+	}
+
+	vc2, err := VideoCaptureFile("nonexistent.mp4")
+	defer vc2.Close()
+
+	if err == nil {
+		t.Errorf("Expected error when opening invalid file")
 	}
 }
 


### PR DESCRIPTION
When opening a video capture (file or device) `VideoCapture::open(...)` returns `bool` value depending on success of the `open` call. However we are ignoring the return value and not setting the error when returning from Go bindings functions. This leads to bugs in Go programs which are checking for `error` values returned from `VideoCapture*` functions when the returned error is `nil`, which leads to the code assuming the video capture `open` was successful.

Furthermore `VideoCapture::open(...)` calls return `bool` values. We are however returning integer, which is ok in C/C++ world as it's implicitly cast by `cgo` into particular bool value. However, we want to make this explicit in GoCV so we are returning bool now as per OpenCV.