### PR TITLE
Return the right type and error when opening VideoCapture fails

### DIFF
--- a/videoio.cpp
+++ b/videoio.cpp
@@ -9,11 +9,11 @@ void VideoCapture_Close(VideoCapture v) {
     delete v;
 }
 
-int VideoCapture_Open(VideoCapture v, const char* uri) {
+bool VideoCapture_Open(VideoCapture v, const char* uri) {
     return v->open(uri);
 }
 
-int VideoCapture_OpenDevice(VideoCapture v, int device) {
+bool VideoCapture_OpenDevice(VideoCapture v, int device) {
     return v->open(device);
 }
 

--- a/videoio.go
+++ b/videoio.go
@@ -162,7 +162,7 @@ type VideoCapture struct {
 }
 
 // VideoCaptureFile opens a VideoCapture from a file and prepares
-// to start capturing.
+// to start capturing. It returns error if it fails to open the file stored in uri path.
 func VideoCaptureFile(uri string) (vc *VideoCapture, err error) {
 	vc = &VideoCapture{p: C.VideoCapture_New()}
 
@@ -177,7 +177,7 @@ func VideoCaptureFile(uri string) (vc *VideoCapture, err error) {
 }
 
 // VideoCaptureDevice opens a VideoCapture from a device and prepares
-// to start capturing.
+// to start capturing. It returns error if it fails to open the video device.
 func VideoCaptureDevice(device int) (vc *VideoCapture, err error) {
 	vc = &VideoCapture{p: C.VideoCapture_New()}
 

--- a/videoio.go
+++ b/videoio.go
@@ -169,7 +169,10 @@ func VideoCaptureFile(uri string) (vc *VideoCapture, err error) {
 	cURI := C.CString(uri)
 	defer C.free(unsafe.Pointer(cURI))
 
-	C.VideoCapture_Open(vc.p, cURI)
+	if !C.VideoCapture_Open(vc.p, cURI) {
+		err = fmt.Errorf("Error opening file: %s", uri)
+	}
+
 	return
 }
 
@@ -177,7 +180,11 @@ func VideoCaptureFile(uri string) (vc *VideoCapture, err error) {
 // to start capturing.
 func VideoCaptureDevice(device int) (vc *VideoCapture, err error) {
 	vc = &VideoCapture{p: C.VideoCapture_New()}
-	C.VideoCapture_OpenDevice(vc.p, C.int(device))
+
+	if !C.VideoCapture_OpenDevice(vc.p, C.int(device)) {
+		err = fmt.Errorf("Error opening device: %d", device)
+	}
+
 	return
 }
 

--- a/videoio.h
+++ b/videoio.h
@@ -19,8 +19,8 @@ typedef void* VideoWriter;
 // VideoCapture
 VideoCapture VideoCapture_New();
 void VideoCapture_Close(VideoCapture v);
-int VideoCapture_Open(VideoCapture v, const char* uri);
-int VideoCapture_OpenDevice(VideoCapture v, int device);
+bool VideoCapture_Open(VideoCapture v, const char* uri);
+bool VideoCapture_OpenDevice(VideoCapture v, int device);
 void VideoCapture_Set(VideoCapture v, int prop, double param);
 double VideoCapture_Get(VideoCapture v, int prop);
 int VideoCapture_IsOpened(VideoCapture v);

--- a/videoio_test.go
+++ b/videoio_test.go
@@ -37,8 +37,12 @@ func TestVideoCaptureInvalid(t *testing.T) {
 }
 
 func TestVideoCaptureFile(t *testing.T) {
-	vc, _ := VideoCaptureFile("images/small.mp4")
+	vc, err := VideoCaptureFile("images/small.mp4")
 	defer vc.Close()
+
+	if err != nil {
+		t.Errorf("%s", err)
+	}
 
 	if !vc.IsOpened() {
 		t.Error("Unable to open VideoCaptureFile")
@@ -61,6 +65,13 @@ func TestVideoCaptureFile(t *testing.T) {
 	vc.Read(&img)
 	if img.Empty() {
 		t.Error("Unable to read VideoCaptureFile")
+	}
+
+	vc2, err := VideoCaptureFile("nonexistent.mp4")
+	defer vc2.Close()
+
+	if err == nil {
+		t.Errorf("Expected error when opening invalid file")
 	}
 }
 


### PR DESCRIPTION
When opening a video capture (file or device) `VideoCapture::open(...)` returns `bool` value depending on success of the `open` call. However we are ignoring the return value and not setting the error when returning from Go bindings functions. This leads to bugs in Go programs which are checking for `error` values returned from `VideoCapture*` functions when the returned error is `nil`, which leads to the code assuming the video capture `open` was successful.

Furthermore `VideoCapture::open(...)` calls return `bool` values. We are however returning integer, which is ok in C/C++ world as it's implicitly cast by `cgo` into particular bool value. However, we want to make this explicit in GoCV so we are returning bool now as per OpenCV.