### PR TITLE
dnn: add ReadNetFromModelOptimizer() to gocv

### DIFF
--- a/cmd/caffe-classifier-optimized/main.go
+++ b/cmd/caffe-classifier-optimized/main.go
@@ -1,0 +1,149 @@
+// What it does:
+//
+// This example uses the Caffe (http://caffe.berkeleyvision.org/) deep learning framework
+// to classify whatever is in front of the camera.
+//
+// Download the Caffe model file from:
+// http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel
+//
+// Also, you will need the prototxt file:
+// https://raw.githubusercontent.com/opencv/opencv_extra/master/testdata/dnn/bvlc_googlenet.prototxt
+//
+// And the words text file with the descriptions:
+// https://raw.githubusercontent.com/opencv/opencv/master/samples/data/dnn/classification_classes_ILSVRC2012.txt
+//
+// Convert the model to Intel's Model Optimizer intermediate representation:
+// 		python3 /opt/intel/computer_vision_sdk/deployment_tools/model_optimizer/mo_caffe.py --input_model ~/Downloads/bvlc_googlenet.caffemodel --input_proto ~/Downloads/bvlc_googlenet.prototxt
+//
+// How to run:
+//
+// 		go run ./cmd/caffe-classifier-optimized/main.go 0 ~/Downloads/bvlc_googlenet.caffemodel ~/Downloads/bvlc_googlenet.prototxt ~/Downloads/synset_words.txt
+//
+// You can also use this sample with the Intel OpenVINO Inference Engine, if you have it installed.
+//
+// 		go run ./cmd/caffe-classifier-optimized/main.go 0 ~/Downloads/bvlc_googlenet.caffemodel ~/Downloads/bvlc_googlenet.prototxt ~/Downloads/synset_words.txt openvino fp32
+//
+// +build example
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"image"
+	"image/color"
+	"os"
+
+	"gocv.io/x/gocv"
+)
+
+func main() {
+	if len(os.Args) < 5 {
+		fmt.Println("How to run:\ncaffe-classifier-optimized [camera ID] [xmlfile] [binfile] [descriptionsfile] ([backend] [device])")
+		return
+	}
+
+	// parse args
+	deviceID := os.Args[1]
+	xml := os.Args[2]
+	bin := os.Args[3]
+	descr := os.Args[4]
+	descriptions, err := readDescriptions(descr)
+	if err != nil {
+		fmt.Printf("Error reading descriptions file: %v\n", descr)
+		return
+	}
+
+	backend := gocv.NetBackendDefault
+	if len(os.Args) > 5 {
+		backend = gocv.ParseNetBackend(os.Args[5])
+	}
+
+	target := gocv.NetTargetCPU
+	if len(os.Args) > 6 {
+		target = gocv.ParseNetTarget(os.Args[6])
+	}
+
+	// open capture device
+	webcam, err := gocv.OpenVideoCapture(deviceID)
+	if err != nil {
+		fmt.Printf("Error opening video capture device: %v\n", deviceID)
+		return
+	}
+	defer webcam.Close()
+
+	window := gocv.NewWindow("Caffe Classifier")
+	defer window.Close()
+
+	img := gocv.NewMat()
+	defer img.Close()
+
+	// open DNN classifier
+	net := gocv.ReadNetFromModelOptimizer(xml, bin)
+	if net.Empty() {
+		fmt.Printf("Error reading network xml from : %v %v\n", xml, bin)
+		return
+	}
+	defer net.Close()
+	net.SetPreferableBackend(gocv.NetBackendType(backend))
+	net.SetPreferableTarget(gocv.NetTargetType(target))
+
+	status := "Ready"
+	statusColor := color.RGBA{0, 255, 0, 0}
+	fmt.Printf("Start reading device: %v\n", deviceID)
+
+	for {
+		if ok := webcam.Read(&img); !ok {
+			fmt.Printf("Device closed: %v\n", deviceID)
+			return
+		}
+		if img.Empty() {
+			continue
+		}
+
+		// convert image Mat to 224x224 blob that the classifier can analyze
+		blob := gocv.BlobFromImage(img, 1.0, image.Pt(224, 224), gocv.NewScalar(104, 117, 123, 0), false, false)
+
+		// feed the blob into the classifier
+		net.SetInput(blob, "")
+
+		// run a forward pass thru the network
+		prob := net.Forward("")
+
+		// reshape the results into a 1x1000 matrix
+		probMat := prob.Reshape(1, 1)
+
+		// determine the most probable classification
+		_, maxVal, _, maxLoc := gocv.MinMaxLoc(probMat)
+
+		// display classification
+		status = fmt.Sprintf("description: %v, maxVal: %v\n", descriptions[maxLoc.X], maxVal)
+		gocv.PutText(&img, status, image.Pt(10, 20), gocv.FontHersheyPlain, 1.2, statusColor, 2)
+
+		blob.Close()
+		prob.Close()
+		probMat.Close()
+
+		window.IMShow(img)
+		if window.WaitKey(1) >= 0 {
+			break
+		}
+	}
+}
+
+// readDescriptions reads the descriptions from a file
+// and returns a slice of its lines.
+func readDescriptions(path string) ([]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	return lines, scanner.Err()
+}

--- a/dnn.cpp
+++ b/dnn.cpp
@@ -15,6 +15,11 @@ Net Net_ReadNetFromTensorflow(const char* model) {
     return n;
 }
 
+Net Net_ReadNetFromModelOptimizer(const char* xml, const char* bin) {
+    Net n = new cv::dnn::Net(cv::dnn::readNetFromModelOptimizer(xml, bin));
+    return n;
+}
+
 void Net_Close(Net net) {
     delete net;
 }

--- a/dnn.go
+++ b/dnn.go
@@ -207,6 +207,20 @@ func ReadNetFromTensorflow(model string) Net {
 	return Net{p: unsafe.Pointer(C.Net_ReadNetFromTensorflow(cmodel))}
 }
 
+// ReadNetFromTensorflow reads a model from Intel's Model Optimizer intermediate representation.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d6/d0f/group__dnn.html#ga4f3b552113d2bff48a54e168791c448e
+//
+func ReadNetFromModelOptimizer(xml string, bin string) Net {
+	cxml := C.CString(xml)
+	defer C.free(unsafe.Pointer(cxml))
+
+	cbin := C.CString(bin)
+	defer C.free(unsafe.Pointer(cbin))
+	return Net{p: unsafe.Pointer(C.Net_ReadNetFromModelOptimizer(cxml, cbin))}
+}
+
 // BlobFromImage creates 4-dimensional blob from image. Optionally resizes and crops
 // image from center, subtract mean values, scales values by scalefactor,
 // swap Blue and Red channels.

--- a/dnn.h
+++ b/dnn.h
@@ -22,6 +22,7 @@ typedef void* Layer;
 Net Net_ReadNet(const char* model, const char* config);
 Net Net_ReadNetFromCaffe(const char* prototxt, const char* caffeModel);
 Net Net_ReadNetFromTensorflow(const char* model);
+Net Net_ReadNetFromModelOptimizer(const char* xml, const char* bin);
 Mat Net_BlobFromImage(Mat image, double scalefactor, Size size, Scalar mean, bool swapRB,
                       bool crop);
 void Net_Close(Net net);


### PR DESCRIPTION
Hi, this PR is for adding support for reading nets using the openvino Model Optimizer intermediate representation.

For running the test you need to have openvino installed and also define an environment variable GOCV_MODELOPTIMIZER_TEST_FILES pointing to a folder with the bvlc_googlenet optimized model.

You could create it this way:
`python3 /opt/intel/computer_vision_sdk/deployment_tools/model_optimizer/mo_caffe.py --input_model ~/Downloads/bvlc_googlenet.caffemodel --input_proto ~/Downloads/bvlc_googlenet.prototxt`
And then move the xml and bin files to the test files folder.

I don't now if you have to define something conditional for running the test only if openvino is installed?

Many thanks for the awesome gocv!!!
