### PR TITLE
Implement CLAHE to imgproc

### DIFF
--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -465,3 +465,20 @@ void FitLine(Contour points, Mat line, int distType, double param, double reps, 
 	}
 	cv::fitLine(pts, *line, distType, param, reps, aeps);
 }
+
+CLAHE CLAHE_Create() {
+    return new cv::Ptr<cv::CLAHE>(cv::createCLAHE());
+}
+
+CLAHE CLAHE_CreateWithParams(double clipLimit, Size tileGridSize) {
+    cv::Size sz(tileGridSize.width, tileGridSize.height);
+    return new cv::Ptr<cv::CLAHE>(cv::createCLAHE(clipLimit, sz));
+}
+
+void CLAHE_Close(CLAHE c) {
+    delete c;
+}
+
+void CLAHE_Apply(CLAHE c, Mat src, Mat dst) {
+    (*c)->apply(*src, *dst);
+}

--- a/imgproc.go
+++ b/imgproc.go
@@ -1292,3 +1292,47 @@ func FitLine(pts []image.Point, line *Mat, distType DistanceTypes, param, reps, 
 	cPoints := toCPoints(pts)
 	C.FitLine(cPoints, line.p, C.int(distType), C.double(param), C.double(reps), C.double(aeps))
 }
+
+// CLAHE is a wrapper around the cv::CLAHE algorithm.
+type CLAHE struct {
+	// C.CLAHE
+	p unsafe.Pointer
+}
+
+// NewCLAHE returns a new CLAHE algorithm
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d6/db6/classcv_1_1CLAHE.html
+//
+func NewCLAHE() CLAHE {
+	return CLAHE{p: unsafe.Pointer(C.CLAHE_Create())}
+}
+
+// NewCLAHEWithParams returns a new CLAHE algorithm
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d6/db6/classcv_1_1CLAHE.html
+//
+func NewCLAHEWithParams(clipLimit float64, tileGridSize image.Point) CLAHE {
+	pSize := C.struct_Size{
+		width:  C.int(tileGridSize.X),
+		height: C.int(tileGridSize.Y),
+	}
+	return CLAHE{p: unsafe.Pointer(C.CLAHE_CreateWithParams(C.double(clipLimit), pSize))}
+}
+
+// Close CLAHE.
+func (c *CLAHE) Close() error {
+	C.CLAHE_Close((C.CLAHE)(c.p))
+	c.p = nil
+	return nil
+}
+
+// Apply CLAHE.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d6/db6/classcv_1_1CLAHE.html#a4e92e0e427de21be8d1fae8dcd862c5e
+//
+func (c *CLAHE) Apply(src Mat, dst *Mat) {
+	C.CLAHE_Apply((C.CLAHE)(c.p), src.p, dst.p)
+}

--- a/imgproc.h
+++ b/imgproc.h
@@ -14,7 +14,6 @@ typedef cv::Ptr<cv::CLAHE>* CLAHE;
 typedef void* CLAHE;
 #endif
 
-
 #include "core.h"
 
 double ArcLength(Contour curve, bool is_closed);

--- a/imgproc.h
+++ b/imgproc.h
@@ -8,6 +8,13 @@
 extern "C" {
 #endif
 
+#ifdef __cplusplus
+typedef cv::Ptr<cv::CLAHE>* CLAHE;
+#else
+typedef void* CLAHE;
+#endif
+
+
 #include "core.h"
 
 double ArcLength(Contour curve, bool is_closed);
@@ -79,6 +86,11 @@ void Filter2D(Mat src, Mat dst, int ddepth, Mat kernel, Point anchor, double del
 void SepFilter2D(Mat src, Mat dst, int ddepth, Mat kernelX, Mat kernelY, Point anchor, double delta, int borderType);
 void LogPolar(Mat src, Mat dst, Point center, double m, int flags);
 void FitLine(Contour points, Mat line, int distType, double param, double reps, double aeps);
+CLAHE CLAHE_Create();
+CLAHE CLAHE_CreateWithParams(double clipLimit, Size tileGridSize);
+void CLAHE_Close(CLAHE c);
+void CLAHE_Apply(CLAHE c, Mat src, Mat dst);
+
 #ifdef __cplusplus
 }
 #endif

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -1178,10 +1178,10 @@ func TestCLAHEWithParams(t *testing.T) {
 	dst := NewMat()
 	defer dst.Close()
 
-	c := NewCLAHE()
+	c := NewCLAHEWithParams(2.0, image.Pt(10, 10))
 	defer c.Close()
 	c.Apply(src, &dst)
 	if dst.Empty() || img.Rows() != dst.Rows() || img.Cols() != dst.Cols() {
-		t.Error("Invalid NewCLAHE test")
+		t.Error("Invalid NewCLAHEWithParams test")
 	}
 }

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -1141,3 +1141,47 @@ func TestFitLine(t *testing.T) {
 		t.Errorf("FitLine(): line is empty")
 	}
 }
+
+func TestCLAHE(t *testing.T) {
+	img := IMRead("images/face-detect.jpg", IMReadGrayScale)
+	if img.Empty() {
+		t.Error("Invalid read of Mat in NewCLAHE test")
+	}
+	defer img.Close()
+
+	src := NewMat()
+	defer src.Close()
+	img.ConvertTo(&src, MatTypeCV8UC1)
+
+	dst := NewMat()
+	defer dst.Close()
+
+	c := NewCLAHE()
+	defer c.Close()
+	c.Apply(src, &dst)
+	if dst.Empty() || img.Rows() != dst.Rows() || img.Cols() != dst.Cols() {
+		t.Error("Invalid NewCLAHE test")
+	}
+}
+
+func TestCLAHEWithParams(t *testing.T) {
+	img := IMRead("images/face-detect.jpg", IMReadGrayScale)
+	if img.Empty() {
+		t.Error("Invalid read of Mat in CLAHEWithParams test")
+	}
+	defer img.Close()
+
+	src := NewMat()
+	defer src.Close()
+	img.ConvertTo(&src, MatTypeCV8UC1)
+
+	dst := NewMat()
+	defer dst.Close()
+
+	c := NewCLAHE()
+	defer c.Close()
+	c.Apply(src, &dst)
+	if dst.Empty() || img.Rows() != dst.Rows() || img.Cols() != dst.Cols() {
+		t.Error("Invalid NewCLAHE test")
+	}
+}


### PR DESCRIPTION
Hi, this PR is for adding the CLAHE that is one of the histogram equalization methods.

Maybe it's none of my business. I've added the official OpenCV link describing the CLAHE for your reference, although this reference's code is written by Python.
https://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_imgproc/py_histograms/py_histogram_equalization/py_histogram_equalization.html?highlight=clahe#clahe-contrast-limited-adaptive-histogram-equalization

As I'm not very familiar with both the OpenCV and gocv, please give me some comments if this PR has some problems, 
Thank you.