### PR TITLE
Added Bitwise Operations With Masks

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -326,16 +326,32 @@ void Mat_BitwiseAnd(Mat src1, Mat src2, Mat dst) {
     cv::bitwise_and(*src1, *src2, *dst);
 }
 
+void Mat_BitwiseAndWithMask(Mat src1, Mat src2, Mat dst, Mat mask){
+    cv::bitwise_and(*src1, *src2, *dst, *mask);
+}
+
 void Mat_BitwiseNot(Mat src1, Mat dst) {
     cv::bitwise_not(*src1, *dst);
+}
+
+void Mat_BitwiseNotWithMask(Mat src1, Mat dst, Mat mask) {
+    cv::bitwise_not(*src1, *dst, *mask);
 }
 
 void Mat_BitwiseOr(Mat src1, Mat src2, Mat dst) {
     cv::bitwise_or(*src1, *src2, *dst);
 }
 
+void Mat_BitwiseOrWithMask(Mat src1, Mat src2, Mat dst, Mat mask) {
+    cv::bitwise_or(*src1, *src2, *dst, *mask);
+}
+
 void Mat_BitwiseXor(Mat src1, Mat src2, Mat dst) {
     cv::bitwise_xor(*src1, *src2, *dst);
+}
+
+void Mat_BitwiseXorWithMask(Mat src1, Mat src2, Mat dst, Mat mask) {
+    cv::bitwise_xor(*src1, *src2, *dst, *mask);
 }
 
 void Mat_BatchDistance(Mat src1, Mat src2, Mat dist, int dtype, Mat nidx, int normType, int K,

--- a/core.go
+++ b/core.go
@@ -788,6 +788,17 @@ func BitwiseAnd(src1 Mat, src2 Mat, dst *Mat) {
 	C.Mat_BitwiseAnd(src1.p, src2.p, dst.p)
 }
 
+// BitwiseAndWithMask computes bitwise conjunction of the two arrays (dst = src1 & src2).
+// Calculates the per-element bit-wise conjunction of two arrays
+// or an array and a scalar. It has an additional parameter for a mask.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d2/de8/group__core__array.html#ga60b4d04b251ba5eb1392c34425497e14
+//
+func BitwiseAndWithMask(src1 Mat, src2 Mat, dst *Mat, mask Mat) {
+	C.Mat_BitwiseAndWithMask(src1.p, src2.p, dst.p, mask.p)
+}
+
 // BitwiseNot inverts every bit of an array.
 //
 // For further details, please see:
@@ -795,6 +806,15 @@ func BitwiseAnd(src1 Mat, src2 Mat, dst *Mat) {
 //
 func BitwiseNot(src1 Mat, dst *Mat) {
 	C.Mat_BitwiseNot(src1.p, dst.p)
+}
+
+// BitwiseNotWithMask inverts every bit of an array. It has an additional parameter for a mask.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d2/de8/group__core__array.html#ga0002cf8b418479f4cb49a75442baee2f
+//
+func BitwiseNotWithMask(src1 Mat, dst *Mat, mask Mat) {
+	C.Mat_BitwiseNotWithMask(src1.p, dst.p, mask.p)
 }
 
 // BitwiseOr calculates the per-element bit-wise disjunction of two arrays
@@ -807,6 +827,16 @@ func BitwiseOr(src1 Mat, src2 Mat, dst *Mat) {
 	C.Mat_BitwiseOr(src1.p, src2.p, dst.p)
 }
 
+// BitwiseOrWithMask calculates the per-element bit-wise disjunction of two arrays
+// or an array and a scalar. It has an additional parameter for a mask.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d2/de8/group__core__array.html#gab85523db362a4e26ff0c703793a719b4
+//
+func BitwiseOrWithMask(src1 Mat, src2 Mat, dst *Mat, mask Mat) {
+	C.Mat_BitwiseOrWithMask(src1.p, src2.p, dst.p, mask.p)
+}
+
 // BitwiseXor calculates the per-element bit-wise "exclusive or" operation
 // on two arrays or an array and a scalar.
 //
@@ -815,6 +845,16 @@ func BitwiseOr(src1 Mat, src2 Mat, dst *Mat) {
 //
 func BitwiseXor(src1 Mat, src2 Mat, dst *Mat) {
 	C.Mat_BitwiseXor(src1.p, src2.p, dst.p)
+}
+
+// BitwiseXorWithMask calculates the per-element bit-wise "exclusive or" operation
+// on two arrays or an array and a scalar. It has an additional parameter for a mask.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d2/de8/group__core__array.html#ga84b2d8188ce506593dcc3f8cd00e8e2c
+//
+func BitwiseXorWithMask(src1 Mat, src2 Mat, dst *Mat, mask Mat) {
+	C.Mat_BitwiseXorWithMask(src1.p, src2.p, dst.p, mask.p)
 }
 
 // BatchDistance is a naive nearest neighbor finder.

--- a/core.h
+++ b/core.h
@@ -268,9 +268,13 @@ void Mat_AbsDiff(Mat src1, Mat src2, Mat dst);
 void Mat_Add(Mat src1, Mat src2, Mat dst);
 void Mat_AddWeighted(Mat src1, double alpha, Mat src2, double beta, double gamma, Mat dst);
 void Mat_BitwiseAnd(Mat src1, Mat src2, Mat dst);
+void Mat_BitwiseAndWithMask(Mat src1, Mat src2, Mat dst, Mat mask);
 void Mat_BitwiseNot(Mat src1, Mat dst);
+void Mat_BitwiseNotWithMask(Mat src1, Mat dst, Mat mask);
 void Mat_BitwiseOr(Mat src1, Mat src2, Mat dst);
+void Mat_BitwiseOrWithMask(Mat src1, Mat src2, Mat dst, Mat mask);
 void Mat_BitwiseXor(Mat src1, Mat src2, Mat dst);
+void Mat_BitwiseXorWithMask(Mat src1, Mat src2, Mat dst, Mat mask);
 void Mat_Compare(Mat src1, Mat src2, Mat dst, int ct);
 void Mat_BatchDistance(Mat src1, Mat src2, Mat dist, int dtype, Mat nidx, int normType, int K,
                        Mat mask, int update, bool crosscheck);

--- a/core_test.go
+++ b/core_test.go
@@ -843,6 +843,35 @@ func TestMatBitwiseOperations(t *testing.T) {
 
 }
 
+func TestMatBitwiseOperationsWithMasks(t *testing.T) {
+	mat1 := NewMatWithSize(101, 102, MatTypeCV8U)
+	defer mat1.Close()
+	mat2 := NewMatWithSize(101, 102, MatTypeCV8U)
+	defer mat2.Close()
+	mat3 := NewMat()
+	defer mat3.Close()
+	mat4 := NewMatWithSize(101, 102, MatTypeCV8U)
+	defer mat4.Close()
+	BitwiseAndWithMask(mat1, mat2, &mat3, mat4)
+	if mat3.Empty() {
+		t.Error("TestMatBitwiseAndWithMask dest mat3 should not be empty.")
+	}
+
+	BitwiseOrWithMask(mat1, mat2, &mat3, mat4)
+	if mat3.Empty() {
+		t.Error("TestMatBitwiseOrWithMask dest mat3 should not be empty.")
+	}
+
+	BitwiseXorWithMask(mat1, mat2, &mat3, mat4)
+	if mat3.Empty() {
+		t.Error("TestMatBitwiseXorWithMask dest mat3 should not be empty.")
+	}
+	BitwiseNotWithMask(mat1, &mat3, mat4)
+	if mat3.Empty() {
+		t.Error("TestMatBitwiseNotWithMask dest mat3 should not be empty.")
+	}
+}
+
 func TestMatInRange(t *testing.T) {
 	mat1 := NewMatWithSize(101, 102, MatTypeCV8U)
 	defer mat1.Close()


### PR DESCRIPTION
The current bitwise operations don't have a parameter for a mask (I needed the mask parameter for a project), so I added new functions with this parameter - BitwiseAndWithMask, BitwiseNotWithMask, BitwiseOrWithMask, and BitwiseXorWithMask. Thanks!

