### PR TITLE
RFC: Add KMeans function

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -485,6 +485,21 @@ double Mat_Invert(Mat src, Mat dst, int flags) {
     return ret;
 }
 
+double KMeans(Mat data, int k, Mat bestLabels, TermCriteria criteria, int attempts, int flags, Mat centers) {
+    double ret = cv::kmeans(*data, k, *bestLabels, *criteria, attempts, flags, *centers);
+    return ret;
+}
+
+double KMeansPoints(Contour points, int k, Mat bestLabels, TermCriteria criteria, int attempts, int flags, Mat centers) {
+    std::vector<cv::Point2f> pts;
+
+    for (size_t i = 0; i < points.length; i++) {
+        pts.push_back(cv::Point2f(points.points[i].x, points.points[i].y));
+    }
+    double ret = cv::kmeans(pts, k, *bestLabels, *criteria, attempts, flags, *centers);
+    return ret;
+}
+
 void Mat_Log(Mat src, Mat dst) {
     cv::log(*src, *dst);
 }

--- a/core.go
+++ b/core.go
@@ -1246,6 +1246,43 @@ func Invert(src Mat, dst *Mat, flags int) float64 {
 	return float64(ret)
 }
 
+// KMeansFlags for kmeans center selection
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d0/de1/group__core.html#ga276000efe55ee2756e0c471c7b270949
+type KMeansFlags int
+
+const (
+	// KMeansRandomCenters selects random initial centers in each attempt.
+	KMeansRandomCenters KMeansFlags = 0
+	// KMeansPPCenters uses kmeans++ center initialization by Arthur and Vassilvitskii [Arthur2007].
+	KMeansPPCenters = 1
+	// KMeansUseInitialLabels uses the user-supplied lables during the first (and possibly the only) attempt
+	// instead of computing them from the initial centers. For the second and further attempts, use the random or semi-random     // centers. Use one of KMEANS_*_CENTERS flag to specify the exact method.
+	KMeansUseInitialLabels = 2
+)
+
+// KMeans finds centers of clusters and groups input samples around the clusters.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d5/d38/group__core__cluster.html#ga9a34dc06c6ec9460e90860f15bcd2f88
+//
+func KMeans(data Mat, k int, bestLabels *Mat, criteria TermCriteria, attempts int, flags KMeansFlags, centers *Mat) float64 {
+	ret := C.KMeans(data.p, C.int(k), bestLabels.p, criteria.p, C.int(attempts), C.int(flags), centers.p)
+	return float64(ret)
+}
+
+// KMeansPoints finds centers of clusters and groups input samples around the clusters.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d5/d38/group__core__cluster.html#ga9a34dc06c6ec9460e90860f15bcd2f88
+//
+func KMeansPoints(points []image.Point, k int, bestLabels *Mat, criteria TermCriteria, attempts int, flags KMeansFlags, centers *Mat) float64 {
+	cPoints := toCPoints(points)
+	ret := C.KMeansPoints(cPoints, C.int(k), bestLabels.p, criteria.p, C.int(attempts), C.int(flags), centers.p)
+	return float64(ret)
+}
+
 // Log calculates the natural logarithm of every array element.
 //
 // For further details, please see:

--- a/core.h
+++ b/core.h
@@ -331,6 +331,8 @@ void Mat_InRange(Mat src, Mat lowerb, Mat upperb, Mat dst);
 void Mat_InRangeWithScalar(Mat src, const Scalar lowerb, const Scalar upperb, Mat dst);
 void Mat_InsertChannel(Mat src, Mat dst, int coi);
 double Mat_Invert(Mat src, Mat dst, int flags);
+double KMeans(Mat data, int k, Mat bestLabels, TermCriteria criteria, int attempts, int flags, Mat centers);
+double KMeansPoints(Contour points, int k, Mat bestLabels, TermCriteria criteria, int attempts, int flags, Mat centers);
 void Mat_Log(Mat src, Mat dst);
 void Mat_Magnitude(Mat x, Mat y, Mat magnitude);
 void Mat_Max(Mat src1, Mat src2, Mat dst);

--- a/core_test.go
+++ b/core_test.go
@@ -1828,6 +1828,40 @@ func TestMatInvert(t *testing.T) {
 	}
 }
 
+func TestKMeans(t *testing.T) {
+	src := NewMatWithSize(4, 4, MatTypeCV32F) // only implemented for symm. Mats
+	defer src.Close()
+
+	bestLabels := NewMat()
+	defer bestLabels.Close()
+
+	centers := NewMat()
+	defer centers.Close()
+
+	criteria := NewTermCriteria(Count, 10, 1.0)
+	KMeans(src, 2, &bestLabels, criteria, 2, KMeansRandomCenters, &centers)
+	if bestLabels.Empty() {
+		t.Error("bla")
+	}
+}
+
+func TestKMeansPoints(t *testing.T) {
+	points := []image.Point{
+		image.Pt(0, 0),
+		image.Pt(1, 1),
+	}
+	bestLabels := NewMat()
+	defer bestLabels.Close()
+	centers := NewMat()
+	defer centers.Close()
+
+	criteria := NewTermCriteria(Count, 10, 1.0)
+	KMeansPoints(points, 2, &bestLabels, criteria, 2, KMeansRandomCenters, &centers)
+	if bestLabels.Empty() || bestLabels.Size()[0] != len(points) {
+		t.Error("Labels is not proper")
+	}
+}
+
 func TestMatLog(t *testing.T) {
 	src := NewMatWithSize(4, 3, MatTypeCV32F)
 	defer src.Close()


### PR DESCRIPTION
Added the KMeans function.

However, I also realized that I wanted to call the function on a `[]image.Point` to cluster a bunch of contour points and not just a `Mat` type; so my solution was to create a `KMeansPoints` function.

Please let me know if there is a better way to do it and that function isn't required. If it is required, please let me know if you would like to rename it to something better.