### PR TITLE
Added ToCodec to convert FOURCC string to numeric representation

### DIFF
--- a/videoio.go
+++ b/videoio.go
@@ -236,7 +236,7 @@ func (v *VideoCapture) CodecString() string {
 // ToCodec returns an float64 representation of FourCC bytes
 func (v *VideoCapture) ToCodec(codec string) float64 {
 	if len(codec) != 4 {
-		panic("Invalid codec string")
+		return -1.0
 	}
 	c1 := []rune(string(codec[0]))[0]
 	c2 := []rune(string(codec[1]))[0]

--- a/videoio.go
+++ b/videoio.go
@@ -233,6 +233,18 @@ func (v *VideoCapture) CodecString() string {
 	return res
 }
 
+// ToCodec returns an float64 representation of FourCC bytes
+func (v *VideoCapture) ToCodec(codec string) float64 {
+	if len(codec) != 4 {
+		panic("Invalid codec string")
+	}
+	c1 := []rune(string(codec[0]))[0]
+	c2 := []rune(string(codec[1]))[0]
+	c3 := []rune(string(codec[2]))[0]
+	c4 := []rune(string(codec[3]))[0]
+	return float64((c1 & 255) + ((c2 & 255) << 8) + ((c3 & 255) << 16) + ((c4 & 255) << 24))
+}
+
 // VideoWriter is a wrapper around the OpenCV VideoWriter`class.
 //
 // For further details, please see:

--- a/videoio_test.go
+++ b/videoio_test.go
@@ -30,7 +30,6 @@ func TestVideoCaptureCodecString(t *testing.T) {
 }
 
 func TestVideoCaptureCodecConversion(t *testing.T) {
-
 	vc, err := OpenVideoCapture("images/small.mp4")
 	if err != nil {
 		t.Errorf("TestVideoCaptureCodecConversion: error loading a file: %v", err)
@@ -38,11 +37,20 @@ func TestVideoCaptureCodecConversion(t *testing.T) {
 	if vc.CodecString() == "" {
 		t.Fatal("TestVideoCaptureCodecConversion: empty codec string")
 	}
-
 	if int64(vc.ToCodec(vc.CodecString())) != int64(vc.Get(VideoCaptureFOURCC)) {
 		t.Fatal("TestVideoCaptureCodecConversion: codec conversion failed")
 	}
+}
 
+func TestVideoCaptureCodecConversionBadInput(t *testing.T) {
+	vc, err := OpenVideoCapture("images/small.mp4")
+	if err != nil {
+		t.Errorf("TestVideoCaptureCodecConversionBadInput: error loading a file: %v", err)
+	}
+	codec := vc.ToCodec("BAD CODEC")
+	if int64(codec) != -1 {
+		t.Fatal("TestVideoCaptureCodecConversionBadInput: input validation failed")
+	}
 }
 
 func TestVideoCaptureInvalid(t *testing.T) {

--- a/videoio_test.go
+++ b/videoio_test.go
@@ -29,6 +29,22 @@ func TestVideoCaptureCodecString(t *testing.T) {
 	}
 }
 
+func TestVideoCaptureCodecConversion(t *testing.T) {
+
+	vc, err := OpenVideoCapture("images/small.mp4")
+	if err != nil {
+		t.Errorf("TestVideoCaptureCodecConversion: error loading a file: %v", err)
+	}
+	if vc.CodecString() == "" {
+		t.Fatal("TestVideoCaptureCodecConversion: empty codec string")
+	}
+
+	if int64(vc.ToCodec(vc.CodecString())) != int64(vc.Get(VideoCaptureFOURCC)) {
+		t.Fatal("TestVideoCaptureCodecConversion: codec conversion failed")
+	}
+
+}
+
 func TestVideoCaptureInvalid(t *testing.T) {
 	_, err := OpenVideoCapture(1.1)
 	if err == nil {


### PR DESCRIPTION
Similarly to `CodecString`, the `ToCodec(codec)` method returns a value that can be used in `VideoCapture.Set`

Example: `vc.Set(gocv.VideoCaptureFOURCC, vc.ToCodec("MJPG"))`