### PR TITLE
Tolerate imprecise result in SolvePoly

### DIFF
--- a/core_test.go
+++ b/core_test.go
@@ -1140,9 +1140,9 @@ func TestSolvePoly(t *testing.T) {
 
 	diffError := SolvePoly(coeffs, &roots, 300)
 
-	expectedDiffError := 0.0
-	if diffError != expectedDiffError {
-		t.Errorf("TestSolvePoly was not exact, got an error of %f and should have been %f", diffError, expectedDiffError)
+	diffTolerance := 1.0e-61
+	if diffError > diffTolerance {
+		t.Errorf("TestSolvePoly was not exact, got an error of %e and should have been less than %f", diffError, diffTolerance)
 	}
 
 	if roots.GetFloatAt(0, 0) != 7.0 {


### PR DESCRIPTION
The SolvePoly test TestSolvePoly generates a result that is slightly
imprecise on aarch64 (~2.75e-62) as opposed to a precise result on
x86_64.  This change adjusts the test to tolerate this imprecision.