### PR TITLE
Tolerate imprecision in TestHoughLines

### DIFF
--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -757,7 +757,8 @@ func TestHoughLines(t *testing.T) {
 	if dest.Empty() {
 		t.Error("Empty HoughLines test")
 	}
-	if dest.Rows() != 10411 {
+	rowsDiff := dest.Rows() - 10411
+	if rowsDiff > 2 || rowsDiff < 0 {
 		t.Errorf("Invalid HoughLines test rows: %v", dest.Rows())
 	}
 	if dest.Cols() != 1 {


### PR DESCRIPTION
TestHoughLines in opencv generates a slightly different result for the
TestHoughLines test on arm64 when opencv is built in RELEASE mode
because of differences in rounding.  This is because the
TestHoughLinesStandard code ends up using the fused FMADD instead of
separate FMUL and FADD instructions on arm64 and ends up having
rounding semantics that are different from x86.  x86 does not use
fused FMA instructions in its default build.

Building opencv in DEBUG mode hides this error because the multiply
and add ops don't get fused.  Additionally, a comment in cvRound
function in opencv specifies that calling code must tolerate an error
of +/-1 and given that the function is used in a loop to normalise
multiple values in HoughLines, the error adds up.

Fix up the test case to tolerate imprecision seen on arm64.