### PR TITLE
imgcodecs: optimize copy of data used for IMDecode method

### DIFF
--- a/imgcodecs.cpp
+++ b/imgcodecs.cpp
@@ -40,12 +40,7 @@ struct ByteArray Image_IMEncode_WithParams(const char* fileExt, Mat img, IntVect
 }
 
 Mat Image_IMDecode(ByteArray buf, int flags) {
-    std::vector<uchar> data;
-
-    for (size_t i = 0; i < buf.length; i++) {
-        data.push_back(buf.data[i]);
-    }
-
+    std::vector<uchar> data(buf.data, buf.data + buf.length);
     cv::Mat img = cv::imdecode(data, flags);
     return new cv::Mat(img);
 }


### PR DESCRIPTION
This PR optimizes the copying of data used for IMDecode method, to improve in-memory only performance.