### PR TITLE
dnn: respect the bit depth of the input image to set the expected output

### DIFF
--- a/dnn.cpp
+++ b/dnn.cpp
@@ -97,10 +97,17 @@ void Net_GetUnconnectedOutLayers(Net net, IntVector* res) {
 Mat Net_BlobFromImage(Mat image, double scalefactor, Size size, Scalar mean, bool swapRB,
                       bool crop) {
     cv::Size sz(size.width, size.height);
-    cv::Scalar cm = cv::Scalar(mean.val1, mean.val2, mean.val3, mean.val4);
 
-    // TODO: handle different version signatures of this function v2 vs v3.
-    return new cv::Mat(cv::dnn::blobFromImage(*image, scalefactor, sz, cm, swapRB, crop));
+    // set the output ddepth to the input image depth
+    int ddepth = image->depth();
+    if (ddepth == CV_8U)
+    {
+        // no scalar mean adjustment allowed, so ignore
+        return new cv::Mat(cv::dnn::blobFromImage(*image, scalefactor, sz, NULL, swapRB, crop, ddepth));
+    }
+
+    cv::Scalar cm(mean.val1, mean.val2, mean.val3, mean.val4);
+    return new cv::Mat(cv::dnn::blobFromImage(*image, scalefactor, sz, cm, swapRB, crop, ddepth));
 }
 
 void Net_BlobFromImages(struct Mats images, Mat blob, double scalefactor, Size size,

--- a/dnn_test.go
+++ b/dnn_test.go
@@ -60,11 +60,11 @@ func TestReadNet(t *testing.T) {
 		defer probMat.Close()
 		_, maxVal, minLoc, maxLoc := MinMaxLoc(probMat)
 
-		if round(float64(maxVal), 0.00005) != 0.99995 {
+		if round(float64(maxVal), 0.00005) != 0.9998 {
 			t.Errorf("ReadNet maxVal incorrect: %v\n", round(float64(maxVal), 0.00005))
 		}
 
-		if minLoc.X != 793 || minLoc.Y != 0 {
+		if minLoc.X != 955 || minLoc.Y != 0 {
 			t.Errorf("ReadNet minLoc incorrect: %v\n", minLoc)
 		}
 
@@ -140,11 +140,11 @@ func TestCaffe(t *testing.T) {
 		defer probMat.Close()
 		_, maxVal, minLoc, maxLoc := MinMaxLoc(probMat)
 
-		if round(float64(maxVal), 0.00005) != 0.99995 {
+		if round(float64(maxVal), 0.00005) != 0.9998 {
 			t.Errorf("Caffe maxVal incorrect: %v\n", round(float64(maxVal), 0.00005))
 		}
 
-		if minLoc.X != 793 || minLoc.Y != 0 {
+		if minLoc.X != 955 || minLoc.Y != 0 {
 			t.Errorf("Caffe minLoc incorrect: %v\n", minLoc)
 		}
 
@@ -198,7 +198,7 @@ func TestTensorflow(t *testing.T) {
 		}
 		defer img.Close()
 
-		blob := BlobFromImage(img, 1.0, image.Pt(224, 224), NewScalar(0, 0, 0, 0), true, false)
+		blob := BlobFromImage(img, 1.0, image.Pt(224, 224), NewScalar(127.5, 127.5, 127.5, 0), true, false)
 		if blob.Empty() {
 			t.Error("Invalid blob in Tensorflow test")
 		}
@@ -280,6 +280,21 @@ func TestBlobFromImages(t *testing.T) {
 	sz := GetBlobSize(blob)
 	if sz.Val1 != 2 || sz.Val2 != 3 || sz.Val3 != 25 || sz.Val4 != 25 {
 		t.Errorf("GetBlobSize in BlobFromImages retrieved wrong values")
+	}
+}
+
+func TestBlobFromImageGreyscale(t *testing.T) {
+	img := IMRead("images/space_shuttle.jpg", IMReadGrayScale)
+	if img.Empty() {
+		t.Error("Invalid Mat in TestBlobFromImageGreyscale test")
+	}
+	defer img.Close()
+
+	blob := BlobFromImage(img, 1.0, image.Pt(100, 100), NewScalar(127.5, 127.5, 127.5, 0), false, false)
+	defer blob.Close()
+
+	if blob.Empty() {
+		t.Errorf("BlobFromImageGreyscale failed to create blob")
 	}
 }
 


### PR DESCRIPTION
This PR respects the bit depth of the input image to set the expected output when converting an image to a blob. Needed to allow for proper DNN handling of greyscale images.