### PR TITLE
 Fix memory leak in Mat.Size() and Mat.Split()

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -761,3 +761,6 @@ Mat Mat_colRange(Mat m,int startrow,int endrow) {
     return new cv::Mat(m->colRange(startrow,endrow));
 }
 
+void IntVector_Close(struct IntVector ivec) {
+    delete[] ivec.val;
+}

--- a/core.go
+++ b/core.go
@@ -287,6 +287,7 @@ func (m *Mat) Total() int {
 func (m *Mat) Size() (dims []int) {
 	cdims := C.IntVector{}
 	C.Mat_Size(m.p, &cdims)
+	defer C.IntVector_Close(cdims)
 
 	h := &reflect.SliceHeader{
 		Data: uintptr(unsafe.Pointer(cdims.val)),
@@ -1718,6 +1719,7 @@ func SortIdx(src Mat, dst *Mat, flags SortFlags) {
 func Split(src Mat) (mv []Mat) {
 	cMats := C.struct_Mats{}
 	C.Mat_Split(src.p, &(cMats))
+	defer C.Mats_Close(cMats)
 	mv = make([]Mat, cMats.length)
 	for i := C.int(0); i < cMats.length; i++ {
 		mv[i].p = C.Mats_get(cMats, i)

--- a/core.h
+++ b/core.h
@@ -378,6 +378,8 @@ double GetTickFrequency();
 Mat Mat_rowRange(Mat m,int startrow,int endrow);
 Mat Mat_colRange(Mat m,int startrow,int endrow);
 
+void IntVector_Close(struct IntVector ivec);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This patch fix #394 and #486.