### PR TITLE
Remove breaking case statement

### DIFF
--- a/cuda/cudawarping_string.go
+++ b/cuda/cudawarping_string.go
@@ -30,8 +30,6 @@ func (c BorderType) String() string {
 		return "border-reflect101"
 	case BorderTransparent:
 		return "border-transparent"
-	case BorderDefault:
-		return "border-default"
 	case BorderIsolated:
 		return "border-isolated"
 	}


### PR DESCRIPTION
like the above func, the case for the BorderDefault is referring to another item in the enum, which breaks the switch statement (BorderDefault = BorderReflect101 = 4 in the enum)