### PR TITLE
Threshold() should return a value

### DIFF
--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -382,8 +382,8 @@ void Integral(Mat src, Mat sum, Mat sqsum, Mat tilted) {
     cv::integral(*src, *sum, *sqsum, *tilted);
 }
 
-void Threshold(Mat src, Mat dst, double thresh, double maxvalue, int typ) {
-    cv::threshold(*src, *dst, thresh, maxvalue, typ);
+double Threshold(Mat src, Mat dst, double thresh, double maxvalue, int typ) {
+    return cv::threshold(*src, *dst, thresh, maxvalue, typ);
 }
 
 void AdaptiveThreshold(Mat src, Mat dst, double maxValue, int adaptiveMethod, int thresholdType,

--- a/imgproc.go
+++ b/imgproc.go
@@ -1124,8 +1124,8 @@ const (
 // For further details, please see:
 // https://docs.opencv.org/3.3.0/d7/d1b/group__imgproc__misc.html#gae8a4a146d1ca78c626a53577199e9c57
 //
-func Threshold(src Mat, dst *Mat, thresh float32, maxvalue float32, typ ThresholdType) {
-	C.Threshold(src.p, dst.p, C.double(thresh), C.double(maxvalue), C.int(typ))
+func Threshold(src Mat, dst *Mat, thresh float32, maxvalue float32, typ ThresholdType) (threshold float32) {
+	return float32( C.Threshold(src.p, dst.p, C.double(thresh), C.double(maxvalue), C.int(typ)) )
 }
 
 // AdaptiveThresholdType type of adaptive threshold operation.

--- a/imgproc.go
+++ b/imgproc.go
@@ -1125,7 +1125,7 @@ const (
 // https://docs.opencv.org/3.3.0/d7/d1b/group__imgproc__misc.html#gae8a4a146d1ca78c626a53577199e9c57
 //
 func Threshold(src Mat, dst *Mat, thresh float32, maxvalue float32, typ ThresholdType) (threshold float32) {
-	return float32( C.Threshold(src.p, dst.p, C.double(thresh), C.double(maxvalue), C.int(typ)) )
+	return float32(C.Threshold(src.p, dst.p, C.double(thresh), C.double(maxvalue), C.int(typ)))
 }
 
 // AdaptiveThresholdType type of adaptive threshold operation.

--- a/imgproc.h
+++ b/imgproc.h
@@ -70,7 +70,7 @@ void HoughLinesPointSet(Mat points, Mat lines, int lines_max, int threshold,
                         double min_rho, double  max_rho, double rho_step,
                         double min_theta, double max_theta, double theta_step);
 void Integral(Mat src, Mat sum, Mat sqsum, Mat tilted);
-void Threshold(Mat src, Mat dst, double thresh, double maxvalue, int typ);
+double Threshold(Mat src, Mat dst, double thresh, double maxvalue, int typ);
 void AdaptiveThreshold(Mat src, Mat dst, double maxValue, int adaptiveTyp, int typ, int blockSize,
                        double c);
 


### PR DESCRIPTION
I'm new to both opencv and gocv.

The [OpenCV Threshold(...) function()](https://docs.opencv.org/3.3.0/d7/d1b/group__imgproc__misc.html#gae8a4a146d1ca78c626a53577199e9c57) returns a threshold value for use in later computations (eg. Canny edge detection). The [analogous GoCV function](https://pkg.go.dev/gocv.io/x/gocv?tab=doc#Threshold) operates on the destination Mat, but returns no value.

Hopefully this small change won't break things? I've used the float32 type for the returned value, but if it should be float64 please feel free to change.

Thanks for all your work on this fantastic set of bindings!

Mike Traynor.