### PR TITLE
Wrong documentation [cuda.go]

### DIFF
--- a/cuda/cuda.go
+++ b/cuda/cuda.go
@@ -1,7 +1,7 @@
 // Package cuda is the GoCV wrapper around OpenCV cuda.
 //
 // For further details, please see:
-// https://github.com/opencv/c
+// https://github.com/opencv/opencv
 //
 // import "gocv.io/x/gocv/cuda"
 package cuda


### PR DESCRIPTION
The path 
`https://github.com/opencv/opencv` does not exist
The relevant path should be?
`https://github.com/opencv/opencv`