### PR TITLE
Change constants and corresponding function signatures to have the correct types

### DIFF
--- a/core.go
+++ b/core.go
@@ -959,7 +959,7 @@ func BitwiseXorWithMask(src1 Mat, src2 Mat, dst *Mat, mask Mat) {
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga4ba778a1c57f83233b1d851c83f5a622
 //
-func BatchDistance(src1 Mat, src2 Mat, dist Mat, dtype int, nidx Mat, normType int, K int, mask Mat, update int, crosscheck bool) {
+func BatchDistance(src1 Mat, src2 Mat, dist Mat, dtype MatType, nidx Mat, normType NormType, K int, mask Mat, update int, crosscheck bool) {
 	C.Mat_BatchDistance(src1.p, src2.p, dist.p, C.int(dtype), nidx.p, C.int(normType), C.int(K), mask.p, C.int(update), C.bool(crosscheck))
 }
 
@@ -1005,7 +1005,7 @@ const (
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga017122d912af19d7d0d2cccc2d63819f
 //
-func CalcCovarMatrix(samples Mat, covar *Mat, mean *Mat, flags CovarFlags, ctype int) {
+func CalcCovarMatrix(samples Mat, covar *Mat, mean *Mat, flags CovarFlags, ctype MatType) {
 	C.Mat_CalcCovarMatrix(samples.p, covar.p, mean.p, C.int(flags), C.int(ctype))
 }
 
@@ -1651,7 +1651,7 @@ const (
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga4b78072a303f29d9031d56e5638da78e
 //
-func Reduce(src Mat, dst *Mat, dim int, rType ReduceTypes, dType int) {
+func Reduce(src Mat, dst *Mat, dim int, rType ReduceTypes, dType MatType) {
 	C.Mat_Reduce(src.p, dst.p, C.int(dim), C.int(rType), C.int(dType))
 }
 

--- a/core.go
+++ b/core.go
@@ -35,25 +35,25 @@ const (
 	MatTypeCV8U MatType = 0
 
 	// MatTypeCV8S is a Mat of 8-bit signed int
-	MatTypeCV8S = 1
+	MatTypeCV8S MatType = 1
 
 	// MatTypeCV16U is a Mat of 16-bit unsigned int
-	MatTypeCV16U = 2
+	MatTypeCV16U MatType = 2
 
 	// MatTypeCV16S is a Mat of 16-bit signed int
-	MatTypeCV16S = 3
+	MatTypeCV16S MatType = 3
 
 	// MatTypeCV16SC2 is a Mat of 16-bit signed int with 2 channels
 	MatTypeCV16SC2 = MatTypeCV16S + MatChannels2
 
 	// MatTypeCV32S is a Mat of 32-bit signed int
-	MatTypeCV32S = 4
+	MatTypeCV32S MatType = 4
 
 	// MatTypeCV32F is a Mat of 32-bit float
-	MatTypeCV32F = 5
+	MatTypeCV32F MatType = 5
 
 	// MatTypeCV64F is a Mat of 64-bit float
-	MatTypeCV64F = 6
+	MatTypeCV64F MatType = 6
 
 	// MatTypeCV8UC1 is a Mat of 8-bit unsigned int with a single channel
 	MatTypeCV8UC1 = MatTypeCV8U + MatChannels1
@@ -146,19 +146,19 @@ const (
 	CompareEQ CompareType = 0
 
 	// CompareGT src1 is greater than src2.
-	CompareGT = 1
+	CompareGT CompareType = 1
 
 	// CompareGE src1 is greater than or equal to src2.
-	CompareGE = 2
+	CompareGE CompareType = 2
 
 	// CompareLT src1 is less than src2.
-	CompareLT = 3
+	CompareLT CompareType = 3
 
 	// CompareLE src1 is less than or equal to src2.
-	CompareLE = 4
+	CompareLE CompareType = 4
 
 	// CompareNE src1 is unequal to src2.
-	CompareNE = 5
+	CompareNE CompareType = 5
 )
 
 type Point2f struct {
@@ -985,19 +985,19 @@ const (
 	CovarScrambled CovarFlags = 0
 
 	// CovarNormal indicates to use normal covariation.
-	CovarNormal = 1
+	CovarNormal CovarFlags = 1
 
 	// CovarUseAvg indicates to use average covariation.
-	CovarUseAvg = 2
+	CovarUseAvg CovarFlags = 2
 
 	// CovarScale indicates to use scaled covariation.
-	CovarScale = 4
+	CovarScale CovarFlags = 4
 
 	// CovarRows indicates to use covariation on rows.
-	CovarRows = 8
+	CovarRows CovarFlags = 8
 
 	// CovarCols indicates to use covariation on columns.
-	CovarCols = 16
+	CovarCols CovarFlags = 16
 )
 
 // CalcCovarMatrix calculates the covariance matrix of a set of vectors.
@@ -1093,24 +1093,24 @@ const (
 	DftForward DftFlags = 0
 
 	// DftInverse performs an inverse 1D or 2D transform.
-	DftInverse = 1
+	DftInverse DftFlags = 1
 
 	// DftScale scales the result: divide it by the number of array elements. Normally, it is combined with DFT_INVERSE.
-	DftScale = 2
+	DftScale DftFlags = 2
 
 	// DftRows performs a forward or inverse transform of every individual row of the input matrix.
-	DftRows = 4
+	DftRows DftFlags = 4
 
 	// DftComplexOutput performs a forward transformation of 1D or 2D real array; the result, though being a complex array, has complex-conjugate symmetry
-	DftComplexOutput = 16
+	DftComplexOutput DftFlags = 16
 
 	// DftRealOutput performs an inverse transformation of a 1D or 2D complex array; the result is normally a complex array of the same size,
 	// however, if the input array has conjugate-complex symmetry (for example, it is a result of forward transformation with DFT_COMPLEX_OUTPUT flag),
 	// the output is a real array.
-	DftRealOutput = 32
+	DftRealOutput DftFlags = 32
 
 	// DftComplexInput specifies that input is complex input. If this flag is set, the input must have 2 channels.
-	DftComplexInput = 64
+	DftComplexInput DftFlags = 64
 
 	// DctInverse performs an inverse 1D or 2D dct transform.
 	DctInverse = DftInverse
@@ -1260,9 +1260,9 @@ const (
 	// Rotate90Clockwise allows to rotate image 90 degrees clockwise
 	Rotate90Clockwise RotateFlag = 0
 	// Rotate180Clockwise allows to rotate image 180 degrees clockwise
-	Rotate180Clockwise = 1
+	Rotate180Clockwise RotateFlag = 1
 	// Rotate90CounterClockwise allows to rotate 270 degrees clockwise
-	Rotate90CounterClockwise = 2
+	Rotate90CounterClockwise RotateFlag = 2
 )
 
 // Rotate rotates a 2D array in multiples of 90 degrees
@@ -1353,10 +1353,10 @@ const (
 	// KMeansRandomCenters selects random initial centers in each attempt.
 	KMeansRandomCenters KMeansFlags = 0
 	// KMeansPPCenters uses kmeans++ center initialization by Arthur and Vassilvitskii [Arthur2007].
-	KMeansPPCenters = 1
+	KMeansPPCenters KMeansFlags = 1
 	// KMeansUseInitialLabels uses the user-supplied lables during the first (and possibly the only) attempt
 	// instead of computing them from the initial centers. For the second and further attempts, use the random or semi-random     // centers. Use one of KMEANS_*_CENTERS flag to specify the exact method.
-	KMeansUseInitialLabels = 2
+	KMeansUseInitialLabels KMeansFlags = 2
 )
 
 // KMeans finds centers of clusters and groups input samples around the clusters.
@@ -1509,28 +1509,28 @@ const (
 	NormInf NormType = 1
 
 	// NormL1 indicates use L1 normalization.
-	NormL1 = 2
+	NormL1 NormType = 2
 
 	// NormL2 indicates use L2 normalization.
-	NormL2 = 4
+	NormL2 NormType = 4
 
 	// NormL2Sqr indicates use L2 squared normalization.
-	NormL2Sqr = 5
+	NormL2Sqr NormType = 5
 
 	// NormHamming indicates use Hamming normalization.
-	NormHamming = 6
+	NormHamming NormType = 6
 
 	// NormHamming2 indicates use Hamming 2-bit normalization.
-	NormHamming2 = 7
+	NormHamming2 NormType = 7
 
 	// NormTypeMask indicates use type mask for normalization.
-	NormTypeMask = 7
+	NormTypeMask NormType = 7
 
 	// NormRelative indicates use relative normalization.
-	NormRelative = 8
+	NormRelative NormType = 8
 
 	// NormMinMax indicates use min/max normalization.
-	NormMinMax = 32
+	NormMinMax NormType = 32
 )
 
 // Normalize normalizes the norm or value range of an array.
@@ -1572,35 +1572,35 @@ const (
 	Count TermCriteriaType = 1
 
 	// MaxIter is the maximum number of iterations or elements to compute.
-	MaxIter = 1
+	MaxIter TermCriteriaType = 1
 
 	// EPS is the desired accuracy or change in parameters at which the
 	// iterative algorithm stops.
-	EPS = 2
+	EPS TermCriteriaType = 2
 )
 
 type SolveDecompositionFlags int
 
 const (
 	// Gaussian elimination with the optimal pivot element chosen.
-	SolveDecompositionLu = 0
+	SolveDecompositionLu SolveDecompositionFlags = 0
 
 	// Singular value decomposition (SVD) method. The system can be over-defined and/or the matrix src1 can be singular.
-	SolveDecompositionSvd = 1
+	SolveDecompositionSvd SolveDecompositionFlags = 1
 
 	// Eigenvalue decomposition. The matrix src1 must be symmetrical.
-	SolveDecompositionEing = 2
+	SolveDecompositionEing SolveDecompositionFlags = 2
 
 	// Cholesky LL^T factorization. The matrix src1 must be symmetrical and positively defined.
-	SolveDecompositionCholesky = 3
+	SolveDecompositionCholesky SolveDecompositionFlags = 3
 
 	// QR factorization. The system can be over-defined and/or the matrix src1 can be singular.
-	SolveDecompositionQr = 4
+	SolveDecompositionQr SolveDecompositionFlags = 4
 
 	// While all the previous flags are mutually exclusive, this flag can be used together with any of the previous.
 	// It means that the normal equations 𝚜𝚛𝚌𝟷^T⋅𝚜𝚛𝚌𝟷⋅𝚍𝚜𝚝=𝚜𝚛𝚌𝟷^T𝚜𝚛𝚌𝟸 are solved instead of the original system
 	// 𝚜𝚛𝚌𝟷⋅𝚍𝚜𝚝=𝚜𝚛𝚌𝟸.
-	SolveDecompositionNormal = 5
+	SolveDecompositionNormal SolveDecompositionFlags = 5
 )
 
 // Solve solves one or more linear systems or least-squares problems.

--- a/cuda/cudawarping.go
+++ b/cuda/cudawarping.go
@@ -19,23 +19,23 @@ const (
 	InterpolationNearestNeighbor InterpolationFlags = 0
 
 	// InterpolationLinear is bilinear interpolation.
-	InterpolationLinear = 1
+	InterpolationLinear InterpolationFlags = 1
 
 	// InterpolationCubic is bicube interpolation.
-	InterpolationCubic = 2
+	InterpolationCubic InterpolationFlags = 2
 
 	// InterpolationArea uses pixel area relation. It is preferred for image
 	// decimation as it gives moire-free results.
-	InterpolationArea = 3
+	InterpolationArea InterpolationFlags = 3
 
 	// InterpolationLanczos4 is Lanczos interpolation over 8x8 neighborhood.
-	InterpolationLanczos4 = 4
+	InterpolationLanczos4 InterpolationFlags = 4
 
 	// InterpolationDefault is an alias for InterpolationLinear.
 	InterpolationDefault = InterpolationLinear
 
 	// InterpolationMax indicates use maximum interpolation.
-	InterpolationMax = 7
+	InterpolationMax InterpolationFlags = 7
 )
 
 // BorderType type of border.
@@ -46,25 +46,25 @@ const (
 	BorderConstant BorderType = 0
 
 	// BorderReplicate border type
-	BorderReplicate = 1
+	BorderReplicate BorderType = 1
 
 	// BorderReflect border type
-	BorderReflect = 2
+	BorderReflect BorderType = 2
 
 	// BorderWrap border type
-	BorderWrap = 3
+	BorderWrap BorderType = 3
 
 	// BorderReflect101 border type
-	BorderReflect101 = 4
+	BorderReflect101 BorderType = 4
 
 	// BorderTransparent border type
-	BorderTransparent = 5
+	BorderTransparent BorderType = 5
 
 	// BorderDefault border type
 	BorderDefault = BorderReflect101
 
 	// BorderIsolated border type
-	BorderIsolated = 16
+	BorderIsolated BorderType = 16
 )
 
 // Resize resizes an image.

--- a/cuda/objdetect.go
+++ b/cuda/objdetect.go
@@ -23,7 +23,7 @@ type DescriptorStorageFormat int
 const (
 	DESCR_FORMAT_COL_BY_COL DescriptorStorageFormat = 0
 
-	DESCR_FORMAT_COL_BY_ROW = 1
+	DESCR_FORMAT_COL_BY_ROW DescriptorStorageFormat = 1
 )
 
 // CascadeClassifier_GPU is a cascade classifier class for object detection.

--- a/dnn.go
+++ b/dnn.go
@@ -325,7 +325,7 @@ func BlobFromImage(img Mat, scaleFactor float64, size image.Point, mean Scalar,
 // https://docs.opencv.org/master/d6/d0f/group__dnn.html#ga2b89ed84432e4395f5a1412c2926293c
 //
 func BlobFromImages(imgs []Mat, blob *Mat, scaleFactor float64, size image.Point, mean Scalar,
-	swapRB bool, crop bool, ddepth int) {
+	swapRB bool, crop bool, ddepth MatType) {
 
 	cMatArray := make([]C.Mat, len(imgs))
 	for i, r := range imgs {

--- a/features2d.go
+++ b/features2d.go
@@ -149,9 +149,9 @@ const (
 	//FastFeatureDetectorType58 is an alias of FastFeatureDetector::TYPE_5_8
 	FastFeatureDetectorType58 FastFeatureDetectorType = 0
 	//FastFeatureDetectorType712 is an alias of FastFeatureDetector::TYPE_7_12
-	FastFeatureDetectorType712 = 1
+	FastFeatureDetectorType712 FastFeatureDetectorType = 1
 	//FastFeatureDetectorType916 is an alias of FastFeatureDetector::TYPE_9_16
-	FastFeatureDetectorType916 = 2
+	FastFeatureDetectorType916 FastFeatureDetectorType = 2
 )
 
 // FastFeatureDetector is a wrapper around the cv::FastFeatureDetector.
@@ -710,11 +710,11 @@ const (
 	// DrawDefault creates new image and for each keypoint only the center point will be drawn
 	DrawDefault DrawMatchesFlag = 0
 	// DrawOverOutImg draws matches on existing content of image
-	DrawOverOutImg = 1
+	DrawOverOutImg DrawMatchesFlag = 1
 	// NotDrawSinglePoints will not draw single points
-	NotDrawSinglePoints = 2
+	NotDrawSinglePoints DrawMatchesFlag = 2
 	// DrawRichKeyPoints draws the circle around each keypoint with keypoint size and orientation
-	DrawRichKeyPoints = 3
+	DrawRichKeyPoints DrawMatchesFlag = 3
 )
 
 // DrawKeyPoints draws keypoints

--- a/highgui.go
+++ b/highgui.go
@@ -63,24 +63,23 @@ func (w *Window) IsOpen() bool {
 }
 
 // WindowFlag value for SetWindowProperty / GetWindowProperty.
-// XXX: There are currently overlapping values in this enum.
 type WindowFlag float32
 
 const (
 	// WindowNormal indicates a normal window.
-	WindowNormal WindowFlag = 0
+	WindowNormal WindowFlag = 0x00000000
+
+	// WindowAutosize indicates a window sized based on the contents.
+	WindowAutosize WindowFlag = 0x00000001
 
 	// WindowFullscreen indicates a full-screen window.
 	WindowFullscreen WindowFlag = 1
-
-	// WindowAutosize indicates a window sized based on the contents.
-	WindowAutosize WindowFlag = 1
 
 	// WindowFreeRatio indicates allow the user to resize without maintaining aspect ratio.
 	WindowFreeRatio WindowFlag = 0x00000100
 
 	// WindowKeepRatio indicates always maintain an aspect ratio that matches the contents.
-	WindowKeepRatio WindowFlag = 0
+	WindowKeepRatio WindowFlag = 0x00000000
 )
 
 // WindowPropertyFlag flags for SetWindowProperty / GetWindowProperty.

--- a/highgui.go
+++ b/highgui.go
@@ -63,6 +63,7 @@ func (w *Window) IsOpen() bool {
 }
 
 // WindowFlag value for SetWindowProperty / GetWindowProperty.
+// XXX: There are currently overlapping values in this enum.
 type WindowFlag float32
 
 const (
@@ -70,16 +71,16 @@ const (
 	WindowNormal WindowFlag = 0
 
 	// WindowFullscreen indicates a full-screen window.
-	WindowFullscreen = 1
+	WindowFullscreen WindowFlag = 1
 
 	// WindowAutosize indicates a window sized based on the contents.
-	WindowAutosize = 1
+	WindowAutosize WindowFlag = 1
 
 	// WindowFreeRatio indicates allow the user to resize without maintaining aspect ratio.
-	WindowFreeRatio = 0x00000100
+	WindowFreeRatio WindowFlag = 0x00000100
 
 	// WindowKeepRatio indicates always maintain an aspect ratio that matches the contents.
-	WindowKeepRatio = 0
+	WindowKeepRatio WindowFlag = 0
 )
 
 // WindowPropertyFlag flags for SetWindowProperty / GetWindowProperty.
@@ -92,17 +93,17 @@ const (
 
 	// WindowPropertyAutosize is autosize property
 	// (can be WINDOW_NORMAL or WINDOW_AUTOSIZE).
-	WindowPropertyAutosize = 1
+	WindowPropertyAutosize WindowPropertyFlag = 1
 
 	// WindowPropertyAspectRatio window's aspect ration
 	// (can be set to WINDOW_FREERATIO or WINDOW_KEEPRATIO).
-	WindowPropertyAspectRatio = 2
+	WindowPropertyAspectRatio WindowPropertyFlag = 2
 
 	// WindowPropertyOpenGL opengl support.
-	WindowPropertyOpenGL = 3
+	WindowPropertyOpenGL WindowPropertyFlag = 3
 
 	// WindowPropertyVisible or not.
-	WindowPropertyVisible = 4
+	WindowPropertyVisible WindowPropertyFlag = 4
 )
 
 // GetWindowProperty returns properties of a window.

--- a/highgui_test.go
+++ b/highgui_test.go
@@ -26,7 +26,7 @@ func TestWindow(t *testing.T) {
 
 	window.SetWindowProperty(WindowPropertyFullscreen, WindowFullscreen)
 
-	prop := int(window.GetWindowProperty(WindowPropertyFullscreen))
+	prop := WindowFlag(window.GetWindowProperty(WindowPropertyFullscreen))
 	if prop != WindowFullscreen {
 		t.Error("Window property should have been fullscreen")
 	}

--- a/imgcodecs.go
+++ b/imgcodecs.go
@@ -19,48 +19,52 @@ const (
 
 	// IMReadGrayScale always convert image to the single channel
 	// grayscale image.
-	IMReadGrayScale = 0
+	IMReadGrayScale IMReadFlag = 0
 
 	// IMReadColor always converts image to the 3 channel BGR color image.
-	IMReadColor = 1
+	IMReadColor IMReadFlag = 1
 
 	// IMReadAnyDepth returns 16-bit/32-bit image when the input has the corresponding
 	// depth, otherwise convert it to 8-bit.
-	IMReadAnyDepth = 2
+	IMReadAnyDepth IMReadFlag = 2
 
 	// IMReadAnyColor the image is read in any possible color format.
-	IMReadAnyColor = 4
+	IMReadAnyColor IMReadFlag = 4
 
 	// IMReadLoadGDAL uses the gdal driver for loading the image.
-	IMReadLoadGDAL = 8
+	IMReadLoadGDAL IMReadFlag = 8
 
 	// IMReadReducedGrayscale2 always converts image to the single channel grayscale image
 	// and the image size reduced 1/2.
-	IMReadReducedGrayscale2 = 16
+	IMReadReducedGrayscale2 IMReadFlag = 16
 
 	// IMReadReducedColor2 always converts image to the 3 channel BGR color image and the
 	// image size reduced 1/2.
-	IMReadReducedColor2 = 17
+	IMReadReducedColor2 IMReadFlag = 17
 
 	// IMReadReducedGrayscale4 always converts image to the single channel grayscale image and
 	// the image size reduced 1/4.
-	IMReadReducedGrayscale4 = 32
+	IMReadReducedGrayscale4 IMReadFlag = 32
 
 	// IMReadReducedColor4 always converts image to the 3 channel BGR color image and
 	// the image size reduced 1/4.
-	IMReadReducedColor4 = 33
+	IMReadReducedColor4 IMReadFlag = 33
 
 	// IMReadReducedGrayscale8 always convert image to the single channel grayscale image and
 	// the image size reduced 1/8.
-	IMReadReducedGrayscale8 = 64
+	IMReadReducedGrayscale8 IMReadFlag = 64
 
 	// IMReadReducedColor8 always convert image to the 3 channel BGR color image and the
 	// image size reduced 1/8.
-	IMReadReducedColor8 = 65
+	IMReadReducedColor8 IMReadFlag = 65
 
 	// IMReadIgnoreOrientation do not rotate the image according to EXIF's orientation flag.
-	IMReadIgnoreOrientation = 128
+	IMReadIgnoreOrientation IMReadFlag = 128
+)
 
+// TODO: Define IMWriteFlag type?
+
+const (
 	//IMWriteJpegQuality is the quality from 0 to 100 for JPEG (the higher is the better). Default value is 95.
 	IMWriteJpegQuality = 1
 

--- a/imgproc.go
+++ b/imgproc.go
@@ -901,7 +901,7 @@ func GetGaussianKernel(ksize int, sigma float64) Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#gac05a120c1ae92a6060dd0db190a61afa
-func GetGaussianKernelWithParams(ksize int, sigma float64, ktype int) Mat {
+func GetGaussianKernelWithParams(ksize int, sigma float64, ktype MatType) Mat {
 	return newMat(C.GetGaussianKernel(C.int(ksize), C.double(sigma), C.int(ktype)))
 }
 
@@ -910,7 +910,7 @@ func GetGaussianKernelWithParams(ksize int, sigma float64, ktype int) Mat {
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#gacea54f142e81b6758cb6f375ce782c8d
 //
-func Sobel(src Mat, dst *Mat, ddepth, dx, dy, ksize int, scale, delta float64, borderType BorderType) {
+func Sobel(src Mat, dst *Mat, ddepth MatType, dx, dy, ksize int, scale, delta float64, borderType BorderType) {
 	C.Sobel(src.p, dst.p, C.int(ddepth), C.int(dx), C.int(dy), C.int(ksize), C.double(scale), C.double(delta), C.int(borderType))
 }
 
@@ -919,7 +919,7 @@ func Sobel(src Mat, dst *Mat, ddepth, dx, dy, ksize int, scale, delta float64, b
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#ga405d03b20c782b65a4daf54d233239a2
 //
-func SpatialGradient(src Mat, dx, dy *Mat, ksize int, borderType BorderType) {
+func SpatialGradient(src Mat, dx, dy *Mat, ksize MatType, borderType BorderType) {
 	C.SpatialGradient(src.p, dx.p, dy.p, C.int(ksize), C.int(borderType))
 }
 
@@ -928,7 +928,7 @@ func SpatialGradient(src Mat, dx, dy *Mat, ksize int, borderType BorderType) {
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#gad78703e4c8fe703d479c1860d76429e6
 //
-func Laplacian(src Mat, dst *Mat, dDepth int, size int, scale float64,
+func Laplacian(src Mat, dst *Mat, dDepth MatType, size int, scale float64,
 	delta float64, borderType BorderType) {
 	C.Laplacian(src.p, dst.p, C.int(dDepth), C.int(size), C.double(scale), C.double(delta), C.int(borderType))
 }
@@ -938,7 +938,7 @@ func Laplacian(src Mat, dst *Mat, dDepth int, size int, scale float64,
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#gaa13106761eedf14798f37aa2d60404c9
 //
-func Scharr(src Mat, dst *Mat, dDepth int, dx int, dy int, scale float64,
+func Scharr(src Mat, dst *Mat, dDepth MatType, dx int, dy int, scale float64,
 	delta float64, borderType BorderType) {
 	C.Scharr(src.p, dst.p, C.int(dDepth), C.int(dx), C.int(dy), C.double(scale), C.double(delta), C.int(borderType))
 }

--- a/imgproc.go
+++ b/imgproc.go
@@ -178,22 +178,22 @@ const (
 	HistCmpCorrel HistCompMethod = 0
 
 	// HistCmpChiSqr calculates the Chi-Square
-	HistCmpChiSqr = 1
+	HistCmpChiSqr HistCompMethod = 1
 
 	// HistCmpIntersect calculates the Intersection
-	HistCmpIntersect = 2
+	HistCmpIntersect HistCompMethod = 2
 
 	// HistCmpBhattacharya applies the HistCmpBhattacharya by calculating the Bhattacharya distance.
-	HistCmpBhattacharya = 3
+	HistCmpBhattacharya HistCompMethod = 3
 
 	// HistCmpHellinger applies the HistCmpBhattacharya comparison. It is a synonym to HistCmpBhattacharya.
 	HistCmpHellinger = HistCmpBhattacharya
 
 	// HistCmpChiSqrAlt applies the Alternative Chi-Square (regularly used for texture comparsion).
-	HistCmpChiSqrAlt = 4
+	HistCmpChiSqrAlt HistCompMethod = 4
 
 	// HistCmpKlDiv applies the Kullback-Liebler divergence comparison.
-	HistCmpKlDiv = 5
+	HistCmpKlDiv HistCompMethod = 5
 )
 
 // CompareHist Compares two histograms.
@@ -359,21 +359,21 @@ const (
 
 	// RetrievalList retrieves all of the contours without establishing
 	// any hierarchical relationships.
-	RetrievalList = 1
+	RetrievalList RetrievalMode = 1
 
 	// RetrievalCComp retrieves all of the contours and organizes them into
 	// a two-level hierarchy. At the top level, there are external boundaries
 	// of the components. At the second level, there are boundaries of the holes.
 	// If there is another contour inside a hole of a connected component, it
 	// is still put at the top level.
-	RetrievalCComp = 2
+	RetrievalCComp RetrievalMode = 2
 
 	// RetrievalTree retrieves all of the contours and reconstructs a full
 	// hierarchy of nested contours.
-	RetrievalTree = 3
+	RetrievalTree RetrievalMode = 3
 
 	// RetrievalFloodfill lacks a description in the original header.
-	RetrievalFloodfill = 4
+	RetrievalFloodfill RetrievalMode = 4
 )
 
 // ContourApproximationMode is the mode of the contour approximation algorithm.
@@ -389,15 +389,15 @@ const (
 	// ChainApproxSimple compresses horizontal, vertical, and diagonal segments
 	// and leaves only their end points.
 	// For example, an up-right rectangular contour is encoded with 4 points.
-	ChainApproxSimple = 2
+	ChainApproxSimple ContourApproximationMode = 2
 
 	// ChainApproxTC89L1 applies one of the flavors of the Teh-Chin chain
 	// approximation algorithms.
-	ChainApproxTC89L1 = 3
+	ChainApproxTC89L1 ContourApproximationMode = 3
 
 	// ChainApproxTC89KCOS applies one of the flavors of the Teh-Chin chain
 	// approximation algorithms.
-	ChainApproxTC89KCOS = 4
+	ChainApproxTC89KCOS ContourApproximationMode = 4
 )
 
 // BoundingRect calculates the up-right bounding rectangle of a point set.
@@ -591,10 +591,10 @@ const (
 	CCL_WU ConnectedComponentsAlgorithmType = 0
 
 	// BBDT algorithm for 8-way connectivity, SAUF algorithm for 4-way connectivity.
-	CCL_DEFAULT = 1
+	CCL_DEFAULT ConnectedComponentsAlgorithmType = 1
 
 	// BBDT algorithm for 8-way connectivity, SAUF algorithm for 4-way connectivity
-	CCL_GRANA = 2
+	CCL_GRANA ConnectedComponentsAlgorithmType = 2
 )
 
 // ConnectedComponents computes the connected components labeled image of boolean image.
@@ -621,21 +621,21 @@ type ConnectedComponentsTypes int
 
 const (
 	//The leftmost (x) coordinate which is the inclusive start of the bounding box in the horizontal direction.
-	CC_STAT_LEFT = 0
+	CC_STAT_LEFT ConnectedComponentsTypes = 0
 
 	//The topmost (y) coordinate which is the inclusive start of the bounding box in the vertical direction.
-	CC_STAT_TOP = 1
+	CC_STAT_TOP ConnectedComponentsTypes = 1
 
 	// The horizontal size of the bounding box.
-	CC_STAT_WIDTH = 2
+	CC_STAT_WIDTH ConnectedComponentsTypes = 2
 
 	// The vertical size of the bounding box.
-	CC_STAT_HEIGHT = 3
+	CC_STAT_HEIGHT ConnectedComponentsTypes = 3
 
 	// The total area (in pixels) of the connected component.
-	CC_STAT_AREA = 4
+	CC_STAT_AREA ConnectedComponentsTypes = 4
 
-	CC_STAT_MAX = 5
+	CC_STAT_MAX ConnectedComponentsTypes = 5
 )
 
 // ConnectedComponentsWithStats computes the connected components labeled image of boolean
@@ -668,15 +668,15 @@ const (
 	// TmSqdiff maps to TM_SQDIFF
 	TmSqdiff TemplateMatchMode = 0
 	// TmSqdiffNormed maps to TM_SQDIFF_NORMED
-	TmSqdiffNormed = 1
+	TmSqdiffNormed TemplateMatchMode = 1
 	// TmCcorr maps to TM_CCORR
-	TmCcorr = 2
+	TmCcorr TemplateMatchMode = 2
 	// TmCcorrNormed maps to TM_CCORR_NORMED
-	TmCcorrNormed = 3
+	TmCcorrNormed TemplateMatchMode = 3
 	// TmCcoeff maps to TM_CCOEFF
-	TmCcoeff = 4
+	TmCcoeff TemplateMatchMode = 4
 	// TmCcoeffNormed maps to TM_CCOEFF_NORMED
-	TmCcoeffNormed = 5
+	TmCcoeffNormed TemplateMatchMode = 5
 )
 
 // MatchTemplate compares a template against overlapped image regions.
@@ -793,10 +793,10 @@ const (
 	MorphRect MorphShape = 0
 
 	// MorphCross is the cross morph shape.
-	MorphCross = 1
+	MorphCross MorphShape = 1
 
 	// MorphEllipse is the ellipse morph shape.
-	MorphEllipse = 2
+	MorphEllipse MorphShape = 2
 )
 
 // GetStructuringElement returns a structuring element of the specified size
@@ -822,25 +822,25 @@ const (
 	MorphErode MorphType = 0
 
 	// MorphDilate operation
-	MorphDilate = 1
+	MorphDilate MorphType = 1
 
 	// MorphOpen operation
-	MorphOpen = 2
+	MorphOpen MorphType = 2
 
 	// MorphClose operation
-	MorphClose = 3
+	MorphClose MorphType = 3
 
 	// MorphGradient operation
-	MorphGradient = 4
+	MorphGradient MorphType = 4
 
 	// MorphTophat operation
-	MorphTophat = 5
+	MorphTophat MorphType = 5
 
 	// MorphBlackhat operation
-	MorphBlackhat = 6
+	MorphBlackhat MorphType = 6
 
 	// MorphHitmiss operation
-	MorphHitmiss = 7
+	MorphHitmiss MorphType = 7
 )
 
 // BorderType type of border.
@@ -851,25 +851,25 @@ const (
 	BorderConstant BorderType = 0
 
 	// BorderReplicate border type
-	BorderReplicate = 1
+	BorderReplicate BorderType = 1
 
 	// BorderReflect border type
-	BorderReflect = 2
+	BorderReflect BorderType = 2
 
 	// BorderWrap border type
-	BorderWrap = 3
+	BorderWrap BorderType = 3
 
 	// BorderReflect101 border type
-	BorderReflect101 = 4
+	BorderReflect101 BorderType = 4
 
 	// BorderTransparent border type
-	BorderTransparent = 5
+	BorderTransparent BorderType = 5
 
 	// BorderDefault border type
 	BorderDefault = BorderReflect101
 
 	// BorderIsolated border type
-	BorderIsolated = 16
+	BorderIsolated BorderType = 16
 )
 
 // GaussianBlur blurs an image Mat using a Gaussian filter.
@@ -1008,12 +1008,12 @@ const (
 	// GCInitWithMask makes the function initialize the state using the provided mask.
 	// GCInitWithMask and GCInitWithRect can be combined.
 	// Then all the pixels outside of the ROI are automatically initialized with GC_BGD.
-	GCInitWithMask = 1
+	GCInitWithMask GrabCutMode = 1
 	// GCEval means that the algorithm should just resume.
-	GCEval = 2
+	GCEval GrabCutMode = 2
 	// GCEvalFreezeModel means that the algorithm should just run a single iteration of the GrabCut algorithm
 	// with the fixed model
-	GCEvalFreezeModel = 3
+	GCEvalFreezeModel GrabCutMode = 3
 )
 
 // Grabcut runs the GrabCut algorithm.
@@ -1040,15 +1040,15 @@ const (
 	HoughStandard HoughMode = 0
 	// HoughProbabilistic is the probabilistic Hough transform (more efficient
 	// in case if the picture contains a few long linear segments).
-	HoughProbabilistic = 1
+	HoughProbabilistic HoughMode = 1
 	// HoughMultiScale is the multi-scale variant of the classical Hough
 	// transform.
-	HoughMultiScale = 2
+	HoughMultiScale HoughMode = 2
 	// HoughGradient is basically 21HT, described in: HK Yuen, John Princen,
 	// John Illingworth, and Josef Kittler. Comparative study of hough
 	// transform methods for circle finding. Image and Vision Computing,
 	// 8(1):71–77, 1990.
-	HoughGradient = 3
+	HoughGradient HoughMode = 3
 )
 
 // HoughCircles finds circles in a grayscale image using the Hough transform.
@@ -1128,25 +1128,25 @@ const (
 	ThresholdBinary ThresholdType = 0
 
 	// ThresholdBinaryInv threshold type
-	ThresholdBinaryInv = 1
+	ThresholdBinaryInv ThresholdType = 1
 
 	// ThresholdTrunc threshold type
-	ThresholdTrunc = 2
+	ThresholdTrunc ThresholdType = 2
 
 	// ThresholdToZero threshold type
-	ThresholdToZero = 3
+	ThresholdToZero ThresholdType = 3
 
 	// ThresholdToZeroInv threshold type
-	ThresholdToZeroInv = 4
+	ThresholdToZeroInv ThresholdType = 4
 
 	// ThresholdMask threshold type
-	ThresholdMask = 7
+	ThresholdMask ThresholdType = 7
 
 	// ThresholdOtsu threshold type
-	ThresholdOtsu = 8
+	ThresholdOtsu ThresholdType = 8
 
 	// ThresholdTriangle threshold type
-	ThresholdTriangle = 16
+	ThresholdTriangle ThresholdType = 16
 )
 
 // Threshold applies a fixed-level threshold to each array element.
@@ -1166,7 +1166,7 @@ const (
 	AdaptiveThresholdMean AdaptiveThresholdType = 0
 
 	// AdaptiveThresholdGaussian threshold type
-	AdaptiveThresholdGaussian = 1
+	AdaptiveThresholdGaussian AdaptiveThresholdType = 1
 )
 
 // AdaptiveThreshold applies a fixed-level threshold to each array element.
@@ -1395,23 +1395,23 @@ const (
 	// FontHersheySimplex is normal size sans-serif font.
 	FontHersheySimplex HersheyFont = 0
 	// FontHersheyPlain issmall size sans-serif font.
-	FontHersheyPlain = 1
+	FontHersheyPlain HersheyFont = 1
 	// FontHersheyDuplex normal size sans-serif font
 	// (more complex than FontHersheySIMPLEX).
-	FontHersheyDuplex = 2
+	FontHersheyDuplex HersheyFont = 2
 	// FontHersheyComplex i a normal size serif font.
-	FontHersheyComplex = 3
+	FontHersheyComplex HersheyFont = 3
 	// FontHersheyTriplex is a normal size serif font
 	// (more complex than FontHersheyCOMPLEX).
-	FontHersheyTriplex = 4
+	FontHersheyTriplex HersheyFont = 4
 	// FontHersheyComplexSmall is a smaller version of FontHersheyCOMPLEX.
-	FontHersheyComplexSmall = 5
+	FontHersheyComplexSmall HersheyFont = 5
 	// FontHersheyScriptSimplex is a hand-writing style font.
-	FontHersheyScriptSimplex = 6
+	FontHersheyScriptSimplex HersheyFont = 6
 	// FontHersheyScriptComplex is a more complex variant of FontHersheyScriptSimplex.
-	FontHersheyScriptComplex = 7
+	FontHersheyScriptComplex HersheyFont = 7
 	// FontItalic is the flag for italic font.
-	FontItalic = 16
+	FontItalic HersheyFont = 16
 )
 
 // LineType are the line libraries included in OpenCV.
@@ -1425,11 +1425,11 @@ const (
 	// Filled line
 	Filled LineType = -1
 	// Line4 4-connected line
-	Line4 = 4
+	Line4 LineType = 4
 	// Line8 8-connected line
-	Line8 = 8
+	Line8 LineType = 8
 	// LineAA antialiased line
-	LineAA = 16
+	LineAA LineType = 16
 )
 
 // GetTextSize calculates the width and height of a text string.
@@ -1512,23 +1512,23 @@ const (
 	InterpolationNearestNeighbor InterpolationFlags = 0
 
 	// InterpolationLinear is bilinear interpolation.
-	InterpolationLinear = 1
+	InterpolationLinear InterpolationFlags = 1
 
 	// InterpolationCubic is bicube interpolation.
-	InterpolationCubic = 2
+	InterpolationCubic InterpolationFlags = 2
 
 	// InterpolationArea uses pixel area relation. It is preferred for image
 	// decimation as it gives moire-free results.
-	InterpolationArea = 3
+	InterpolationArea InterpolationFlags = 3
 
 	// InterpolationLanczos4 is Lanczos interpolation over 8x8 neighborhood.
-	InterpolationLanczos4 = 4
+	InterpolationLanczos4 InterpolationFlags = 4
 
 	// InterpolationDefault is an alias for InterpolationLinear.
 	InterpolationDefault = InterpolationLinear
 
 	// InterpolationMax indicates use maximum interpolation.
-	InterpolationMax = 7
+	InterpolationMax InterpolationFlags = 7
 )
 
 // Resize resizes an image.
@@ -1642,18 +1642,18 @@ type ColormapTypes int
 // https://docs.opencv.org/master/d3/d50/group__imgproc__colormap.html#ga9a805d8262bcbe273f16be9ea2055a65
 const (
 	ColormapAutumn  ColormapTypes = 0
-	ColormapBone                  = 1
-	ColormapJet                   = 2
-	ColormapWinter                = 3
-	ColormapRainbow               = 4
-	ColormapOcean                 = 5
-	ColormapSummer                = 6
-	ColormapSpring                = 7
-	ColormapCool                  = 8
-	ColormapHsv                   = 9
-	ColormapPink                  = 10
-	ColormapHot                   = 11
-	ColormapParula                = 12
+	ColormapBone    ColormapTypes = 1
+	ColormapJet     ColormapTypes = 2
+	ColormapWinter  ColormapTypes = 3
+	ColormapRainbow ColormapTypes = 4
+	ColormapOcean   ColormapTypes = 5
+	ColormapSummer  ColormapTypes = 6
+	ColormapSpring  ColormapTypes = 7
+	ColormapCool    ColormapTypes = 8
+	ColormapHsv     ColormapTypes = 9
+	ColormapPink    ColormapTypes = 10
+	ColormapHot     ColormapTypes = 11
+	ColormapParula  ColormapTypes = 12
 )
 
 // ApplyColorMap applies a GNU Octave/MATLAB equivalent colormap on a given image.
@@ -1698,8 +1698,8 @@ type HomographyMethod int
 
 const (
 	HomograpyMethodAllPoints HomographyMethod = 0
-	HomograpyMethodLMEDS                      = 4
-	HomograpyMethodRANSAC                     = 8
+	HomograpyMethodLMEDS     HomographyMethod = 4
+	HomograpyMethodRANSAC    HomographyMethod = 8
 )
 
 // FindHomography finds an optimal homography matrix using 4 or more point pairs (as opposed to GetPerspectiveTransform, which uses exactly 4)
@@ -1828,13 +1828,13 @@ type DistanceTypes int
 
 const (
 	DistUser   DistanceTypes = 0
-	DistL1                   = 1
-	DistL2                   = 2
-	DistC                    = 3
-	DistL12                  = 4
-	DistFair                 = 5
-	DistWelsch               = 6
-	DistHuber                = 7
+	DistL1     DistanceTypes = 1
+	DistL2     DistanceTypes = 2
+	DistC      DistanceTypes = 3
+	DistL12    DistanceTypes = 4
+	DistFair   DistanceTypes = 5
+	DistWelsch DistanceTypes = 6
+	DistHuber  DistanceTypes = 7
 )
 
 // FitLine fits a line to a 2D or 3D point set.

--- a/imgproc.go
+++ b/imgproc.go
@@ -1776,7 +1776,7 @@ func Remap(src Mat, dst, map1, map2 *Mat, interpolation InterpolationFlags, bord
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#ga27c049795ce870216ddfb366086b5a04
-func Filter2D(src Mat, dst *Mat, ddepth int, kernel Mat, anchor image.Point, delta float64, borderType BorderType) {
+func Filter2D(src Mat, dst *Mat, ddepth MatType, kernel Mat, anchor image.Point, delta float64, borderType BorderType) {
 	anchorP := C.struct_Point{
 		x: C.int(anchor.X),
 		y: C.int(anchor.Y),
@@ -1788,7 +1788,7 @@ func Filter2D(src Mat, dst *Mat, ddepth int, kernel Mat, anchor image.Point, del
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#ga910e29ff7d7b105057d1625a4bf6318d
-func SepFilter2D(src Mat, dst *Mat, ddepth int, kernelX, kernelY Mat, anchor image.Point, delta float64, borderType BorderType) {
+func SepFilter2D(src Mat, dst *Mat, ddepth MatType, kernelX, kernelY Mat, anchor image.Point, delta float64, borderType BorderType) {
 	anchorP := C.struct_Point{
 		x: C.int(anchor.X),
 		y: C.int(anchor.Y),

--- a/imgproc_colorcodes.go
+++ b/imgproc_colorcodes.go
@@ -12,340 +12,340 @@ const (
 	ColorBGRToBGRA ColorConversionCode = 0
 
 	// ColorBGRAToBGR removes alpha channel from BGR image.
-	ColorBGRAToBGR = 1
+	ColorBGRAToBGR ColorConversionCode = 1
 
 	// ColorBGRToRGBA converts from BGR to RGB with alpha channel.
-	ColorBGRToRGBA = 2
+	ColorBGRToRGBA ColorConversionCode = 2
 
 	// ColorRGBAToBGR converts from RGB with alpha to BGR color space.
-	ColorRGBAToBGR = 3
+	ColorRGBAToBGR ColorConversionCode = 3
 
 	// ColorBGRToRGB converts from BGR to RGB without alpha channel.
-	ColorBGRToRGB = 4
+	ColorBGRToRGB ColorConversionCode = 4
 
 	// ColorBGRAToRGBA converts from BGR with alpha channel
 	// to RGB with alpha channel.
-	ColorBGRAToRGBA = 5
+	ColorBGRAToRGBA ColorConversionCode = 5
 
 	// ColorBGRToGray converts from BGR to grayscale.
-	ColorBGRToGray = 6
+	ColorBGRToGray ColorConversionCode = 6
 
 	// ColorRGBToGray converts from RGB to grayscale.
-	ColorRGBToGray = 7
+	ColorRGBToGray ColorConversionCode = 7
 
 	// ColorGrayToBGR converts from grayscale to BGR.
-	ColorGrayToBGR = 8
+	ColorGrayToBGR ColorConversionCode = 8
 
 	// ColorGrayToBGRA converts from grayscale to BGR with alpha channel.
-	ColorGrayToBGRA = 9
+	ColorGrayToBGRA ColorConversionCode = 9
 
 	// ColorBGRAToGray converts from BGR with alpha channel to grayscale.
-	ColorBGRAToGray = 10
+	ColorBGRAToGray ColorConversionCode = 10
 
 	// ColorRGBAToGray converts from RGB with alpha channel to grayscale.
-	ColorRGBAToGray = 11
+	ColorRGBAToGray ColorConversionCode = 11
 
 	// ColorBGRToBGR565 converts from BGR to BGR565 (16-bit images).
-	ColorBGRToBGR565 = 12
+	ColorBGRToBGR565 ColorConversionCode = 12
 
 	// ColorRGBToBGR565 converts from RGB to BGR565 (16-bit images).
-	ColorRGBToBGR565 = 13
+	ColorRGBToBGR565 ColorConversionCode = 13
 
 	// ColorBGR565ToBGR converts from BGR565 (16-bit images) to BGR.
-	ColorBGR565ToBGR = 14
+	ColorBGR565ToBGR ColorConversionCode = 14
 
 	// ColorBGR565ToRGB converts from BGR565 (16-bit images) to RGB.
-	ColorBGR565ToRGB = 15
+	ColorBGR565ToRGB ColorConversionCode = 15
 
 	// ColorBGRAToBGR565 converts from BGRA (with alpha channel)
 	// to BGR565 (16-bit images).
-	ColorBGRAToBGR565 = 16
+	ColorBGRAToBGR565 ColorConversionCode = 16
 
 	// ColorRGBAToBGR565 converts from RGBA (with alpha channel)
 	// to BGR565 (16-bit images).
-	ColorRGBAToBGR565 = 17
+	ColorRGBAToBGR565 ColorConversionCode = 17
 
 	// ColorBGR565ToBGRA converts from BGR565 (16-bit images)
 	// to BGRA (with alpha channel).
-	ColorBGR565ToBGRA = 18
+	ColorBGR565ToBGRA ColorConversionCode = 18
 
 	// ColorBGR565ToRGBA converts from BGR565 (16-bit images)
 	// to RGBA (with alpha channel).
-	ColorBGR565ToRGBA = 19
+	ColorBGR565ToRGBA ColorConversionCode = 19
 
 	// ColorGrayToBGR565 converts from grayscale
 	// to BGR565 (16-bit images).
-	ColorGrayToBGR565 = 20
+	ColorGrayToBGR565 ColorConversionCode = 20
 
 	// ColorBGR565ToGray converts from BGR565 (16-bit images)
 	// to grayscale.
-	ColorBGR565ToGray = 21
+	ColorBGR565ToGray ColorConversionCode = 21
 
 	// ColorBGRToBGR555 converts from BGR to BGR555 (16-bit images).
-	ColorBGRToBGR555 = 22
+	ColorBGRToBGR555 ColorConversionCode = 22
 
 	// ColorRGBToBGR555 converts from RGB to BGR555 (16-bit images).
-	ColorRGBToBGR555 = 23
+	ColorRGBToBGR555 ColorConversionCode = 23
 
 	// ColorBGR555ToBGR converts from BGR555 (16-bit images) to BGR.
-	ColorBGR555ToBGR = 24
+	ColorBGR555ToBGR ColorConversionCode = 24
 
 	// ColorBGR555ToRGB converts from BGR555 (16-bit images) to RGB.
-	ColorBGR555ToRGB = 25
+	ColorBGR555ToRGB ColorConversionCode = 25
 
 	// ColorBGRAToBGR555 converts from BGRA (with alpha channel)
 	// to BGR555 (16-bit images).
-	ColorBGRAToBGR555 = 26
+	ColorBGRAToBGR555 ColorConversionCode = 26
 
 	// ColorRGBAToBGR555 converts from RGBA (with alpha channel)
 	// to BGR555 (16-bit images).
-	ColorRGBAToBGR555 = 27
+	ColorRGBAToBGR555 ColorConversionCode = 27
 
 	// ColorBGR555ToBGRA converts from BGR555 (16-bit images)
 	// to BGRA (with alpha channel).
-	ColorBGR555ToBGRA = 28
+	ColorBGR555ToBGRA ColorConversionCode = 28
 
 	// ColorBGR555ToRGBA converts from BGR555 (16-bit images)
 	// to RGBA (with alpha channel).
-	ColorBGR555ToRGBA = 29
+	ColorBGR555ToRGBA ColorConversionCode = 29
 
 	// ColorGrayToBGR555 converts from grayscale to BGR555 (16-bit images).
-	ColorGrayToBGR555 = 30
+	ColorGrayToBGR555 ColorConversionCode = 30
 
 	// ColorBGR555ToGRAY converts from BGR555 (16-bit images) to grayscale.
-	ColorBGR555ToGRAY = 31
+	ColorBGR555ToGRAY ColorConversionCode = 31
 
 	// ColorBGRToXYZ converts from BGR to CIE XYZ.
-	ColorBGRToXYZ = 32
+	ColorBGRToXYZ ColorConversionCode = 32
 
 	// ColorRGBToXYZ converts from RGB to CIE XYZ.
-	ColorRGBToXYZ = 33
+	ColorRGBToXYZ ColorConversionCode = 33
 
 	// ColorXYZToBGR converts from CIE XYZ to BGR.
-	ColorXYZToBGR = 34
+	ColorXYZToBGR ColorConversionCode = 34
 
 	// ColorXYZToRGB converts from CIE XYZ to RGB.
-	ColorXYZToRGB = 35
+	ColorXYZToRGB ColorConversionCode = 35
 
 	// ColorBGRToYCrCb converts from BGR to luma-chroma (aka YCC).
-	ColorBGRToYCrCb = 36
+	ColorBGRToYCrCb ColorConversionCode = 36
 
 	// ColorRGBToYCrCb converts from RGB to luma-chroma (aka YCC).
-	ColorRGBToYCrCb = 37
+	ColorRGBToYCrCb ColorConversionCode = 37
 
 	// ColorYCrCbToBGR converts from luma-chroma (aka YCC) to BGR.
-	ColorYCrCbToBGR = 38
+	ColorYCrCbToBGR ColorConversionCode = 38
 
 	// ColorYCrCbToRGB converts from luma-chroma (aka YCC) to RGB.
-	ColorYCrCbToRGB = 39
+	ColorYCrCbToRGB ColorConversionCode = 39
 
 	// ColorBGRToHSV converts from BGR to HSV (hue saturation value).
-	ColorBGRToHSV = 40
+	ColorBGRToHSV ColorConversionCode = 40
 
 	// ColorRGBToHSV converts from RGB to HSV (hue saturation value).
-	ColorRGBToHSV = 41
+	ColorRGBToHSV ColorConversionCode = 41
 
 	// ColorBGRToLab converts from BGR to CIE Lab.
-	ColorBGRToLab = 44
+	ColorBGRToLab ColorConversionCode = 44
 
 	// ColorRGBToLab converts from RGB to CIE Lab.
-	ColorRGBToLab = 45
+	ColorRGBToLab ColorConversionCode = 45
 
 	// ColorBGRToLuv converts from BGR to CIE Luv.
-	ColorBGRToLuv = 50
+	ColorBGRToLuv ColorConversionCode = 50
 
 	// ColorRGBToLuv converts from RGB to CIE Luv.
-	ColorRGBToLuv = 51
+	ColorRGBToLuv ColorConversionCode = 51
 
 	// ColorBGRToHLS converts from BGR to HLS (hue lightness saturation).
-	ColorBGRToHLS = 52
+	ColorBGRToHLS ColorConversionCode = 52
 
 	// ColorRGBToHLS converts from RGB to HLS (hue lightness saturation).
-	ColorRGBToHLS = 53
+	ColorRGBToHLS ColorConversionCode = 53
 
 	// ColorHSVToBGR converts from HSV (hue saturation value) to BGR.
-	ColorHSVToBGR = 54
+	ColorHSVToBGR ColorConversionCode = 54
 
 	// ColorHSVToRGB converts from HSV (hue saturation value) to RGB.
-	ColorHSVToRGB = 55
+	ColorHSVToRGB ColorConversionCode = 55
 
 	// ColorLabToBGR converts from CIE Lab to BGR.
-	ColorLabToBGR = 56
+	ColorLabToBGR ColorConversionCode = 56
 
 	// ColorLabToRGB converts from CIE Lab to RGB.
-	ColorLabToRGB = 57
+	ColorLabToRGB ColorConversionCode = 57
 
 	// ColorLuvToBGR converts from CIE Luv to BGR.
-	ColorLuvToBGR = 58
+	ColorLuvToBGR ColorConversionCode = 58
 
 	// ColorLuvToRGB converts from CIE Luv to RGB.
-	ColorLuvToRGB = 59
+	ColorLuvToRGB ColorConversionCode = 59
 
 	// ColorHLSToBGR converts from HLS (hue lightness saturation) to BGR.
-	ColorHLSToBGR = 60
+	ColorHLSToBGR ColorConversionCode = 60
 
 	// ColorHLSToRGB converts from HLS (hue lightness saturation) to RGB.
-	ColorHLSToRGB = 61
+	ColorHLSToRGB ColorConversionCode = 61
 
 	// ColorBGRToHSVFull converts from BGR to HSV (hue saturation value) full.
-	ColorBGRToHSVFull = 66
+	ColorBGRToHSVFull ColorConversionCode = 66
 
 	// ColorRGBToHSVFull converts from RGB to HSV (hue saturation value) full.
-	ColorRGBToHSVFull = 67
+	ColorRGBToHSVFull ColorConversionCode = 67
 
 	// ColorBGRToHLSFull converts from BGR to HLS (hue lightness saturation) full.
-	ColorBGRToHLSFull = 68
+	ColorBGRToHLSFull ColorConversionCode = 68
 
 	// ColorRGBToHLSFull converts from RGB to HLS (hue lightness saturation) full.
-	ColorRGBToHLSFull = 69
+	ColorRGBToHLSFull ColorConversionCode = 69
 
 	// ColorHSVToBGRFull converts from HSV (hue saturation value) to BGR full.
-	ColorHSVToBGRFull = 70
+	ColorHSVToBGRFull ColorConversionCode = 70
 
 	// ColorHSVToRGBFull converts from HSV (hue saturation value) to RGB full.
-	ColorHSVToRGBFull = 71
+	ColorHSVToRGBFull ColorConversionCode = 71
 
 	// ColorHLSToBGRFull converts from HLS (hue lightness saturation) to BGR full.
-	ColorHLSToBGRFull = 72
+	ColorHLSToBGRFull ColorConversionCode = 72
 
 	// ColorHLSToRGBFull converts from HLS (hue lightness saturation) to RGB full.
-	ColorHLSToRGBFull = 73
+	ColorHLSToRGBFull ColorConversionCode = 73
 
 	// ColorLBGRToLab converts from LBGR to CIE Lab.
-	ColorLBGRToLab = 74
+	ColorLBGRToLab ColorConversionCode = 74
 
 	// ColorLRGBToLab converts from LRGB to CIE Lab.
-	ColorLRGBToLab = 75
+	ColorLRGBToLab ColorConversionCode = 75
 
 	// ColorLBGRToLuv converts from LBGR to CIE Luv.
-	ColorLBGRToLuv = 76
+	ColorLBGRToLuv ColorConversionCode = 76
 
 	// ColorLRGBToLuv converts from LRGB to CIE Luv.
-	ColorLRGBToLuv = 77
+	ColorLRGBToLuv ColorConversionCode = 77
 
 	// ColorLabToLBGR converts from CIE Lab to LBGR.
-	ColorLabToLBGR = 78
+	ColorLabToLBGR ColorConversionCode = 78
 
 	// ColorLabToLRGB converts from CIE Lab to LRGB.
-	ColorLabToLRGB = 79
+	ColorLabToLRGB ColorConversionCode = 79
 
 	// ColorLuvToLBGR converts from CIE Luv to LBGR.
-	ColorLuvToLBGR = 80
+	ColorLuvToLBGR ColorConversionCode = 80
 
 	// ColorLuvToLRGB converts from CIE Luv to LRGB.
-	ColorLuvToLRGB = 81
+	ColorLuvToLRGB ColorConversionCode = 81
 
 	// ColorBGRToYUV converts from BGR to YUV.
-	ColorBGRToYUV = 82
+	ColorBGRToYUV ColorConversionCode = 82
 
 	// ColorRGBToYUV converts from RGB to YUV.
-	ColorRGBToYUV = 83
+	ColorRGBToYUV ColorConversionCode = 83
 
 	// ColorYUVToBGR converts from YUV to BGR.
-	ColorYUVToBGR = 84
+	ColorYUVToBGR ColorConversionCode = 84
 
 	// ColorYUVToRGB converts from YUV to RGB.
-	ColorYUVToRGB = 85
+	ColorYUVToRGB ColorConversionCode = 85
 
 	// ColorYUVToRGBNV12 converts from YUV 4:2:0 to RGB NV12.
-	ColorYUVToRGBNV12 = 90
+	ColorYUVToRGBNV12 ColorConversionCode = 90
 
 	// ColorYUVToBGRNV12 converts from YUV 4:2:0 to BGR NV12.
-	ColorYUVToBGRNV12 = 91
+	ColorYUVToBGRNV12 ColorConversionCode = 91
 
 	// ColorYUVToRGBNV21 converts from YUV 4:2:0 to RGB NV21.
-	ColorYUVToRGBNV21 = 92
+	ColorYUVToRGBNV21 ColorConversionCode = 92
 
 	// ColorYUVToBGRNV21 converts from YUV 4:2:0 to BGR NV21.
-	ColorYUVToBGRNV21 = 93
+	ColorYUVToBGRNV21 ColorConversionCode = 93
 
 	// ColorYUVToRGBANV12 converts from YUV 4:2:0 to RGBA NV12.
-	ColorYUVToRGBANV12 = 94
+	ColorYUVToRGBANV12 ColorConversionCode = 94
 
 	// ColorYUVToBGRANV12 converts from YUV 4:2:0 to BGRA NV12.
-	ColorYUVToBGRANV12 = 95
+	ColorYUVToBGRANV12 ColorConversionCode = 95
 
 	// ColorYUVToRGBANV21 converts from YUV 4:2:0 to RGBA NV21.
-	ColorYUVToRGBANV21 = 96
+	ColorYUVToRGBANV21 ColorConversionCode = 96
 
 	// ColorYUVToBGRANV21 converts from YUV 4:2:0 to BGRA NV21.
-	ColorYUVToBGRANV21 = 97
+	ColorYUVToBGRANV21 ColorConversionCode = 97
 
-	ColorYUVToRGBYV12 = 98
-	ColorYUVToBGRYV12 = 99
-	ColorYUVToRGBIYUV = 100
-	ColorYUVToBGRIYUV = 101
+	ColorYUVToRGBYV12 ColorConversionCode = 98
+	ColorYUVToBGRYV12 ColorConversionCode = 99
+	ColorYUVToRGBIYUV ColorConversionCode = 100
+	ColorYUVToBGRIYUV ColorConversionCode = 101
 
-	ColorYUVToRGBAYV12 = 102
-	ColorYUVToBGRAYV12 = 103
-	ColorYUVToRGBAIYUV = 104
-	ColorYUVToBGRAIYUV = 105
+	ColorYUVToRGBAYV12 ColorConversionCode = 102
+	ColorYUVToBGRAYV12 ColorConversionCode = 103
+	ColorYUVToRGBAIYUV ColorConversionCode = 104
+	ColorYUVToBGRAIYUV ColorConversionCode = 105
 
-	ColorYUVToGRAY420 = 106
+	ColorYUVToGRAY420 ColorConversionCode = 106
 
 	// YUV 4:2:2 family to RGB
-	ColorYUVToRGBUYVY = 107
-	ColorYUVToBGRUYVY = 108
+	ColorYUVToRGBUYVY ColorConversionCode = 107
+	ColorYUVToBGRUYVY ColorConversionCode = 108
 
-	ColorYUVToRGBAUYVY = 111
-	ColorYUVToBGRAUYVY = 112
+	ColorYUVToRGBAUYVY ColorConversionCode = 111
+	ColorYUVToBGRAUYVY ColorConversionCode = 112
 
-	ColorYUVToRGBYUY2 = 115
-	ColorYUVToBGRYUY2 = 116
-	ColorYUVToRGBYVYU = 117
-	ColorYUVToBGRYVYU = 118
+	ColorYUVToRGBYUY2 ColorConversionCode = 115
+	ColorYUVToBGRYUY2 ColorConversionCode = 116
+	ColorYUVToRGBYVYU ColorConversionCode = 117
+	ColorYUVToBGRYVYU ColorConversionCode = 118
 
-	ColorYUVToRGBAYUY2 = 119
-	ColorYUVToBGRAYUY2 = 120
-	ColorYUVToRGBAYVYU = 121
-	ColorYUVToBGRAYVYU = 122
+	ColorYUVToRGBAYUY2 ColorConversionCode = 119
+	ColorYUVToBGRAYUY2 ColorConversionCode = 120
+	ColorYUVToRGBAYVYU ColorConversionCode = 121
+	ColorYUVToBGRAYVYU ColorConversionCode = 122
 
-	ColorYUVToGRAYUYVY = 123
-	ColorYUVToGRAYYUY2 = 124
+	ColorYUVToGRAYUYVY ColorConversionCode = 123
+	ColorYUVToGRAYYUY2 ColorConversionCode = 124
 
 	// alpha premultiplication
-	ColorRGBATomRGBA = 125
-	ColormRGBAToRGBA = 126
+	ColorRGBATomRGBA ColorConversionCode = 125
+	ColormRGBAToRGBA ColorConversionCode = 126
 
 	// RGB to YUV 4:2:0 family
-	ColorRGBToYUVI420 = 127
-	ColorBGRToYUVI420 = 128
+	ColorRGBToYUVI420 ColorConversionCode = 127
+	ColorBGRToYUVI420 ColorConversionCode = 128
 
-	ColorRGBAToYUVI420 = 129
-	ColorBGRAToYUVI420 = 130
-	ColorRGBToYUVYV12  = 131
-	ColorBGRToYUVYV12  = 132
-	ColorRGBAToYUVYV12 = 133
-	ColorBGRAToYUVYV12 = 134
+	ColorRGBAToYUVI420 ColorConversionCode = 129
+	ColorBGRAToYUVI420 ColorConversionCode = 130
+	ColorRGBToYUVYV12  ColorConversionCode = 131
+	ColorBGRToYUVYV12  ColorConversionCode = 132
+	ColorRGBAToYUVYV12 ColorConversionCode = 133
+	ColorBGRAToYUVYV12 ColorConversionCode = 134
 
 	// Demosaicing
-	ColorBayerBGToBGR = 46
-	ColorBayerGBToBGR = 47
-	ColorBayerRGToBGR = 48
-	ColorBayerGRToBGR = 49
+	ColorBayerBGToBGR ColorConversionCode = 46
+	ColorBayerGBToBGR ColorConversionCode = 47
+	ColorBayerRGToBGR ColorConversionCode = 48
+	ColorBayerGRToBGR ColorConversionCode = 49
 
-	ColorBayerBGToGRAY = 86
-	ColorBayerGBToGRAY = 87
-	ColorBayerRGToGRAY = 88
-	ColorBayerGRToGRAY = 89
+	ColorBayerBGToGRAY ColorConversionCode = 86
+	ColorBayerGBToGRAY ColorConversionCode = 87
+	ColorBayerRGToGRAY ColorConversionCode = 88
+	ColorBayerGRToGRAY ColorConversionCode = 89
 
 	// Demosaicing using Variable Number of Gradients
-	ColorBayerBGToBGRVNG = 62
-	ColorBayerGBToBGRVNG = 63
-	ColorBayerRGToBGRVNG = 64
-	ColorBayerGRToBGRVNG = 65
+	ColorBayerBGToBGRVNG ColorConversionCode = 62
+	ColorBayerGBToBGRVNG ColorConversionCode = 63
+	ColorBayerRGToBGRVNG ColorConversionCode = 64
+	ColorBayerGRToBGRVNG ColorConversionCode = 65
 
 	// Edge-Aware Demosaicing
-	ColorBayerBGToBGREA = 135
-	ColorBayerGBToBGREA = 136
-	ColorBayerRGToBGREA = 137
-	ColorBayerGRToBGREA = 138
+	ColorBayerBGToBGREA ColorConversionCode = 135
+	ColorBayerGBToBGREA ColorConversionCode = 136
+	ColorBayerRGToBGREA ColorConversionCode = 137
+	ColorBayerGRToBGREA ColorConversionCode = 138
 
 	// Demosaicing with alpha channel
-	ColorBayerBGToBGRA = 139
-	ColorBayerGBToBGRA = 140
-	ColorBayerRGToBGRA = 141
-	ColorBayerGRToBGRA = 142
+	ColorBayerBGToBGRA ColorConversionCode = 139
+	ColorBayerGBToBGRA ColorConversionCode = 140
+	ColorBayerRGToBGRA ColorConversionCode = 141
+	ColorBayerGRToBGRA ColorConversionCode = 142
 
-	ColorCOLORCVTMAX = 143
+	ColorCOLORCVTMAX ColorConversionCode = 143
 )

--- a/videoio.go
+++ b/videoio.go
@@ -23,133 +23,133 @@ const (
 
 	// VideoCapturePosFrames 0-based index of the frame to be
 	// decoded/captured next.
-	VideoCapturePosFrames = 1
+	VideoCapturePosFrames VideoCaptureProperties = 1
 
 	// VideoCapturePosAVIRatio relative position of the video file:
 	// 0=start of the film, 1=end of the film.
-	VideoCapturePosAVIRatio = 2
+	VideoCapturePosAVIRatio VideoCaptureProperties = 2
 
 	// VideoCaptureFrameWidth is width of the frames in the video stream.
-	VideoCaptureFrameWidth = 3
+	VideoCaptureFrameWidth VideoCaptureProperties = 3
 
 	// VideoCaptureFrameHeight controls height of frames in the video stream.
-	VideoCaptureFrameHeight = 4
+	VideoCaptureFrameHeight VideoCaptureProperties = 4
 
 	// VideoCaptureFPS controls capture frame rate.
-	VideoCaptureFPS = 5
+	VideoCaptureFPS VideoCaptureProperties = 5
 
 	// VideoCaptureFOURCC contains the 4-character code of codec.
 	// see VideoWriter::fourcc for details.
-	VideoCaptureFOURCC = 6
+	VideoCaptureFOURCC VideoCaptureProperties = 6
 
 	// VideoCaptureFrameCount contains number of frames in the video file.
-	VideoCaptureFrameCount = 7
+	VideoCaptureFrameCount VideoCaptureProperties = 7
 
 	// VideoCaptureFormat format of the Mat objects returned by
 	// VideoCapture::retrieve().
-	VideoCaptureFormat = 8
+	VideoCaptureFormat VideoCaptureProperties = 8
 
 	// VideoCaptureMode contains backend-specific value indicating
 	// the current capture mode.
-	VideoCaptureMode = 9
+	VideoCaptureMode VideoCaptureProperties = 9
 
 	// VideoCaptureBrightness is brightness of the image
 	// (only for those cameras that support).
-	VideoCaptureBrightness = 10
+	VideoCaptureBrightness VideoCaptureProperties = 10
 
 	// VideoCaptureContrast is contrast of the image
 	// (only for cameras that support it).
-	VideoCaptureContrast = 11
+	VideoCaptureContrast VideoCaptureProperties = 11
 
 	// VideoCaptureSaturation saturation of the image
 	// (only for cameras that support).
-	VideoCaptureSaturation = 12
+	VideoCaptureSaturation VideoCaptureProperties = 12
 
 	// VideoCaptureHue hue of the image (only for cameras that support).
-	VideoCaptureHue = 13
+	VideoCaptureHue VideoCaptureProperties = 13
 
 	// VideoCaptureGain is the gain of the capture image.
 	// (only for those cameras that support).
-	VideoCaptureGain = 14
+	VideoCaptureGain VideoCaptureProperties = 14
 
 	// VideoCaptureExposure is the exposure of the capture image.
 	// (only for those cameras that support).
-	VideoCaptureExposure = 15
+	VideoCaptureExposure VideoCaptureProperties = 15
 
 	// VideoCaptureConvertRGB is a boolean flags indicating whether
 	// images should be converted to RGB.
-	VideoCaptureConvertRGB = 16
+	VideoCaptureConvertRGB VideoCaptureProperties = 16
 
 	// VideoCaptureWhiteBalanceBlueU is currently unsupported.
-	VideoCaptureWhiteBalanceBlueU = 17
+	VideoCaptureWhiteBalanceBlueU VideoCaptureProperties = 17
 
 	// VideoCaptureRectification is the rectification flag for stereo cameras.
 	// Note: only supported by DC1394 v 2.x backend currently.
-	VideoCaptureRectification = 18
+	VideoCaptureRectification VideoCaptureProperties = 18
 
 	// VideoCaptureMonochrome indicates whether images should be
 	// converted to monochrome.
-	VideoCaptureMonochrome = 19
+	VideoCaptureMonochrome VideoCaptureProperties = 19
 
 	// VideoCaptureSharpness controls image capture sharpness.
-	VideoCaptureSharpness = 20
+	VideoCaptureSharpness VideoCaptureProperties = 20
 
 	// VideoCaptureAutoExposure controls the DC1394 exposure control
 	// done by camera, user can adjust reference level using this feature.
-	VideoCaptureAutoExposure = 21
+	VideoCaptureAutoExposure VideoCaptureProperties = 21
 
 	// VideoCaptureGamma controls video capture gamma.
-	VideoCaptureGamma = 22
+	VideoCaptureGamma VideoCaptureProperties = 22
 
 	// VideoCaptureTemperature controls video capture temperature.
-	VideoCaptureTemperature = 23
+	VideoCaptureTemperature VideoCaptureProperties = 23
 
 	// VideoCaptureTrigger controls video capture trigger.
-	VideoCaptureTrigger = 24
+	VideoCaptureTrigger VideoCaptureProperties = 24
 
 	// VideoCaptureTriggerDelay controls video capture trigger delay.
-	VideoCaptureTriggerDelay = 25
+	VideoCaptureTriggerDelay VideoCaptureProperties = 25
 
 	// VideoCaptureWhiteBalanceRedV controls video capture setting for
 	// white balance.
-	VideoCaptureWhiteBalanceRedV = 26
+	VideoCaptureWhiteBalanceRedV VideoCaptureProperties = 26
 
 	// VideoCaptureZoom controls video capture zoom.
-	VideoCaptureZoom = 27
+	VideoCaptureZoom VideoCaptureProperties = 27
 
 	// VideoCaptureFocus controls video capture focus.
-	VideoCaptureFocus = 28
+	VideoCaptureFocus VideoCaptureProperties = 28
 
 	// VideoCaptureGUID controls video capture GUID.
-	VideoCaptureGUID = 29
+	VideoCaptureGUID VideoCaptureProperties = 29
 
 	// VideoCaptureISOSpeed controls video capture ISO speed.
-	VideoCaptureISOSpeed = 30
+	VideoCaptureISOSpeed VideoCaptureProperties = 30
 
 	// VideoCaptureBacklight controls video capture backlight.
-	VideoCaptureBacklight = 32
+	VideoCaptureBacklight VideoCaptureProperties = 32
 
 	// VideoCapturePan controls video capture pan.
-	VideoCapturePan = 33
+	VideoCapturePan VideoCaptureProperties = 33
 
 	// VideoCaptureTilt controls video capture tilt.
-	VideoCaptureTilt = 34
+	VideoCaptureTilt VideoCaptureProperties = 34
 
 	// VideoCaptureRoll controls video capture roll.
-	VideoCaptureRoll = 35
+	VideoCaptureRoll VideoCaptureProperties = 35
 
 	// VideoCaptureIris controls video capture iris.
-	VideoCaptureIris = 36
+	VideoCaptureIris VideoCaptureProperties = 36
 
 	// VideoCaptureSettings is the pop up video/camera filter dialog. Note:
 	// only supported by DSHOW backend currently. The property value is ignored.
-	VideoCaptureSettings = 37
+	VideoCaptureSettings VideoCaptureProperties = 37
 
 	// VideoCaptureBufferSize controls video capture buffer size.
-	VideoCaptureBufferSize = 38
+	VideoCaptureBufferSize VideoCaptureProperties = 38
 
 	// VideoCaptureAutoFocus controls video capture auto focus..
-	VideoCaptureAutoFocus = 39
+	VideoCaptureAutoFocus VideoCaptureProperties = 39
 )
 
 // VideoCapture is a wrapper around the OpenCV VideoCapture class.


### PR DESCRIPTION
Annotate constant in const() blocks with the correct type if they have a value specified. This also changes some function parameter types from `int` to the correct type.

Fixes #686.