### PR TITLE
Added ability to load Torch file

### DIFF
--- a/dnn.cpp
+++ b/dnn.cpp
@@ -33,6 +33,11 @@ Net Net_ReadNetFromTensorflowBytes(struct ByteArray model) {
     return n;
 }
 
+Net Net_ReadNetFromTorch(const char* model) {
+    Net n = new cv::dnn::Net(cv::dnn::readNetFromTorch(model));
+    return n;
+}
+
 void Net_Close(Net net) {
     delete net;
 }

--- a/dnn.go
+++ b/dnn.go
@@ -292,6 +292,18 @@ func ReadNetFromTensorflowBytes(model []byte) (Net, error) {
 	return Net{p: unsafe.Pointer(C.Net_ReadNetFromTensorflowBytes(*bModel))}, nil
 }
 
+// ReadNetFromTorch reads a network model stored in Torch framework's format (t7).
+//   check net.Empty() for read failure
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d6/d0f/group__dnn.html#gaaaed8c8530e9e92fe6647700c13d961e
+//
+func ReadNetFromTorch(model string) Net {
+	cmodel := C.CString(model)
+	defer C.free(unsafe.Pointer(cmodel))
+	return Net{p: unsafe.Pointer(C.Net_ReadNetFromTorch(cmodel))}
+}
+
 // BlobFromImage creates 4-dimensional blob from image. Optionally resizes and crops
 // image from center, subtract mean values, scales values by scalefactor,
 // swap Blue and Red channels.

--- a/dnn.h
+++ b/dnn.h
@@ -25,6 +25,7 @@ Net Net_ReadNetFromCaffe(const char* prototxt, const char* caffeModel);
 Net Net_ReadNetFromCaffeBytes(struct ByteArray prototxt, struct ByteArray caffeModel);
 Net Net_ReadNetFromTensorflow(const char* model);
 Net Net_ReadNetFromTensorflowBytes(struct ByteArray model);
+Net Net_ReadNetFromTorch(const char* model);
 Mat Net_BlobFromImage(Mat image, double scalefactor, Size size, Scalar mean, bool swapRB,
                       bool crop);
 void Net_BlobFromImages(struct Mats images, Mat blob,  double scalefactor, Size size, 


### PR DESCRIPTION
Exactly the same as loading other DNN nets, but this one was missing. Allows you to load .t7 files.

```
embedder := gocv.ReadNetFromTorch(embeddingModel)
```

Tested using `openface.nn4.small2.v1.t7` to get 128d vectors from an image without any issues.