### PR TITLE
Fix a memory leak issue in SIFT.

### DIFF
--- a/features2d.go
+++ b/features2d.go
@@ -779,6 +779,7 @@ func (d *SIFT) Close() error {
 //
 func (d *SIFT) Detect(src Mat) []KeyPoint {
 	ret := C.SIFT_Detect((C.SIFT)(d.p), C.Mat(src.Ptr()))
+	defer C.KeyPoints_Close(ret)
 
 	return getKeyPoints(ret)
 }
@@ -792,6 +793,7 @@ func (d *SIFT) DetectAndCompute(src Mat, mask Mat) ([]KeyPoint, Mat) {
 	desc := NewMat()
 	ret := C.SIFT_DetectAndCompute((C.SIFT)(d.p), C.Mat(src.Ptr()), C.Mat(mask.Ptr()),
 		C.Mat(desc.Ptr()))
+	defer C.KeyPoints_Close(ret)
 
 	return getKeyPoints(ret), desc
 }


### PR DESCRIPTION
Hi,

I noticed a memory leak issue in the SIFT detection code path, where the C.KeyPoints structures are not closed after extraction. This may be related to https://github.com/hybridgroup/gocv/issues/205, but it was closed more than 2 years ago.

Here's a demo: https://pastebin.com/CTiE2SKJ. The image I'm using is https://upload.wikimedia.org/wikipedia/commons/c/c7/Caravaggio_-_Boy_Bitten_by_a_Lizard.jpg.

Before the fix, the process would use ~1G memory after 1280 iterations (this would take ~40 mins on my machine). After the fix it stays at ~30MB after GC periodically kicks in.

Environment:
macOS Catalina
go version go1.15 darwin/amd64

Thanks,
Todd
