### PR TITLE
Add Matrix initializers: eye, ones, zeros

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -28,6 +28,21 @@ Mat Mat_NewFromBytes(int rows, int cols, int type, struct ByteArray buf) {
     return new cv::Mat(rows, cols, type, buf.data);
 }
 
+Mat Eye(int rows, int cols, int type) {
+    cv::Mat temp = cv::Mat::eye(rows, cols, type);
+    return new cv::Mat(rows, cols, type, temp.data);
+}
+
+Mat Zeros(int rows, int cols, int type) {
+    cv::Mat temp = cv::Mat::zeros(rows, cols, type);
+    return new cv::Mat(rows, cols, type, temp.data);
+}
+
+Mat Ones(int rows, int cols, int type) {
+    cv::Mat temp = cv::Mat::ones(rows, cols, type);
+    return new cv::Mat(rows, cols, type, temp.data);
+}
+
 Mat Mat_FromPtr(Mat m, int rows, int cols, int type, int prow, int pcol) {
     return new cv::Mat(rows, cols, type, m->ptr(prow, pcol));
 }

--- a/core.go
+++ b/core.go
@@ -224,6 +224,18 @@ func NewMatFromBytes(rows int, cols int, mt MatType, data []byte) (Mat, error) {
 	return newMat(C.Mat_NewFromBytes(C.int(rows), C.int(cols), C.int(mt), *cBytes)), nil
 }
 
+func Eye(rows int, cols int, mt MatType) Mat {
+	return newMat(C.Eye(C.int(rows), C.int(cols), C.int(mt)))
+}
+
+func Zeros(rows int, cols int, mt MatType) Mat {
+	return newMat(C.Zeros(C.int(rows), C.int(cols), C.int(mt)))
+}
+
+func Ones(rows int, cols int, mt MatType) Mat {
+	return newMat(C.Ones(C.int(rows), C.int(cols), C.int(mt)))
+}
+
 // FromPtr returns a new Mat with a specific size and type, initialized from a Mat Ptr.
 func (m *Mat) FromPtr(rows int, cols int, mt MatType, prow int, pcol int) (Mat, error) {
 	return newMat(C.Mat_FromPtr(m.p, C.int(rows), C.int(cols), C.int(mt), C.int(prow), C.int(pcol))), nil

--- a/core.go
+++ b/core.go
@@ -224,14 +224,29 @@ func NewMatFromBytes(rows int, cols int, mt MatType, data []byte) (Mat, error) {
 	return newMat(C.Mat_NewFromBytes(C.int(rows), C.int(cols), C.int(mt), *cBytes)), nil
 }
 
+// Returns an identity matrix of the specified size and type.
+//
+// The method returns a Matlab-style identity matrix initializer, similarly to Mat::zeros. Similarly to Mat::ones.
+// For further details, please see:
+// https://docs.opencv.org/master/d3/d63/classcv_1_1Mat.html#a2cf9b9acde7a9852542bbc20ef851ed2
 func Eye(rows int, cols int, mt MatType) Mat {
 	return newMat(C.Eye(C.int(rows), C.int(cols), C.int(mt)))
 }
 
+// Returns a zero array of the specified size and type.
+//
+// The method returns a Matlab-style zero array initializer.
+// For further details, please see:
+// https://docs.opencv.org/master/d3/d63/classcv_1_1Mat.html#a0b57b6a326c8876d944d188a46e0f556
 func Zeros(rows int, cols int, mt MatType) Mat {
 	return newMat(C.Zeros(C.int(rows), C.int(cols), C.int(mt)))
 }
 
+// Returns an array of all 1's of the specified size and type.
+//
+// The method returns a Matlab-style 1's array initializer
+// For further details, please see:
+// https://docs.opencv.org/master/d3/d63/classcv_1_1Mat.html#a69ae0402d116fc9c71908d8508dc2f09
 func Ones(rows int, cols int, mt MatType) Mat {
 	return newMat(C.Ones(C.int(rows), C.int(cols), C.int(mt)))
 }

--- a/core.h
+++ b/core.h
@@ -258,6 +258,9 @@ int Mat_Cols(Mat m);
 int Mat_Channels(Mat m);
 int Mat_Type(Mat m);
 int Mat_Step(Mat m);
+Mat Eye(int rows, int cols, int type);
+Mat Zeros(int rows, int cols, int type);
+Mat Ones(int rows, int cols, int type);
 
 uint8_t Mat_GetUChar(Mat m, int row, int col);
 uint8_t Mat_GetUChar3(Mat m, int x, int y, int z);

--- a/core_test.go
+++ b/core_test.go
@@ -222,6 +222,68 @@ func TestMatToBytes(t *testing.T) {
 	}
 }
 
+func TestMatEye(t *testing.T) {
+	data := []byte{1, 0, 0, 1}
+	e := Eye(2, 2, MatTypeCV8U)
+
+	if bytes.Compare(e.ToBytes(), data) != 0 {
+		t.Errorf("Mat bytes are not equal")
+	}
+	e.Close()
+
+	data2 := []byte{1, 0, 0, 0, 1, 0}
+	e2 := Eye(2, 3, MatTypeCV8U)
+	if bytes.Compare(e2.ToBytes(), data2) != 0 {
+		t.Errorf("Mat bytes are not equal")
+	}
+
+	val := e2.GetUCharAt(0, 2)
+	if val != 0 {
+		t.Errorf("Mat bytes unexpected value at [0,2]: %v\n", val)
+	}
+	e2.Close()
+}
+
+func TestMatZeros(t *testing.T) {
+	expected := NewMatWithSize(2, 3, MatTypeCV8U)
+	z := Zeros(2, 3, MatTypeCV8U)
+
+	if bytes.Compare(z.ToBytes(), expected.ToBytes()) != 0 {
+		t.Errorf("Mat bytes are not equal")
+	}
+
+	expected.Close()
+	z.Close()
+
+	expected2 := NewMatWithSize(2, 3, MatTypeCV64F)
+	z2 := Zeros(2, 3, MatTypeCV64F)
+
+	if bytes.Compare(z2.ToBytes(), expected2.ToBytes()) != 0 {
+		t.Errorf("Mat bytes are not equal")
+	}
+	expected2.Close()
+	z2.Close()
+}
+
+func TestMatOnes(t *testing.T) {
+	expected := NewMatWithSizeFromScalar(Scalar{Val1: 1}, 2, 3, MatTypeCV8U)
+	o := Ones(2, 3, MatTypeCV8U)
+	if bytes.Compare(o.ToBytes(), expected.ToBytes()) != 0 {
+		t.Errorf("Mat bytes are not equal")
+	}
+	defer expected.Close()
+	defer o.Close()
+
+	expected2 := NewMatWithSizeFromScalar(Scalar{Val1: 1}, 2, 1, MatTypeCV64F)
+	o2 := Ones(2, 1, MatTypeCV64F)
+
+	if bytes.Compare(o2.ToBytes(), expected2.ToBytes()) != 0 {
+		t.Errorf("Mat bytes are not equal")
+	}
+	expected2.Close()
+	o2.Close()
+}
+
 func TestMatDataPtr(t *testing.T) {
 	const (
 		rows = 101


### PR DESCRIPTION
Following issue [244](https://github.com/hybridgroup/gocv/issues/244) here are a few useful Matrix initializers. 