### PR TITLE
Add option to return baseline with GetTextSizeWithBaseline

### DIFF
--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -494,7 +494,11 @@ void Polylines(Mat img, Contours points, bool isClosed, Scalar color,int thickne
 }
 
 struct Size GetTextSize(const char* text, int fontFace, double fontScale, int thickness) {
-    cv::Size sz = cv::getTextSize(text, fontFace, fontScale, thickness, NULL);
+    return GetTextSizeWithBaseline(text, fontFace, fontScale, thickness, NULL);
+}
+
+struct Size GetTextSizeWithBaseline(const char* text, int fontFace, double fontScale, int thickness, int* baesline) {
+    cv::Size sz = cv::getTextSize(text, fontFace, fontScale, thickness, baesline);
     Size size = {sz.width, sz.height};
     return size;
 }

--- a/imgproc.go
+++ b/imgproc.go
@@ -1447,6 +1447,22 @@ func GetTextSize(text string, fontFace HersheyFont, fontScale float64, thickness
 	return image.Pt(int(sz.width), int(sz.height))
 }
 
+// GetTextSizeWithBaseline calculates the width and height of a text string including the basline of the text.
+// It returns an image.Point with the size required to draw text using
+// a specific font face, scale, and thickness as well as its baseline.
+//
+// For further details, please see:
+// http://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#ga3d2abfcb995fd2db908c8288199dba82
+//
+func GetTextSizeWithBaseline(text string, fontFace HersheyFont, fontScale float64, thickness int) (image.Point, int) {
+	cText := C.CString(text)
+	defer C.free(unsafe.Pointer(cText))
+	cBaseline := C.int(0)
+
+	sz := C.GetTextSizeWithBaseline(cText, C.int(fontFace), C.double(fontScale), C.int(thickness), &cBaseline)
+	return image.Pt(int(sz.width), int(sz.height)), int(cBaseline)
+}
+
 // PutText draws a text string.
 // It renders the specified text string into the img Mat at the location
 // passed in the "org" param, using the desired font face, font scale,

--- a/imgproc.h
+++ b/imgproc.h
@@ -85,6 +85,7 @@ void Rectangle(Mat img, Rect rect, Scalar color, int thickness);
 void FillPoly(Mat img, Contours points, Scalar color);
 void Polylines(Mat img, Contours points, bool isClosed, Scalar color, int thickness);
 struct Size GetTextSize(const char* text, int fontFace, double fontScale, int thickness);
+struct Size GetTextSizeWithBaseline(const char* text, int fontFace, double fontScale, int thickness, int* baseline);
 void PutText(Mat img, const char* text, Point org, int fontFace, double fontScale,
              Scalar color, int thickness);
 void PutTextWithParams(Mat img, const char* text, Point org, int fontFace, double fontScale,


### PR DESCRIPTION
Currently, there is no way to get the baseline value of the opencv getTextSize function. Added GetTextSizeWithBaseline and used it with GetTextSize. Let me know what you think