### PR TITLE
stop failing tests

### DIFF
--- a/videoio.go
+++ b/videoio.go
@@ -228,7 +228,7 @@ func (v *VideoCapture) CodecString() string {
 	res := ""
 	hexes := []int64{0xff, 0xff00, 0xff0000, 0xff000000}
 	for i, h := range hexes {
-		res += string(int64(v.Get(VideoCaptureFOURCC)) & h >> (uint(i * 8)))
+		res += string(byte(int64(v.Get(VideoCaptureFOURCC)) & h >> (uint(i * 8))))
 	}
 	return res
 }


### PR DESCRIPTION
This stops 'make test' from failing with go 1.15.3