### PR TITLE
Keep a reference to a []byte that backs a Mat.

### DIFF
--- a/core.go
+++ b/core.go
@@ -178,6 +178,9 @@ var ErrEmptyByteSlice = errors.New("empty byte array")
 //
 type Mat struct {
 	p C.Mat
+
+	// Non-nil if Mat was created with a []byte (using NewMatFromBytes()). Nil otherwise.
+	d []byte
 }
 
 // NewMat returns a new empty Mat.
@@ -221,7 +224,17 @@ func NewMatFromBytes(rows int, cols int, mt MatType, data []byte) (Mat, error) {
 	if err != nil {
 		return Mat{}, err
 	}
-	return newMat(C.Mat_NewFromBytes(C.int(rows), C.int(cols), C.int(mt), *cBytes)), nil
+	mat := newMat(C.Mat_NewFromBytes(C.int(rows), C.int(cols), C.int(mt), *cBytes))
+
+	// Store a reference to the backing data slice. This is needed because we pass the backing
+	// array directly to C code and without keeping a Go reference to it, it might end up
+	// garbage collected which would result in crashes.
+	//
+	// TODO(bga): This could live in newMat() but I wanted to reduce the change surface.
+	// TODO(bga): Code that needs access to the array from Go could use this directly.
+	mat.d = data
+
+	return mat, nil
 }
 
 // FromPtr returns a new Mat with a specific size and type, initialized from a Mat Ptr.

--- a/core_test.go
+++ b/core_test.go
@@ -9,6 +9,7 @@ import (
 	_ "image/png"
 	"log"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -31,6 +32,26 @@ func TestMatFromBytesWithEmptyByteSlise(t *testing.T) {
 		t.Errorf("TestMatFromBytesWithEmptyByteSlise: "+
 			"error must contain the following description: "+
 			"%v, but have: %v", ErrEmptyByteSlice, err)
+	}
+}
+
+func TestMatFromBytesSliceGarbageCollected(t *testing.T) {
+	data := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	m, err := NewMatFromBytes(2, 5, MatTypeCV8U, data)
+	if err != nil {
+		t.Error("TestMatFromBytesSliceGarbageCollected: " +
+			"failed to create Mat")
+	}
+	defer m.Close()
+
+	// Force garbage collection. As data is not used after this, its backing array should
+	// be collected.
+	runtime.GC()
+
+	v := m.GetUCharAt(0, 0)
+	if v != 0 {
+		t.Errorf("TestMatFromBytesSliceGarbageCollected: "+
+			"unexpected value. Want %d, got %d.", 0, v)
 	}
 }
 

--- a/core_test.go
+++ b/core_test.go
@@ -9,6 +9,7 @@ import (
 	_ "image/png"
 	"log"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -31,6 +32,25 @@ func TestMatFromBytesWithEmptyByteSlise(t *testing.T) {
 		t.Errorf("TestMatFromBytesWithEmptyByteSlise: "+
 			"error must contain the following description: "+
 			"%v, but have: %v", ErrEmptyByteSlice, err)
+	}
+}
+
+func TestMatFromBytesSliceGarbageCollected(t *testing.T) {
+	data := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	m, err := NewMatFromBytes(2, 5, MatTypeCV8U, data)
+	if err != nil {
+		t.Error("TestMatFromBytesSliceGarbageCollected: " +
+			"failed to create Mat")
+	}
+
+	// Force garbage collection. As data is not used after this, its backing array should
+	// be collected.
+	runtime.GC()
+
+	v := m.GetUCharAt(0, 0)
+	if v != 0 {
+		t.Errorf("TestMatFromBytesSliceGarbageCollected: "+
+			"unexpected value. Want %d, got %d.", 0, v)
 	}
 }
 

--- a/mat_noprofile.go
+++ b/mat_noprofile.go
@@ -17,5 +17,6 @@ func newMat(p C.Mat) Mat {
 func (m *Mat) Close() error {
 	C.Mat_Close(m.p)
 	m.p = nil
+	m.d = nil
 	return nil
 }

--- a/mat_profile.go
+++ b/mat_profile.go
@@ -70,5 +70,6 @@ func (m *Mat) Close() error {
 	C.Mat_Close(m.p)
 	MatProfile.Remove(m.p)
 	m.p = nil
+	m.d = nil
 	return nil
 }


### PR DESCRIPTION
- This prevents crashes when Mats created with NewMatFromBytes are used.