### PR TITLE
Add created mats in Split and ForwardLayers to profile

### DIFF
--- a/core.go
+++ b/core.go
@@ -1785,6 +1785,7 @@ func Split(src Mat) (mv []Mat) {
 	mv = make([]Mat, cMats.length)
 	for i := C.int(0); i < cMats.length; i++ {
 		mv[i].p = C.Mats_get(cMats, i)
+		addMatToProfile(mv[i].p)
 	}
 	return
 }

--- a/core.go
+++ b/core.go
@@ -1774,6 +1774,7 @@ func SortIdx(src Mat, dst *Mat, flags SortFlags) {
 }
 
 // Split creates an array of single channel images from a multi-channel image
+// Created images should be closed manualy to avoid memory leaks.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga0547c7fed86152d7e9d0096029c8518a

--- a/core_test.go
+++ b/core_test.go
@@ -103,6 +103,9 @@ func TestMatWithSizes(t *testing.T) {
 				}
 			}
 		}
+		for _, ch := range matChans {
+			ch.Close()
+		}
 	})
 
 	t.Run("create 1x2x3 multidimensional array with 3 channel and data", func(t *testing.T) {
@@ -166,6 +169,9 @@ func TestMatWithSizes(t *testing.T) {
 					}
 				}
 			}
+		}
+		for _, ch := range matChans {
+			ch.Close()
 		}
 	})
 }
@@ -270,6 +276,9 @@ func TestMatWithSizeFromScalar(t *testing.T) {
 				}
 			}
 		}
+	}
+	for _, i := range matChans {
+		i.Close()
 	}
 }
 
@@ -1657,6 +1666,9 @@ func TestMatSplit(t *testing.T) {
 	dst := NewMat()
 	defer dst.Close()
 	Merge(chans, &dst)
+	for _, ch := range chans {
+		ch.Close()
+	}
 	diff := NewMat()
 	defer diff.Close()
 	AbsDiff(src, dst, &diff)
@@ -2285,6 +2297,10 @@ func TestMixChannels(t *testing.T) {
 		}
 	}
 
+	for _, ch := range bgrChans {
+		ch.Close()
+	}
+
 	alphaChans := Split(alpha)
 	scalarByte = []byte{255}
 	for c := 0; c < alpha.Channels(); c++ {
@@ -2295,6 +2311,9 @@ func TestMixChannels(t *testing.T) {
 				}
 			}
 		}
+	}
+	for _, ch := range alphaChans {
+		ch.Close()
 	}
 }
 

--- a/dnn.go
+++ b/dnn.go
@@ -180,6 +180,7 @@ func (net *Net) ForwardLayers(outBlobNames []string) (blobs []Mat) {
 	blobs = make([]Mat, cMats.length)
 	for i := C.int(0); i < cMats.length; i++ {
 		blobs[i].p = C.Mats_get(cMats, i)
+		addMatToProfile(blobs[i].p)
 	}
 	return
 }

--- a/dnn_test.go
+++ b/dnn_test.go
@@ -89,6 +89,9 @@ func checkNet(t *testing.T, net Net) {
 	if perf == 0 {
 		t.Error("ReadNet GetPerfProfile error")
 	}
+	for _, bl := range prob {
+		bl.Close()
+	}
 }
 
 func TestReadNetDisk(t *testing.T) {

--- a/mat_noprofile.go
+++ b/mat_noprofile.go
@@ -8,6 +8,11 @@ package gocv
 */
 import "C"
 
+// addMatToProfile does nothing if matprofile tag is not set.
+func addMatToProfile(p C.Mat) {
+	return
+}
+
 // newMat returns a new Mat from a C Mat
 func newMat(p C.Mat) Mat {
 	return Mat{p: p}

--- a/mat_profile.go
+++ b/mat_profile.go
@@ -58,6 +58,12 @@ func init() {
 	}
 }
 
+// addMatToProfile records Mat to the MatProfile.
+func addMatToProfile(p C.Mat) {
+	MatProfile.Add(p, 1)
+	return
+}
+
 // newMat returns a new Mat from a C Mat and records it to the MatProfile.
 func newMat(p C.Mat) Mat {
 	m := Mat{p: p}

--- a/matprofile_test.go
+++ b/matprofile_test.go
@@ -40,3 +40,27 @@ func TestMatProfile(t *testing.T) {
 		t.Errorf("Mat profile should == 0 after Close but instead was %v", MatProfile.Count())
 	}
 }
+
+func TestAddMatToProfile(t *testing.T) {
+	mat := NewMatWithSize(5, 5, MatTypeCV8UC3)
+	if MatProfile.Count() != 1 {
+		t.Errorf("Mat profile should == 1 after creating 3 channel mat but instead was %v", MatProfile.Count())
+	}
+
+	channels := Split(mat)
+	if MatProfile.Count() != 4 {
+		t.Errorf("Mat profile should == 4 after split channel but instead was %v", MatProfile.Count())
+	}
+
+	for _, channel := range channels {
+		channel.Close()
+	}
+	if MatProfile.Count() != 1 {
+		t.Errorf("Mat profile should == 1 after closing channels but instead was %v", MatProfile.Count())
+	}
+
+	mat.Close()
+	if MatProfile.Count() != 0 {
+		t.Errorf("Mat profile should == 0 after closing all mats but instead was %v", MatProfile.Count())
+	}
+}

--- a/matprofile_test.go
+++ b/matprofile_test.go
@@ -42,6 +42,11 @@ func TestMatProfile(t *testing.T) {
 }
 
 func TestAddMatToProfile(t *testing.T) {
+	if MatProfile.Count() != 0 {
+		var b bytes.Buffer
+		MatProfile.WriteTo(&b, 1)
+		t.Errorf("Mat profile should start with 0 entries. A test failure here likely means that some other test is not closing all Mats. Here are the current profile entries:\n%v", b.String())
+	}
 	mat := NewMatWithSize(5, 5, MatTypeCV8UC3)
 	if MatProfile.Count() != 1 {
 		t.Errorf("Mat profile should == 1 after creating 3 channel mat but instead was %v", MatProfile.Count())


### PR DESCRIPTION
This change reflect issue #771 where mats created inside Split and ForwardLayers  are not registered inside profile. After creating new function which just adds passed mats to profile, those mats are properly registered.