### PR TITLE
Adding gcc-c++ package to rpm deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TMP_DIR?=/tmp/
 BUILD_SHARED_LIBS?=ON
 
 # Package list for each well-known Linux distribution
-RPMS=cmake curl wget git gtk2-devel libpng-devel libjpeg-devel libtiff-devel tbb tbb-devel libdc1394-devel unzip
+RPMS=cmake curl wget git gtk2-devel libpng-devel libjpeg-devel libtiff-devel tbb tbb-devel libdc1394-devel unzip gcc-c++
 DEBS=unzip wget build-essential cmake curl git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libdc1394-22-dev
 
 explain:


### PR DESCRIPTION
A clean fedora workstation does not come with a c++ compiler so we need to install that as a dep.