### PR TITLE
all: make task and build tag for static build of OpenCV/GoCV on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,17 @@ build_cuda:
 	$(MAKE) preinstall
 	cd -
 
+# Build OpenCV staticly linked
+build_static:
+	cd $(TMP_DIR)opencv/opencv-$(OPENCV_VERSION)
+	mkdir build
+	cd build
+	rm -rf *
+	cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -D BUILD_SHARED_LIBS=OFF -D OPENCV_EXTRA_MODULES_PATH=$(TMP_DIR)opencv/opencv_contrib-$(OPENCV_VERSION)/modules -D BUILD_DOCS=OFF -D BUILD_EXAMPLES=OFF -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF -D BUILD_opencv_java=NO -D BUILD_opencv_python=NO -D BUILD_opencv_python2=NO -D BUILD_opencv_python3=NO -DWITH_JASPER=OFF -DWITH_QT=OFF -DWITH_GTK=OFF -DWITH_FFMPEG=OFF -DWITH_TIFF=OFF -DWITH_WEBP=OFF -DWITH_PNG=OFF -DWITH_1394=OFF -DWITH_OPENJPEG=OFF -DOPENCV_GENERATE_PKGCONFIG=ON ..
+	$(MAKE) -j $(shell nproc --all)
+	$(MAKE) preinstall
+	cd -
+
 # Build OpenCV with cuda.
 build_all:
 	cd $(TMP_DIR)opencv/opencv-$(OPENCV_VERSION)
@@ -186,6 +197,9 @@ install_cuda: deps download sudo_pre_install_clean build_cuda sudo_install clean
 
 # Do everything with openvino.
 install_openvino: deps download download_openvino sudo_pre_install_clean build_openvino_package sudo_install_openvino build_openvino sudo_install clean verify_openvino
+
+# Do everything statically.
+install_static: deps download sudo_pre_install_clean build_static sudo_install clean verify
 
 # Do everything with openvino and cuda.
 install_all: deps download download_openvino sudo_pre_install_clean build_openvino_package sudo_install_openvino build_all sudo_install clean verify_openvino verify_cuda

--- a/cgo.go
+++ b/cgo.go
@@ -1,4 +1,4 @@
-// +build !customenv
+// +build !customenv,!static
 
 package gocv
 

--- a/cgo_static.go
+++ b/cgo_static.go
@@ -1,0 +1,12 @@
+// +build !customenv,static,!windows
+
+package gocv
+
+// Changes here should be mirrored in contrib/cgo.go and cuda/cgo.go.
+
+/*
+#cgo CXXFLAGS:   --std=c++11
+#cgo CPPFLAGS: -I/usr/local/include -I/usr/local/include/opencv4
+#cgo LDFLAGS: -L/usr/local/lib -L/usr/local/lib/opencv4/3rdparty -lopencv_gapi -lopencv_stitching -lopencv_aruco -lopencv_bgsegm -lopencv_bioinspired -lopencv_ccalib -lopencv_dnn_objdetect -lopencv_dpm -lopencv_face -lopencv_fuzzy -lopencv_hfs -lopencv_img_hash -lopencv_line_descriptor -lopencv_quality -lopencv_reg -lopencv_rgbd -lopencv_saliency -lopencv_stereo -lopencv_structured_light -lopencv_phase_unwrapping -lopencv_superres -lopencv_optflow -lopencv_surface_matching -lopencv_tracking -lopencv_datasets -lopencv_text -lopencv_highgui -lopencv_dnn -lopencv_plot -lopencv_videostab -lopencv_video -lopencv_videoio -lopencv_xfeatures2d -lopencv_shape -lopencv_ml -lopencv_ximgproc -lopencv_xobjdetect -lopencv_objdetect -lopencv_calib3d -lopencv_imgcodecs -lopencv_features2d -lopencv_flann -lopencv_xphoto -lopencv_photo -lopencv_imgproc -lopencv_core -littnotify -llibprotobuf -lIlmImf -lquirc -lippiw -lippicv -lade -lz -ljpeg -ldl -lm -lpthread -lrt -lquadmath
+*/
+import "C"

--- a/contrib/cgo.go
+++ b/contrib/cgo.go
@@ -1,4 +1,4 @@
-// +build !customenv,!openvino
+// +build !customenv,!static
 
 package contrib
 

--- a/contrib/cgo_static.go
+++ b/contrib/cgo_static.go
@@ -1,0 +1,12 @@
+// +build !customenv,static,!windows
+
+package gocv
+
+// Changes here should be mirrored in contrib/cgo.go and cuda/cgo.go.
+
+/*
+#cgo CXXFLAGS:   --std=c++11
+#cgo CPPFLAGS: -I/usr/local/include -I/usr/local/include/opencv4
+#cgo LDFLAGS: -L/usr/local/lib -L/usr/local/lib/opencv4/3rdparty -lopencv_gapi -lopencv_stitching -lopencv_aruco -lopencv_bgsegm -lopencv_bioinspired -lopencv_ccalib -lopencv_dnn_objdetect -lopencv_dpm -lopencv_face -lopencv_fuzzy -lopencv_hfs -lopencv_img_hash -lopencv_line_descriptor -lopencv_quality -lopencv_reg -lopencv_rgbd -lopencv_saliency -lopencv_stereo -lopencv_structured_light -lopencv_phase_unwrapping -lopencv_superres -lopencv_optflow -lopencv_surface_matching -lopencv_tracking -lopencv_datasets -lopencv_text -lopencv_highgui -lopencv_dnn -lopencv_plot -lopencv_videostab -lopencv_video -lopencv_videoio -lopencv_xfeatures2d -lopencv_shape -lopencv_ml -lopencv_ximgproc -lopencv_xobjdetect -lopencv_objdetect -lopencv_calib3d -lopencv_imgcodecs -lopencv_features2d -lopencv_flann -lopencv_xphoto -lopencv_photo -lopencv_imgproc -lopencv_core -littnotify -llibprotobuf -lIlmImf -lquirc -lippiw -lippicv -lade -lz -ljpeg -ldl -lm -lpthread -lrt -lquadmath
+*/
+import "C"

--- a/cuda/cgo.go
+++ b/cuda/cgo.go
@@ -1,4 +1,4 @@
-// +build !customenv
+// +build !customenv,!static
 
 package cuda
 

--- a/cuda/cgo_static.go
+++ b/cuda/cgo_static.go
@@ -1,0 +1,12 @@
+// +build !customenv,static,!windows
+
+package gocv
+
+// Changes here should be mirrored in contrib/cgo.go and cuda/cgo.go.
+
+/*
+#cgo CXXFLAGS:   --std=c++11
+#cgo CPPFLAGS: -I/usr/local/include -I/usr/local/include/opencv4
+#cgo LDFLAGS: -L/usr/local/lib -L/usr/local/lib/opencv4/3rdparty -lopencv_gapi -lopencv_stitching -lopencv_aruco -lopencv_bgsegm -lopencv_bioinspired -lopencv_ccalib -lopencv_dnn_objdetect -lopencv_dpm -lopencv_face -lopencv_fuzzy -lopencv_hfs -lopencv_img_hash -lopencv_line_descriptor -lopencv_quality -lopencv_reg -lopencv_rgbd -lopencv_saliency -lopencv_stereo -lopencv_structured_light -lopencv_phase_unwrapping -lopencv_superres -lopencv_optflow -lopencv_surface_matching -lopencv_tracking -lopencv_datasets -lopencv_text -lopencv_highgui -lopencv_dnn -lopencv_plot -lopencv_videostab -lopencv_video -lopencv_videoio -lopencv_xfeatures2d -lopencv_shape -lopencv_ml -lopencv_ximgproc -lopencv_xobjdetect -lopencv_objdetect -lopencv_calib3d -lopencv_imgcodecs -lopencv_features2d -lopencv_flann -lopencv_xphoto -lopencv_photo -lopencv_imgproc -lopencv_core -littnotify -llibprotobuf -lIlmImf -lquirc -lippiw -lippicv -lade -lz -ljpeg -ldl -lm -lpthread -lrt -lquadmath
+*/
+import "C"


### PR DESCRIPTION
This is a first attempt to provide a way to create a static build of OpenCV and consequent GoCV programs on Linux.

The info on how to do this was almost entirely figured out by @Danile71 I just am trying to put it into a more easily usable format.

This PR adds a make task and build tag that intended to be used as follows:

First, run the make task to build and install a static build of OpenCV:

***WARNING: this will replace your current shared build of OpenCV!***

```shell
make install_static
```

Once this is done, you should be able to build GoCV programs by using `-tags static` like this:

```shell
go build -tags static --ldflags '-extldflags "-static"' -o static_version ./cmd/version/main.go
```

The following warning is displayed:

```shell
/usr/local/lib/libopencv_videoio.a(backend_plugin.cpp.o): In function `cv::impl::PluginBackendFactory::loadPlugin()':
backend_plugin.cpp:(.text._ZN2cv4impl20PluginBackendFactory10loadPluginEv+0x120): warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
```

Now you can run your statically linked program:

```shell
$ ./static_version 
gocv version: 0.27.0-dev
opencv lib version: 4.5.1
$ ls -l static_version 
-rwxr-xr-x 1 ron ron 61775512 feb  7 19:26 static_version
```