### PR TITLE
Add DilateWithParams() function

### DIFF
--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -129,10 +129,11 @@ void Dilate(Mat src, Mat dst, Mat kernel) {
     cv::dilate(*src, *dst, *kernel);
 }
 
-void DilateWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType) {
+void DilateWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType, Scalar borderValue) {
     cv::Point pt1(anchor.x, anchor.y);
+    cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
 
-    cv::dilate(*src, *dst, *kernel, pt1, iterations, borderType, cv::morphologyDefaultBorderValue());
+    cv::dilate(*src, *dst, *kernel, pt1, iterations, borderType, c);
 }
 
 void DistanceTransform(Mat src, Mat dst, Mat labels, int distanceType, int maskSize, int labelType) {

--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -129,6 +129,12 @@ void Dilate(Mat src, Mat dst, Mat kernel) {
     cv::dilate(*src, *dst, *kernel);
 }
 
+void DilateWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType) {
+    cv::Point pt1(anchor.x, anchor.y);
+
+    cv::dilate(*src, *dst, *kernel, pt1, iterations, borderType, cv::morphologyDefaultBorderValue());
+}
+
 void DistanceTransform(Mat src, Mat dst, Mat labels, int distanceType, int maskSize, int labelType) {
     cv::distanceTransform(*src, *dst, *labels, distanceType, maskSize, labelType);
 }

--- a/imgproc.go
+++ b/imgproc.go
@@ -272,13 +272,20 @@ func Dilate(src Mat, dst *Mat, kernel Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#ga4ff0f3318642c4f469d0e11f242f3b6c
-func DilateWithParams(src Mat, dst *Mat, kernel Mat, anchor image.Point, iterations, borderType int) {
+func DilateWithParams(src Mat, dst *Mat, kernel Mat, anchor image.Point, iterations, borderType BorderType, borderValue color.RGBA) {
 	cAnchor := C.struct_Point{
 		x: C.int(anchor.X),
 		y: C.int(anchor.Y),
 	}
 
-	C.DilateWithParams(src.p, dst.p, kernel.p, cAnchor, C.int(iterations), C.int(borderType))
+	bv := C.struct_Scalar{
+		val1: C.double(borderValue.B),
+		val2: C.double(borderValue.G),
+		val3: C.double(borderValue.R),
+		val4: C.double(borderValue.A),
+	}
+
+	C.DilateWithParams(src.p, dst.p, kernel.p, cAnchor, C.int(iterations), C.int(borderType), bv)
 }
 
 // DistanceTransformLabelTypes are the types of the DistanceTransform algorithm flag

--- a/imgproc.go
+++ b/imgproc.go
@@ -268,6 +268,19 @@ func Dilate(src Mat, dst *Mat, kernel Mat) {
 	C.Dilate(src.p, dst.p, kernel.p)
 }
 
+// DilateWithParams dilates an image by using a specific structuring element.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#ga4ff0f3318642c4f469d0e11f242f3b6c
+func DilateWithParams(src Mat, dst *Mat, kernel Mat, anchor image.Point, iterations, borderType int) {
+	cAnchor := C.struct_Point{
+		x: C.int(anchor.X),
+		y: C.int(anchor.Y),
+	}
+
+	C.DilateWithParams(src.p, dst.p, kernel.p, cAnchor, C.int(iterations), C.int(borderType))
+}
+
 // DistanceTransformLabelTypes are the types of the DistanceTransform algorithm flag
 type DistanceTransformLabelTypes int
 

--- a/imgproc.h
+++ b/imgproc.h
@@ -30,6 +30,7 @@ void Blur(Mat src, Mat dst, Size ps);
 void BoxFilter(Mat src, Mat dst, int ddepth, Size ps);
 void SqBoxFilter(Mat src, Mat dst, int ddepth, Size ps);
 void Dilate(Mat src, Mat dst, Mat kernel);
+void DilateWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType);
 void DistanceTransform(Mat src, Mat dst, Mat labels, int distanceType, int maskSize, int labelType);
 void Erode(Mat src, Mat dst, Mat kernel);
 void ErodeWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType);

--- a/imgproc.h
+++ b/imgproc.h
@@ -30,7 +30,7 @@ void Blur(Mat src, Mat dst, Size ps);
 void BoxFilter(Mat src, Mat dst, int ddepth, Size ps);
 void SqBoxFilter(Mat src, Mat dst, int ddepth, Size ps);
 void Dilate(Mat src, Mat dst, Mat kernel);
-void DilateWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType);
+void DilateWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType, Scalar borderValue);
 void DistanceTransform(Mat src, Mat dst, Mat labels, int distanceType, int maskSize, int labelType);
 void Erode(Mat src, Mat dst, Mat kernel);
 void ErodeWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType);

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -237,6 +237,25 @@ func TestDilate(t *testing.T) {
 	}
 }
 
+func TestDilateWithParams(t *testing.T) {
+	img := IMRead("images/face-detect.jpg", IMReadColor)
+	if img.Empty() {
+		t.Error("Invalid read of Mat in DilateWithParams test")
+	}
+	defer img.Close()
+
+	dest := NewMat()
+	defer dest.Close()
+
+	kernel := GetStructuringElement(MorphRect, image.Pt(1, 1))
+	defer kernel.Close()
+
+	DilateWithParams(img, &dest, kernel, image.Pt(-1, -1), 3, 0)
+	if dest.Empty() || img.Rows() != dest.Rows() || img.Cols() != dest.Cols() {
+		t.Error("Invalid DilateWithParams test")
+	}
+}
+
 func TestDistanceTransform(t *testing.T) {
 	img := IMRead("images/face-detect.jpg", IMReadColor)
 	if img.Empty() {

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -250,7 +250,7 @@ func TestDilateWithParams(t *testing.T) {
 	kernel := GetStructuringElement(MorphRect, image.Pt(1, 1))
 	defer kernel.Close()
 
-	DilateWithParams(img, &dest, kernel, image.Pt(-1, -1), 3, 0)
+	DilateWithParams(img, &dest, kernel, image.Pt(-1, -1), 3, 0, color.RGBA{0, 0, 0, 0})
 	if dest.Empty() || img.Rows() != dest.Rows() || img.Cols() != dest.Cols() {
 		t.Error("Invalid DilateWithParams test")
 	}


### PR DESCRIPTION
Fixes [#682](https://github.com/hybridgroup/gocv/issues/682)

Add `DilateWithParams()` function so that all the parameters of the OpenCV [`dilate()`](https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#ga4ff0f3318642c4f469d0e11f242f3b6c) function can be used in GoCV.