### PR TITLE
make: add Makefile tasks for OpenCV install on Nvidia Jetson

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ BUILD_SHARED_LIBS?=ON
 # Package list for each well-known Linux distribution
 RPMS=cmake curl wget git gtk2-devel libpng-devel libjpeg-devel libtiff-devel tbb tbb-devel libdc1394-devel unzip gcc-c++
 DEBS=unzip wget build-essential cmake curl git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libdc1394-22-dev
+JETSON=build-essential cmake git unzip pkg-config libjpeg-dev libpng-dev libtiff-dev libavcodec-dev libavformat-dev libswscale-dev libgtk2.0-dev libcanberra-gtk* libxvidcore-dev libx264-dev libgtk-3-dev libtbb2 libtbb-dev libdc1394-22-dev libv4l-dev v4l-utils libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libavresample-dev libvorbis-dev libxine2-dev libfaac-dev libmp3lame-dev libtheora-dev libopencore-amrnb-dev libopencore-amrwb-dev libopenblas-dev libatlas-base-dev libblas-dev liblapack-dev libeigen3-dev gfortran libhdf5-dev protobuf-compiler libprotobuf-dev libgoogle-glog-dev libgflags-dev
 
 explain:
 	@echo "For quick install with typical defaults of both OpenCV and GoCV, run 'make install'"
@@ -50,6 +51,11 @@ deps_debian:
 	sudo apt-get -y update
 	sudo apt-get -y install $(DEBS)
 
+deps_jetson:
+	sudo sh -c "echo '/usr/local/cuda/lib64' >> /etc/ld.so.conf.d/nvidia-tegra.conf"
+	sudo ldconfig
+	sudo apt-get -y update
+	sudo apt-get -y install $(JETSON)
 
 # Download OpenCV source tarballs.
 download:
@@ -119,6 +125,45 @@ build_raspi_zero:
 	$(MAKE) preinstall
 	cd -
 
+# Build OpenCV for NVidia Jetson with CUDA.
+build_jetson:
+	cd $(TMP_DIR)opencv/opencv-$(OPENCV_VERSION)
+	mkdir build
+	cd build
+	rm -rf *
+	cmake -D CMAKE_BUILD_TYPE=RELEASE \
+		-D CMAKE_INSTALL_PREFIX=/usr/local \
+		-D EIGEN_INCLUDE_PATH=/usr/include/eigen3 \
+		-D BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} \
+		-D OPENCV_EXTRA_MODULES_PATH=$(TMP_DIR)opencv/opencv_contrib-$(OPENCV_VERSION)/modules \
+		-D BUILD_DOCS=OFF -D BUILD_EXAMPLES=OFF -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF -D BUILD_opencv_java=OFF -D BUILD_opencv_python=NO -D BUILD_opencv_python2=NO -D BUILD_opencv_python3=NO \
+		-D WITH_OPENCL=OFF \
+		-D WITH_CUDA=ON \
+		-D CUDA_ARCH_BIN=5.3 \
+		-D CUDA_ARCH_PTX="" \
+		-D WITH_CUDNN=ON \
+		-D WITH_CUBLAS=ON \
+		-D ENABLE_FAST_MATH=ON \
+		-D CUDA_FAST_MATH=ON \
+		-D OPENCV_DNN_CUDA=ON \
+		-D ENABLE_NEON=ON \
+		-D WITH_QT=OFF \
+		-D WITH_OPENMP=ON \
+		-D WITH_OPENGL=ON \
+		-D BUILD_TIFF=ON \
+		-D WITH_FFMPEG=ON \
+		-D WITH_GSTREAMER=ON \
+		-D WITH_TBB=ON \
+		-D BUILD_TBB=ON \
+		-D BUILD_TESTS=OFF \
+		-D WITH_EIGEN=ON \
+		-D WITH_V4L=ON \
+		-D WITH_LIBV4L=ON \
+		-D OPENCV_GENERATE_PKGCONFIG=ON ..
+	$(MAKE) -j $(shell nproc --all)
+	$(MAKE) preinstall
+	cd -
+
 # Build OpenCV with non-free contrib modules.
 build_nonfree:
 	cd $(TMP_DIR)opencv/opencv-$(OPENCV_VERSION)
@@ -183,6 +228,9 @@ install_raspi: deps download build_raspi sudo_install clean verify
 
 # Do everything on the raspberry pi zero.
 install_raspi_zero: deps download build_raspi_zero sudo_install clean verify
+
+# Do everything on Jetson.
+install_jetson: deps download build_jetson sudo_install clean verify
 
 # Do everything with cuda.
 install_cuda: deps download sudo_pre_install_clean build_cuda sudo_install clean verify verify_cuda


### PR DESCRIPTION
This PR adds Makefile tasks to facilitate installing OpenCV 4.5.2 with CUDA on the Nvidia Jetson Nano developer kit.