### PR TITLE
Add WithParams versions of Circle, Ellipse, FillPoly & Rectangle functions

### DIFF
--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -398,6 +398,19 @@ void Rectangle(Mat img, Rect r, Scalar color, int thickness) {
     );
 }
 
+void RectangleWithParams(Mat img, Rect r, Scalar color, int thickness, int lineType, int shift) {
+    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+    cv::rectangle(
+        *img,
+        cv::Point(r.x, r.y),
+        cv::Point(r.x + r.width, r.y + r.height),
+        c,
+        thickness,
+        lineType,
+        shift
+    );
+}
+
 void FillPoly(Mat img, PointsVector pts, Scalar color) {
     cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 

--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -397,6 +397,12 @@ void FillPoly(Mat img, PointsVector pts, Scalar color) {
     cv::fillPoly(*img, *pts, c);
 }
 
+void FillPolyWithParams(Mat img, PointsVector pts, Scalar color, int lineType, int shift, Point offset) {
+    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+
+    cv::fillPoly(*img, *pts, c, lineType, shift, cv::Point(offset.x, offset.y));
+}
+
 void Polylines(Mat img, PointsVector pts, bool isClosed, Scalar color,int thickness) {
     cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 

--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -362,6 +362,13 @@ void Circle(Mat img, Point center, int radius, Scalar color, int thickness) {
     cv::circle(*img, p1, radius, c, thickness);
 }
 
+void CircleWithParams(Mat img, Point center, int radius, Scalar color, int thickness, int lineType, int shift) {
+    cv::Point p1(center.x, center.y);
+    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+
+    cv::circle(*img, p1, radius, c, thickness, lineType, shift);
+}
+
 void Ellipse(Mat img, Point center, Point axes, double angle, double
              startAngle, double endAngle, Scalar color, int thickness) {
     cv::Point p1(center.x, center.y);

--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -378,6 +378,15 @@ void Ellipse(Mat img, Point center, Point axes, double angle, double
     cv::ellipse(*img, p1, p2, angle, startAngle, endAngle, c, thickness);
 }
 
+void EllipseWithParams(Mat img, Point center, Point axes, double angle, double
+             startAngle, double endAngle, Scalar color, int thickness, int lineType, int shift) {
+    cv::Point p1(center.x, center.y);
+    cv::Point p2(axes.x, axes.y);
+    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+
+    cv::ellipse(*img, p1, p2, angle, startAngle, endAngle, c, thickness, lineType, shift);
+}
+
 void Line(Mat img, Point pt1, Point pt2, Scalar color, int thickness) {
     cv::Point p1(pt1.x, pt1.y);
     cv::Point p2(pt2.x, pt2.y);

--- a/imgproc.go
+++ b/imgproc.go
@@ -1198,6 +1198,27 @@ func Circle(img *Mat, center image.Point, radius int, c color.RGBA, thickness in
 	C.Circle(img.p, pc, C.int(radius), sColor, C.int(thickness))
 }
 
+// CircleWithParams draws a circle.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#gaf10604b069374903dbd0f0488cb43670
+//
+func CircleWithParams(img *Mat, center image.Point, radius int, c color.RGBA, thickness int, lineType LineType, shift int) {
+	pc := C.struct_Point{
+		x: C.int(center.X),
+		y: C.int(center.Y),
+	}
+
+	sColor := C.struct_Scalar{
+		val1: C.double(c.B),
+		val2: C.double(c.G),
+		val3: C.double(c.R),
+		val4: C.double(c.A),
+	}
+
+	C.CircleWithParams(img.p, pc, C.int(radius), sColor, C.int(thickness), C.int(lineType), C.int(shift))
+}
+
 // Ellipse draws a simple or thick elliptic arc or fills an ellipse sector.
 //
 // For further details, please see:

--- a/imgproc.go
+++ b/imgproc.go
@@ -1288,6 +1288,26 @@ func FillPoly(img *Mat, pts PointsVector, c color.RGBA) {
 	C.FillPoly(img.p, pts.p, sColor)
 }
 
+// FillPolyWithParams fills the area bounded by one or more polygons.
+//
+// For more information, see:
+// https://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#gaf30888828337aa4c6b56782b5dfbd4b7
+func FillPolyWithParams(img *Mat, pts PointsVector, c color.RGBA, lineType LineType, shift int, offset image.Point) {
+	offsetP := C.struct_Point{
+		x: C.int(offset.X),
+		y: C.int(offset.Y),
+	}
+
+	sColor := C.struct_Scalar{
+		val1: C.double(c.B),
+		val2: C.double(c.G),
+		val3: C.double(c.R),
+		val4: C.double(c.A),
+	}
+
+	C.FillPolyWithParams(img.p, pts.p, sColor, C.int(lineType), C.int(shift), offsetP)
+}
+
 // Polylines draws several polygonal curves.
 //
 // For more information, see:

--- a/imgproc.go
+++ b/imgproc.go
@@ -1244,6 +1244,31 @@ func Ellipse(img *Mat, center, axes image.Point, angle, startAngle, endAngle flo
 	C.Ellipse(img.p, pc, pa, C.double(angle), C.double(startAngle), C.double(endAngle), sColor, C.int(thickness))
 }
 
+// Ellipse draws a simple or thick elliptic arc or fills an ellipse sector.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#ga28b2267d35786f5f890ca167236cbc69
+//
+func EllipseWithParams(img *Mat, center, axes image.Point, angle, startAngle, endAngle float64, c color.RGBA, thickness int, lineType LineType, shift int) {
+	pc := C.struct_Point{
+		x: C.int(center.X),
+		y: C.int(center.Y),
+	}
+	pa := C.struct_Point{
+		x: C.int(axes.X),
+		y: C.int(axes.Y),
+	}
+
+	sColor := C.struct_Scalar{
+		val1: C.double(c.B),
+		val2: C.double(c.G),
+		val3: C.double(c.R),
+		val4: C.double(c.A),
+	}
+
+	C.EllipseWithParams(img.p, pc, pa, C.double(angle), C.double(startAngle), C.double(endAngle), sColor, C.int(thickness), C.int(lineType), C.int(shift))
+}
+
 // Line draws a line segment connecting two points.
 //
 // For further details, please see:

--- a/imgproc.go
+++ b/imgproc.go
@@ -1294,6 +1294,30 @@ func Rectangle(img *Mat, r image.Rectangle, c color.RGBA, thickness int) {
 	C.Rectangle(img.p, cRect, sColor, C.int(thickness))
 }
 
+// RectangleWithParams draws a simple, thick, or filled up-right rectangle.
+// It renders a rectangle with the desired characteristics to the target Mat image.
+//
+// For further details, please see:
+// http://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#ga346ac30b5c74e9b5137576c9ee9e0e8c
+//
+func RectangleWithParams(img *Mat, r image.Rectangle, c color.RGBA, thickness int, lineType LineType, shift int) {
+	cRect := C.struct_Rect{
+		x:      C.int(r.Min.X),
+		y:      C.int(r.Min.Y),
+		width:  C.int(r.Size().X),
+		height: C.int(r.Size().Y),
+	}
+
+	sColor := C.struct_Scalar{
+		val1: C.double(c.B),
+		val2: C.double(c.G),
+		val3: C.double(c.R),
+		val4: C.double(c.A),
+	}
+
+	C.RectangleWithParams(img.p, cRect, sColor, C.int(thickness), C.int(lineType), C.int(shift))
+}
+
 // FillPoly fills the area bounded by one or more polygons.
 //
 // For more information, see:

--- a/imgproc.h
+++ b/imgproc.h
@@ -84,6 +84,7 @@ void Ellipse(Mat img, Point center, Point axes, double angle, double
 void Line(Mat img, Point pt1, Point pt2, Scalar color, int thickness);
 void Rectangle(Mat img, Rect rect, Scalar color, int thickness);
 void FillPoly(Mat img, PointsVector points, Scalar color);
+void FillPolyWithParams(Mat img, PointsVector points, Scalar color, int lineType, int shift, Point offset);
 void Polylines(Mat img, PointsVector points, bool isClosed, Scalar color, int thickness);
 struct Size GetTextSize(const char* text, int fontFace, double fontScale, int thickness);
 struct Size GetTextSizeWithBaseline(const char* text, int fontFace, double fontScale, int thickness, int* baseline);

--- a/imgproc.h
+++ b/imgproc.h
@@ -84,6 +84,7 @@ void Ellipse(Mat img, Point center, Point axes, double angle, double
              startAngle, double endAngle, Scalar color, int thickness);
 void Line(Mat img, Point pt1, Point pt2, Scalar color, int thickness);
 void Rectangle(Mat img, Rect rect, Scalar color, int thickness);
+void RectangleWithParams(Mat img, Rect rect, Scalar color, int thickness, int lineType, int shift);
 void FillPoly(Mat img, PointsVector points, Scalar color);
 void FillPolyWithParams(Mat img, PointsVector points, Scalar color, int lineType, int shift, Point offset);
 void Polylines(Mat img, PointsVector points, bool isClosed, Scalar color, int thickness);

--- a/imgproc.h
+++ b/imgproc.h
@@ -82,6 +82,8 @@ void Circle(Mat img, Point center, int radius, Scalar color, int thickness);
 void CircleWithParams(Mat img, Point center, int radius, Scalar color, int thickness, int lineType, int shift);
 void Ellipse(Mat img, Point center, Point axes, double angle, double
              startAngle, double endAngle, Scalar color, int thickness);
+void EllipseWithParams(Mat img, Point center, Point axes, double angle, double
+             startAngle, double endAngle, Scalar color, int thickness, int lineType, int shift);
 void Line(Mat img, Point pt1, Point pt2, Scalar color, int thickness);
 void Rectangle(Mat img, Rect rect, Scalar color, int thickness);
 void RectangleWithParams(Mat img, Rect rect, Scalar color, int thickness, int lineType, int shift);

--- a/imgproc.h
+++ b/imgproc.h
@@ -79,6 +79,7 @@ void AdaptiveThreshold(Mat src, Mat dst, double maxValue, int adaptiveTyp, int t
 
 void ArrowedLine(Mat img, Point pt1, Point pt2, Scalar color, int thickness);
 void Circle(Mat img, Point center, int radius, Scalar color, int thickness);
+void CircleWithParams(Mat img, Point center, int radius, Scalar color, int thickness, int lineType, int shift);
 void Ellipse(Mat img, Point center, Point axes, double angle, double
              startAngle, double endAngle, Scalar color, int thickness);
 void Line(Mat img, Point pt1, Point pt2, Scalar color, int thickness);

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -1107,6 +1107,90 @@ func TestAdaptiveThreshold(t *testing.T) {
 	}
 }
 
+func TestCircle(t *testing.T) {
+	tests := []struct {
+		name      string      // name of the testcase
+		thickness int         // thickness of the circle
+		point     image.Point // point to be checked
+		result    uint8       // expected value at the point to be checked
+	}{
+		{
+			name:      "Without filling",
+			thickness: 3,
+			point:     image.Point{80, 89},
+			result:    255,
+		}, {
+			name:      "With filling",
+			thickness: -1,
+			point:     image.Point{60, 60},
+			result:    255,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run("tc.name", func(t *testing.T) {
+			img := NewMatWithSize(100, 100, MatTypeCV8UC1)
+			defer img.Close()
+
+			white := color.RGBA{255, 255, 255, 0}
+			Circle(&img, image.Pt(70, 70), 20, white, tc.thickness)
+
+			if v := img.GetUCharAt(tc.point.X, tc.point.Y); v != tc.result {
+				t.Errorf("Wrong pixel value, got = %v, want = %v", v, tc.result)
+			}
+		})
+	}
+}
+
+func TestCircleWithParams(t *testing.T) {
+	tests := []struct {
+		name      string                // name of the testcase
+		thickness int                   // thickness of the circle
+		shift     int                   // how much to shift and reduce(in size)
+		checks    map[image.Point]uint8 // map of points to be checked and corresponding expected value
+	}{
+		{
+			name:      "Without filling and shift",
+			thickness: 3,
+			shift:     0,
+			checks: map[image.Point]uint8{
+				image.Point{80, 89}: 255,
+			},
+		}, {
+			name:      "With filling, without shift",
+			thickness: -1,
+			shift:     0,
+			checks: map[image.Point]uint8{
+				image.Point{60, 60}: 255,
+			},
+		}, {
+			name:      "Without filling, with shift",
+			thickness: 3,
+			shift:     1,
+			checks: map[image.Point]uint8{
+				image.Point{47, 38}: 255,
+				image.Point{48, 38}: 0,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			img := NewMatWithSize(100, 100, MatTypeCV8UC1)
+			defer img.Close()
+
+			white := color.RGBA{255, 255, 255, 0}
+			CircleWithParams(&img, image.Pt(70, 70), 20, white, tc.thickness, Line4, tc.shift)
+
+			for c, result := range tc.checks {
+				if v := img.GetUCharAt(c.X, c.Y); v != result {
+					t.Errorf("Wrong pixel value, got = %v, want = %v", v, result)
+				}
+			}
+		})
+	}
+}
+
 func TestEqualizeHist(t *testing.T) {
 	img := IMRead("images/face-detect.jpg", IMReadGrayScale)
 	if img.Empty() {

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -1191,6 +1191,78 @@ func TestCircleWithParams(t *testing.T) {
 	}
 }
 
+func TestRectangle(t *testing.T) {
+	tests := []struct {
+		name      string      // name of the testcase
+		thickness int         // thickness of the rectangle
+		point     image.Point // point to be checked
+	}{
+		{
+			name:      "Without filling",
+			thickness: 1,
+			point:     image.Point{10, 60},
+		}, {
+			name:      "With filling",
+			thickness: -1,
+			point:     image.Point{30, 30},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			img := NewMatWithSize(100, 100, MatTypeCV8UC1)
+			defer img.Close()
+
+			white := color.RGBA{255, 255, 255, 0}
+			Rectangle(&img, image.Rect(10, 10, 80, 80), white, tc.thickness)
+
+			if v := img.GetUCharAt(tc.point.X, tc.point.Y); v < 50 {
+				t.Errorf("Wrong pixel value, got = %v, want >= %v", v, 50)
+
+			}
+		})
+	}
+}
+
+func TestRectangleWithParams(t *testing.T) {
+	tests := []struct {
+		name      string      // name of the testcase
+		thickness int         // thickness of the rectangle
+		shift     int         // how much to shift and reduce (in size)
+		point     image.Point // point to be checked
+	}{
+		{
+			name:      "Without filling and shift",
+			thickness: 1,
+			point:     image.Point{10, 60},
+		}, {
+			name:      "With filling, without shift",
+			thickness: -1,
+			point:     image.Point{30, 30},
+		}, {
+			name:      "Without filling, with shift",
+			thickness: 1,
+			shift:     1,
+			point:     image.Point{5, 5},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			img := NewMatWithSize(100, 100, MatTypeCV8UC1)
+			defer img.Close()
+
+			white := color.RGBA{255, 255, 255, 0}
+			RectangleWithParams(&img, image.Rect(10, 10, 80, 80), white, tc.thickness, Line4, tc.shift)
+
+			if v := img.GetUCharAt(tc.point.X, tc.point.Y); v != 255 {
+				t.Errorf("Wrong pixel value, got = %v, want = %v", v, 255)
+			}
+
+		})
+	}
+}
+
 func TestEqualizeHist(t *testing.T) {
 	img := IMRead("images/face-detect.jpg", IMReadGrayScale)
 	if img.Empty() {

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -1773,6 +1773,50 @@ func TestFillPoly(t *testing.T) {
 	}
 }
 
+func TestFillPolyWithParams(t *testing.T) {
+	tests := []struct {
+		name   string      // name of testcase
+		offset image.Point // offset to the FillPolyWithParams function
+		point  image.Point // point to be checked
+		result uint8       // expected value at the point to be checked
+	}{
+		{
+			name:   "No offset",
+			point:  image.Point{10, 10},
+			result: 255,
+		}, {
+			name:   "Offset of 2",
+			offset: image.Point{2, 2},
+			point:  image.Point{12, 12},
+			result: 255,
+		},
+	}
+	white := color.RGBA{255, 255, 255, 0}
+	pts := [][]image.Point{
+		{
+			image.Pt(10, 10),
+			image.Pt(10, 20),
+			image.Pt(20, 20),
+			image.Pt(20, 10),
+		},
+	}
+	pv := NewPointsVectorFromPoints(pts)
+	defer pv.Close()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			img := NewMatWithSize(100, 100, MatTypeCV8UC1)
+			defer img.Close()
+
+			FillPolyWithParams(&img, pv, white, Line4, 0, tc.offset)
+
+			if v := img.GetUCharAt(tc.point.X, tc.point.Y); v != tc.result {
+				t.Errorf("Wrong pixel value; got = %v, want = %v", v, tc.result)
+			}
+		})
+	}
+}
+
 func TestPolylines(t *testing.T) {
 	img := NewMatWithSize(100, 100, MatTypeCV8UC1)
 	defer img.Close()


### PR DESCRIPTION
Fixes [#issue-787](https://github.com/hybridgroup/gocv/issues/787)

Added `CircleWithParams`, `EllipseWithParams`, `RectangleWithParams` and `FillPolyWithParams` functions.

This was originally done by [golubaca](https://github.com/golubaca/gocv/commit/9deb02b2c74149b98a0d603a61cf496d5ffcef88) in Dec, 2020.  He did not raise a PR though. He also doesn't seem to be active recently. I took his commit, fixed some minor issues and restructured the tests as subtests. Credits to [golubaca](https://github.com/golubaca) for the original code.