### PR TITLE
Photo : add MergeMertens, AlignMTB and Denoising function

### DIFF
--- a/photo.cpp
+++ b/photo.cpp
@@ -16,3 +16,71 @@ void SeamlessClone(Mat src, Mat dst, Mat mask, Point p, Mat blend, int flags) {
 void TextureFlattening(Mat src, Mat mask, Mat dst, float low_threshold, float high_threshold, int kernel_size) {
     cv::textureFlattening(*src, *mask, *dst, low_threshold, high_threshold, kernel_size);
 }
+
+
+void FastNlMeansDenoisingColoredMulti(	struct Mats src, Mat dst, int imgToDenoiseIndex, int 	temporalWindowSize){
+  std::vector<cv::Mat> images;
+  for (int i = 0; i < src.length; ++i) {
+    images.push_back(*src.mats[i]);
+  }
+  cv::fastNlMeansDenoisingColoredMulti( images, *dst, imgToDenoiseIndex, 	temporalWindowSize );
+}
+
+void FastNlMeansDenoisingColoredMultiWithParams( struct Mats src, Mat dst, int imgToDenoiseIndex, int 	temporalWindowSize, float 	h, float 	hColor, int 	templateWindowSize, int 	searchWindowSize ){
+  std::vector<cv::Mat> images;
+  for (int i = 0; i < src.length; ++i) {
+    images.push_back(*src.mats[i]);
+  }
+  cv::fastNlMeansDenoisingColoredMulti( images, *dst, imgToDenoiseIndex, 	temporalWindowSize, h, hColor, templateWindowSize, searchWindowSize );
+}
+
+MergeMertens MergeMertens_Create() {
+  return new cv::Ptr<cv::MergeMertens>(cv::createMergeMertens());
+}
+
+MergeMertens MergeMertens_CreateWithParams(float contrast_weight,
+                                           float saturation_weight,
+                                           float exposure_weight) {
+  return new cv::Ptr<cv::MergeMertens>(cv::createMergeMertens(
+      contrast_weight, saturation_weight, exposure_weight));
+}
+
+void MergeMertens_Close(MergeMertens b) {
+  delete b;
+}
+
+void MergeMertens_Process(MergeMertens b, struct Mats src, Mat dst) {
+  std::vector<cv::Mat> images;
+  for (int i = 0; i < src.length; ++i) {
+    images.push_back(*src.mats[i]);
+  }
+  (*b)->process(images, *dst);
+}
+
+AlignMTB AlignMTB_Create() {
+  return new cv::Ptr<cv::AlignMTB>(cv::createAlignMTB(6,4,false));
+}
+
+AlignMTB AlignMTB_CreateWithParams(int max_bits, int exclude_range, bool cut) {
+  return new cv::Ptr<cv::AlignMTB>(
+      cv::createAlignMTB(max_bits, exclude_range, cut));
+}
+
+void AlignMTB_Close(AlignMTB b) { delete b; }
+
+void AlignMTB_Process(AlignMTB b, struct Mats src, struct Mats *dst) {
+
+  std::vector<cv::Mat> srcMats;
+  for (int i = 0; i < src.length; ++i) {
+    srcMats.push_back(*src.mats[i]);
+  }
+
+  std::vector<cv::Mat> dstMats;
+  (*b)->process(srcMats, dstMats);
+
+  dst->mats = new Mat[dstMats.size()];
+  for (size_t i = 0; i < dstMats.size() ; ++i) {
+	dst->mats[i] = new cv::Mat( dstMats[i] );
+  }
+  dst->length = (int)dstMats.size();
+}

--- a/photo.go
+++ b/photo.go
@@ -5,10 +5,23 @@ package gocv
 #include "photo.h"
 */
 import "C"
-import "image"
+import (
+	"image"
+	"unsafe"
+)
 
 //SeamlessCloneFlags seamlessClone algorithm flags
 type SeamlessCloneFlags int
+
+// MergeMertens is a wrapper around the cv::MergeMertens.
+type MergeMertens struct {
+	p unsafe.Pointer // This unsafe pointer will in fact be a C.MergeMertens
+}
+
+// AlignMTB is a wrapper around the cv::AlignMTB.
+type AlignMTB struct {
+	p unsafe.Pointer // This unsafe pointer will in fact be a C.AlignMTB
+}
 
 const (
 	// NormalClone The power of the method is fully expressed when inserting objects with complex outlines into a new background.
@@ -60,4 +73,157 @@ func IlluminationChange(src, mask Mat, dst *Mat, alpha, beta float32) {
 //
 func TextureFlattening(src, mask Mat, dst *Mat, lowThreshold, highThreshold float32, kernelSize int) {
 	C.TextureFlattening(src.p, mask.p, dst.p, C.float(lowThreshold), C.float(highThreshold), C.int(kernelSize))
+}
+
+
+// FastNlMeansDenoisingColoredMulti denoises the selected images.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d1/d79/group__photo__denoise.html#gaa501e71f52fb2dc17ff8ca5e7d2d3619
+//
+func FastNlMeansDenoisingColoredMulti( src []Mat, dst *Mat, imgToDenoiseIndex int , temporalWindowSize int){
+	cMatArray := make([]C.Mat, len(src))
+	for i, r := range src {
+		cMatArray[i] = (C.Mat)(r.p)
+	}
+	matsVector := C.struct_Mats{
+		mats:   (*C.Mat)(&cMatArray[0]),
+		length: C.int(len(src)),
+	}
+	C.FastNlMeansDenoisingColoredMulti(matsVector, dst.p , C.int(imgToDenoiseIndex), C.int(temporalWindowSize))
+}
+
+// FastNlMeansDenoisingColoredMulti denoises the selected images.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d1/d79/group__photo__denoise.html#gaa501e71f52fb2dc17ff8ca5e7d2d3619
+//
+func FastNlMeansDenoisingColoredMultiWithParams( src []Mat, dst *Mat, imgToDenoiseIndex int , temporalWindowSize int , h float32, hColor float32, templateWindowSize int, searchWindowSize int){
+	cMatArray := make([]C.Mat, len(src))
+	for i, r := range src {
+		cMatArray[i] = (C.Mat)(r.p)
+	}
+	matsVector := C.struct_Mats{
+		mats:   (*C.Mat)(&cMatArray[0]),
+		length: C.int(len(src)),
+	}
+	C.FastNlMeansDenoisingColoredMultiWithParams(matsVector, dst.p , C.int(imgToDenoiseIndex), C.int(temporalWindowSize), C.float(h), C.float(hColor), C.int(templateWindowSize), C.int(searchWindowSize))
+}
+
+
+// NewMergeMertens returns returns a new MergeMertens white LDR merge algorithm.
+// of type MergeMertens with default parameters.
+// MergeMertens algorithm merge the ldr image should result in a HDR image.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d6/df5/group__photo__hdr.html
+// https://docs.opencv.org/master/d7/dd6/classcv_1_1MergeMertens.html
+// https://docs.opencv.org/master/d6/df5/group__photo__hdr.html#ga79d59aa3cb3a7c664e59a4b5acc1ccb6
+//
+func NewMergeMertens() MergeMertens {
+	return MergeMertens{p: unsafe.Pointer(C.MergeMertens_Create())}
+}
+
+// NewMergeMertensWithParams returns a new MergeMertens white LDR merge algorithm
+// of type MergeMertens with customized parameters.
+// MergeMertens algorithm merge the ldr image should result in a HDR image.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d6/df5/group__photo__hdr.html
+// https://docs.opencv.org/master/d7/dd6/classcv_1_1MergeMertens.html
+// https://docs.opencv.org/master/d6/df5/group__photo__hdr.html#ga79d59aa3cb3a7c664e59a4b5acc1ccb6
+//
+func NewMergeMertensWithParams(contrast_weight float32, saturation_weight float32, exposure_weight float32) MergeMertens {
+	return MergeMertens{p: unsafe.Pointer(C.MergeMertens_CreateWithParams(C.float(contrast_weight), C.float(saturation_weight), C.float(exposure_weight)))}
+}
+
+// Close MergeMertens.
+func (b *MergeMertens) Close() error {
+	C.MergeMertens_Close((C.MergeMertens)(b.p)) // Here the unsafe pointer is cast into the right type
+	b.p = nil
+	return nil
+}
+
+// BalanceWhite computes merge LDR images using the current MergeMertens.
+// Return a image MAT : 8bits 3 channel image ( RGB 8 bits )
+// For further details, please see:
+// https://docs.opencv.org/master/d7/dd6/classcv_1_1MergeMertens.html#a2d2254b2aab722c16954de13a663644d
+//
+func (b *MergeMertens) Process(src []Mat, dst *Mat) {
+	cMatArray := make([]C.Mat, len(src))
+	for i, r := range src {
+		cMatArray[i] = (C.Mat)(r.p)
+	}
+        // Conversion function from a Golang slice into an array of matrices that are understood by OpenCV
+	matsVector := C.struct_Mats{
+		mats:   (*C.Mat)(&cMatArray[0]),
+		length: C.int(len(src)),
+	}
+	C.MergeMertens_Process((C.MergeMertens)(b.p), matsVector, dst.p)
+        // Convert a series of double [0.0,1.0] to [0,255] with Golang
+	dst.ConvertToWithParams(dst, MatTypeCV8UC3, 255.0, 0.0)
+}
+
+// NewAlignMTB returns an AlignMTB for converts images to median threshold bitmaps.
+// of type AlignMTB converts images to median threshold bitmaps (1 for pixels
+// brighter than median luminance and 0 otherwise) and than aligns the resulting
+// bitmaps using bit operations.
+
+// For further details, please see:
+// https://docs.opencv.org/master/d6/df5/group__photo__hdr.html
+// https://docs.opencv.org/master/d7/db6/classcv_1_1AlignMTB.html
+// https://docs.opencv.org/master/d6/df5/group__photo__hdr.html#ga2f1fafc885a5d79dbfb3542e08db0244
+//
+func NewAlignMTB() AlignMTB {
+	return AlignMTB{p: unsafe.Pointer(C.AlignMTB_Create())}
+}
+
+// NewAlignMTBWithParams returns an AlignMTB for converts images to median threshold bitmaps.
+// of type AlignMTB converts images to median threshold bitmaps (1 for pixels
+// brighter than median luminance and 0 otherwise) and than aligns the resulting
+// bitmaps using bit operations.
+
+// For further details, please see:
+// https://docs.opencv.org/master/d6/df5/group__photo__hdr.html
+// https://docs.opencv.org/master/d7/db6/classcv_1_1AlignMTB.html
+// https://docs.opencv.org/master/d6/df5/group__photo__hdr.html#ga2f1fafc885a5d79dbfb3542e08db0244
+//
+func NewAlignMTBWithParams(max_bits int, exclude_range int, cut bool) AlignMTB {
+	return AlignMTB{p: unsafe.Pointer(C.AlignMTB_CreateWithParams(C.int(max_bits), C.int(exclude_range), C.bool(cut)))}
+}
+
+// Close AlignMTB.
+func (b *AlignMTB) Close() error {
+	C.AlignMTB_Close((C.AlignMTB)(b.p))
+	b.p = nil
+	return nil
+}
+
+// Process computes an alignment using the current AlignMTB.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d7/db6/classcv_1_1AlignMTB.html#a37b3417d844f362d781f34155cbcb201
+//
+func (b *AlignMTB) Process(src []Mat, dst *[]Mat) {
+
+	cSrcArray := make([]C.Mat, len(src))
+	for i, r := range src {
+		cSrcArray[i] = r.p
+	}
+	cSrcMats := C.struct_Mats{
+		mats:   (*C.Mat)(&cSrcArray[0]),
+		length: C.int(len(src)),
+	}
+
+	cDstMats := C.struct_Mats{}
+
+	C.AlignMTB_Process((C.AlignMTB)(b.p), cSrcMats, &cDstMats )
+
+        // Pass the matrices by reference from an OpenCV/C++ to a GoCV::Mat object
+	for i := C.int(0); i < cDstMats.length; i++ {
+		var tempdst Mat
+		tempdst.p = C.Mats_get(cDstMats, i)
+		*dst = append( *dst , tempdst )
+	}
+	return
 }

--- a/photo.go
+++ b/photo.go
@@ -75,13 +75,12 @@ func TextureFlattening(src, mask Mat, dst *Mat, lowThreshold, highThreshold floa
 	C.TextureFlattening(src.p, mask.p, dst.p, C.float(lowThreshold), C.float(highThreshold), C.int(kernelSize))
 }
 
-
 // FastNlMeansDenoisingColoredMulti denoises the selected images.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/d79/group__photo__denoise.html#gaa501e71f52fb2dc17ff8ca5e7d2d3619
 //
-func FastNlMeansDenoisingColoredMulti( src []Mat, dst *Mat, imgToDenoiseIndex int , temporalWindowSize int){
+func FastNlMeansDenoisingColoredMulti(src []Mat, dst *Mat, imgToDenoiseIndex int, temporalWindowSize int) {
 	cMatArray := make([]C.Mat, len(src))
 	for i, r := range src {
 		cMatArray[i] = (C.Mat)(r.p)
@@ -90,7 +89,7 @@ func FastNlMeansDenoisingColoredMulti( src []Mat, dst *Mat, imgToDenoiseIndex in
 		mats:   (*C.Mat)(&cMatArray[0]),
 		length: C.int(len(src)),
 	}
-	C.FastNlMeansDenoisingColoredMulti(matsVector, dst.p , C.int(imgToDenoiseIndex), C.int(temporalWindowSize))
+	C.FastNlMeansDenoisingColoredMulti(matsVector, dst.p, C.int(imgToDenoiseIndex), C.int(temporalWindowSize))
 }
 
 // FastNlMeansDenoisingColoredMulti denoises the selected images.
@@ -98,7 +97,7 @@ func FastNlMeansDenoisingColoredMulti( src []Mat, dst *Mat, imgToDenoiseIndex in
 // For further details, please see:
 // https://docs.opencv.org/master/d1/d79/group__photo__denoise.html#gaa501e71f52fb2dc17ff8ca5e7d2d3619
 //
-func FastNlMeansDenoisingColoredMultiWithParams( src []Mat, dst *Mat, imgToDenoiseIndex int , temporalWindowSize int , h float32, hColor float32, templateWindowSize int, searchWindowSize int){
+func FastNlMeansDenoisingColoredMultiWithParams(src []Mat, dst *Mat, imgToDenoiseIndex int, temporalWindowSize int, h float32, hColor float32, templateWindowSize int, searchWindowSize int) {
 	cMatArray := make([]C.Mat, len(src))
 	for i, r := range src {
 		cMatArray[i] = (C.Mat)(r.p)
@@ -107,9 +106,8 @@ func FastNlMeansDenoisingColoredMultiWithParams( src []Mat, dst *Mat, imgToDenoi
 		mats:   (*C.Mat)(&cMatArray[0]),
 		length: C.int(len(src)),
 	}
-	C.FastNlMeansDenoisingColoredMultiWithParams(matsVector, dst.p , C.int(imgToDenoiseIndex), C.int(temporalWindowSize), C.float(h), C.float(hColor), C.int(templateWindowSize), C.int(searchWindowSize))
+	C.FastNlMeansDenoisingColoredMultiWithParams(matsVector, dst.p, C.int(imgToDenoiseIndex), C.int(temporalWindowSize), C.float(h), C.float(hColor), C.int(templateWindowSize), C.int(searchWindowSize))
 }
-
 
 // NewMergeMertens returns returns a new MergeMertens white LDR merge algorithm.
 // of type MergeMertens with default parameters.
@@ -154,13 +152,13 @@ func (b *MergeMertens) Process(src []Mat, dst *Mat) {
 	for i, r := range src {
 		cMatArray[i] = (C.Mat)(r.p)
 	}
-        // Conversion function from a Golang slice into an array of matrices that are understood by OpenCV
+	// Conversion function from a Golang slice into an array of matrices that are understood by OpenCV
 	matsVector := C.struct_Mats{
 		mats:   (*C.Mat)(&cMatArray[0]),
 		length: C.int(len(src)),
 	}
 	C.MergeMertens_Process((C.MergeMertens)(b.p), matsVector, dst.p)
-        // Convert a series of double [0.0,1.0] to [0,255] with Golang
+	// Convert a series of double [0.0,1.0] to [0,255] with Golang
 	dst.ConvertToWithParams(dst, MatTypeCV8UC3, 255.0, 0.0)
 }
 
@@ -217,13 +215,13 @@ func (b *AlignMTB) Process(src []Mat, dst *[]Mat) {
 
 	cDstMats := C.struct_Mats{}
 
-	C.AlignMTB_Process((C.AlignMTB)(b.p), cSrcMats, &cDstMats )
+	C.AlignMTB_Process((C.AlignMTB)(b.p), cSrcMats, &cDstMats)
 
-        // Pass the matrices by reference from an OpenCV/C++ to a GoCV::Mat object
+	// Pass the matrices by reference from an OpenCV/C++ to a GoCV::Mat object
 	for i := C.int(0); i < cDstMats.length; i++ {
 		var tempdst Mat
 		tempdst.p = C.Mats_get(cDstMats, i)
-		*dst = append( *dst , tempdst )
+		*dst = append(*dst, tempdst)
 	}
 	return
 }

--- a/photo.h
+++ b/photo.h
@@ -3,11 +3,22 @@
 
 #ifdef __cplusplus
 #include <opencv2/opencv.hpp>
+#include <opencv2/photo.hpp>
 
 extern "C" {
 #endif
 
 #include "core.h"
+
+#ifdef __cplusplus
+// see : https://docs.opencv.org/3.4/d7/dd6/classcv_1_1MergeMertens.html
+typedef cv::Ptr<cv::MergeMertens> *MergeMertens;
+// see : https://docs.opencv.org/master/d7/db6/classcv_1_1AlignMTB.html
+typedef cv::Ptr<cv::AlignMTB> *AlignMTB;
+#else
+typedef void *MergeMertens;
+typedef void *AlignMTB;
+#endif
 
 void ColorChange(Mat src, Mat mask, Mat dst, float red_mul, float green_mul, float blue_mul);
 
@@ -16,6 +27,20 @@ void SeamlessClone(Mat src, Mat dst, Mat mask, Point p, Mat blend, int flags);
 void IlluminationChange(Mat src, Mat mask, Mat dst, float alpha, float beta);
 
 void TextureFlattening(Mat src, Mat mask, Mat dst, float low_threshold, float high_threshold, int kernel_size);
+
+void FastNlMeansDenoisingColoredMulti(struct Mats src, Mat dst, int imgToDenoiseIndex, int 	temporalWindowSize);
+
+void FastNlMeansDenoisingColoredMultiWithParams(struct Mats src, Mat dst, int imgToDenoiseIndex, int 	temporalWindowSize, float 	h, float 	hColor, int 	templateWindowSize, int 	searchWindowSize );
+
+MergeMertens MergeMertens_Create();
+MergeMertens MergeMertens_CreateWithParams(float contrast_weight, float saturation_weight, float exposure_weight);
+void MergeMertens_Process(MergeMertens b, struct Mats src, Mat dst);
+void MergeMertens_Close(MergeMertens b);
+
+AlignMTB AlignMTB_Create();
+AlignMTB AlignMTB_CreateWithParams(int max_bits, int exclude_range, bool cut);
+void AlignMTB_Process(AlignMTB b, struct Mats src, struct Mats *dst);
+void AlignMTB_Close(AlignMTB b);
 
 #ifdef __cplusplus
 }

--- a/photo_test.go
+++ b/photo_test.go
@@ -66,7 +66,7 @@ func TestTextureFlattening(t *testing.T) {
 
 func TestFastNlMeansDenoisingColoredMultiWithParams(t *testing.T) {
 	var src [3]Mat
-	for i := 0; i<3 ; i++ {
+	for i := 0; i < 3; i++ {
 		src[i] = NewMatWithSize(20, 20, MatTypeCV8UC3)
 		defer src[i].Close()
 	}
@@ -74,7 +74,7 @@ func TestFastNlMeansDenoisingColoredMultiWithParams(t *testing.T) {
 	dst := NewMat()
 	defer dst.Close()
 
-	FastNlMeansDenoisingColoredMultiWithParams( []Mat{src[0],src[1],src[2]} , &dst, 1, 1, 3, 3, 7, 21)
+	FastNlMeansDenoisingColoredMultiWithParams([]Mat{src[0], src[1], src[2]}, &dst, 1, 1, 3, 3, 7, 21)
 
 	if dst.Empty() || dst.Rows() != src[0].Rows() || dst.Cols() != src[0].Cols() {
 		t.Error("Invalid FastNlMeansDenoisingColoredMultiWithParams test")
@@ -83,7 +83,7 @@ func TestFastNlMeansDenoisingColoredMultiWithParams(t *testing.T) {
 
 func TestMergeMertens(t *testing.T) {
 	var src [3]Mat
-	for i := 0; i<3 ; i++ {
+	for i := 0; i < 3; i++ {
 		src[i] = NewMatWithSize(20, 20, MatTypeCV8UC3)
 		defer src[i].Close()
 	}
@@ -94,17 +94,16 @@ func TestMergeMertens(t *testing.T) {
 	mertens := NewMergeMertens()
 	defer mertens.Close()
 
-	mertens.Process( []Mat{src[0],src[1],src[2]} , &dst )
+	mertens.Process([]Mat{src[0], src[1], src[2]}, &dst)
 
 	if dst.Empty() || dst.Rows() != src[0].Rows() || dst.Cols() != src[0].Cols() {
 		t.Error("Invalid TestMergeMertens test")
 	}
 }
 
-
 func TestNewAlignMTB(t *testing.T) {
 	var src [3]Mat
-	for i := 0; i<3 ; i++ {
+	for i := 0; i < 3; i++ {
 		src[i] = NewMatWithSize(20, 20, MatTypeCV8UC3)
 		defer src[i].Close()
 	}
@@ -113,10 +112,10 @@ func TestNewAlignMTB(t *testing.T) {
 	defer alignwtb.Close()
 
 	var dst []Mat
-	alignwtb.Process( []Mat{src[0],src[1],src[2]} , &dst   )
+	alignwtb.Process([]Mat{src[0], src[1], src[2]}, &dst)
 
 	sizedst := len(dst)
-	t.Logf(" Size Dst slice : %d " , sizedst)
+	t.Logf(" Size Dst slice : %d ", sizedst)
 	if sizedst > 0 {
 		if dst[0].Empty() || dst[0].Rows() != src[0].Rows() || dst[0].Cols() != src[0].Cols() {
 			t.Error("Invalid TestNewAlignMTB test")

--- a/photo_test.go
+++ b/photo_test.go
@@ -63,3 +63,66 @@ func TestTextureFlattening(t *testing.T) {
 		t.Error("Invlalid TextureFlattening test")
 	}
 }
+
+func TestFastNlMeansDenoisingColoredMultiWithParams(t *testing.T) {
+	var src [3]Mat
+	for i := 0; i<3 ; i++ {
+		src[i] = NewMatWithSize(20, 20, MatTypeCV8UC3)
+		defer src[i].Close()
+	}
+
+	dst := NewMat()
+	defer dst.Close()
+
+	FastNlMeansDenoisingColoredMultiWithParams( []Mat{src[0],src[1],src[2]} , &dst, 1, 1, 3, 3, 7, 21)
+
+	if dst.Empty() || dst.Rows() != src[0].Rows() || dst.Cols() != src[0].Cols() {
+		t.Error("Invalid FastNlMeansDenoisingColoredMultiWithParams test")
+	}
+}
+
+func TestMergeMertens(t *testing.T) {
+	var src [3]Mat
+	for i := 0; i<3 ; i++ {
+		src[i] = NewMatWithSize(20, 20, MatTypeCV8UC3)
+		defer src[i].Close()
+	}
+
+	dst := NewMat()
+	defer dst.Close()
+
+	mertens := NewMergeMertens()
+	defer mertens.Close()
+
+	mertens.Process( []Mat{src[0],src[1],src[2]} , &dst )
+
+	if dst.Empty() || dst.Rows() != src[0].Rows() || dst.Cols() != src[0].Cols() {
+		t.Error("Invalid TestMergeMertens test")
+	}
+}
+
+
+func TestNewAlignMTB(t *testing.T) {
+	var src [3]Mat
+	for i := 0; i<3 ; i++ {
+		src[i] = NewMatWithSize(20, 20, MatTypeCV8UC3)
+		defer src[i].Close()
+	}
+
+	alignwtb := NewAlignMTB()
+	defer alignwtb.Close()
+
+	var dst []Mat
+	alignwtb.Process( []Mat{src[0],src[1],src[2]} , &dst   )
+
+	sizedst := len(dst)
+	t.Logf(" Size Dst slice : %d " , sizedst)
+	if sizedst > 0 {
+		if dst[0].Empty() || dst[0].Rows() != src[0].Rows() || dst[0].Cols() != src[0].Cols() {
+			t.Error("Invalid TestNewAlignMTB test")
+		}
+	}
+	if sizedst <= 0 {
+		t.Error("Invalid TestNewAlignMTB test : empty result")
+	}
+}


### PR DESCRIPTION
I have used few functions from Photo group, so if this can help, i share  :

On this **Dev_photo** branch, there are ``AlignMTB`` and ``MergeMertens`` process functions.
Too, you can find ``fastNlMeansDenoisingColoredMulti`` function.

-  **photo. Computational Photography - WORK STARTED** The following functions still need implementation:
    - [x] [fastNlMeansDenoisingColoredMulti](https://docs.opencv.org/master/d1/d79/group__photo__denoise.html#gaa501e71f52fb2dc17ff8ca5e7d2d3619)
    - [x] [createAlignMTB](https://docs.opencv.org/master/d6/df5/group__photo__hdr.html#ga2f1fafc885a5d79dbfb3542e08db0244)
    - [x] [createMergeMertens](https://docs.opencv.org/master/d6/df5/group__photo__hdr.html#ga79d59aa3cb3a7c664e59a4b5acc1ccb6)
