### PR TITLE
fix: change MOSSE to KCF

### DIFF
--- a/cmd/tracking/main.go
+++ b/cmd/tracking/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	// create a tracker instance
 	// (one of MIL, KCF, TLD, MedianFlow, Boosting, MOSSE or CSRT)
-	tracker := contrib.NewTrackerMOSSE()
+	tracker := contrib.NewTrackerKCF()
 	defer tracker.Close()
 
 	// prepare image matrix


### PR DESCRIPTION
MOSSE has been moved to legacy since OpenCV 4.5.1