### PR TITLE
Fix possible MatProfile race by ordering remove before free.

### DIFF
--- a/mat_profile.go
+++ b/mat_profile.go
@@ -73,8 +73,10 @@ func newMat(p C.Mat) Mat {
 
 // Close the Mat object.
 func (m *Mat) Close() error {
-	C.Mat_Close(m.p)
+	// NOTE: The pointer must be removed from the profile before it is deleted to
+	// avoid a data race.
 	MatProfile.Remove(m.p)
+	C.Mat_Close(m.p)
 	m.p = nil
 	m.d = nil
 	return nil


### PR DESCRIPTION
When building with `-tags matprofile` set, gocv will occasionally panic due to a
duplicate pointer added to the pprof Profile: #851 

The pointer added comes directly from new (via Mat_New). Assuming correct memory
allocator behavior, that means that we must be inserting a pointer which was
previously deleted.

Since the pointer is currently removed from the Profile *after* it is freed,
there's a possible data race in multithreaded applications where `new` gives us
back a deleted pointer immediately and we insert it before we have a chance to
remove it from the profile, triggering this condition.

I'm not completely certain this resolves the issue since the race is extremely
difficult to reproduce.