### PR TITLE
imencode: optimize IMEncode avoiding multiple data copies.

### DIFF
--- a/cmd/mjpeg-streamer/main.go
+++ b/cmd/mjpeg-streamer/main.go
@@ -80,6 +80,7 @@ func mjpegCapture() {
 		}
 
 		buf, _ := gocv.IMEncode(".jpg", img)
-		stream.UpdateJPEG(buf)
+		stream.UpdateJPEG(buf.GetBytes())
+		buf.Close()
 	}
 }

--- a/core.cpp
+++ b/core.cpp
@@ -1010,3 +1010,19 @@ void copyPointVectorToPoint2fVector(PointVector src, Point2fVector dest) {
         dest->push_back(cv::Point2f(src->at(i).x, src->at(i).y));
     }
 }
+
+void StdByteVectorInitialize(void* data) {
+    new (data) std::vector<uchar>();
+}
+
+void StdByteVectorFree(void *data) {
+    reinterpret_cast<std::vector<uchar> *>(data)->~vector<uchar>();
+}
+
+size_t StdByteVectorLen(void *data) {
+    return reinterpret_cast<std::vector<uchar> *>(data)->size();
+}
+
+uint8_t* StdByteVectorData(void *data) {
+    return reinterpret_cast<std::vector<uchar> *>(data)->data();
+}

--- a/core.h
+++ b/core.h
@@ -452,6 +452,10 @@ void RandU(Mat mat, Scalar low, Scalar high);
 
 void copyPointVectorToPoint2fVector(PointVector src, Point2fVector dest);
 
+void StdByteVectorInitialize(void* data);
+void StdByteVectorFree(void *data);
+size_t StdByteVectorLen(void *data);
+uint8_t* StdByteVectorData(void *data);
 #ifdef __cplusplus
 }
 #endif

--- a/imgcodecs.cpp
+++ b/imgcodecs.cpp
@@ -21,22 +21,20 @@ bool Image_IMWrite_WithParams(const char* filename, Mat img, IntVector params) {
     return cv::imwrite(filename, *img, compression_params);
 }
 
-struct ByteArray Image_IMEncode(const char* fileExt, Mat img) {
-    std::vector<uchar> data;
-    cv::imencode(fileExt, *img, data);
-    return toByteArray(reinterpret_cast<const char*>(&data[0]), data.size());
+void Image_IMEncode(const char* fileExt, Mat img, void* vector) {
+    auto vectorPtr = reinterpret_cast<std::vector<uchar> *>(vector);
+    cv::imencode(fileExt, *img, *vectorPtr);
 }
 
-struct ByteArray Image_IMEncode_WithParams(const char* fileExt, Mat img, IntVector params) {
-    std::vector<uchar> data;
+void Image_IMEncode_WithParams(const char* fileExt, Mat img, IntVector params, void* vector) {
+    auto vectorPtr = reinterpret_cast<std::vector<uchar> *>(vector);
     std::vector<int> compression_params;
 
     for (int i = 0, *v = params.val; i < params.length; ++v, ++i) {
         compression_params.push_back(*v);
     }
 
-    cv::imencode(fileExt, *img, data, compression_params);
-    return toByteArray(reinterpret_cast<const char*>(&data[0]), data.size());
+    cv::imencode(fileExt, *img, *vectorPtr, compression_params);
 }
 
 Mat Image_IMDecode(ByteArray buf, int flags) {

--- a/imgcodecs.go
+++ b/imgcodecs.go
@@ -197,13 +197,13 @@ const (
 // For further details, please see:
 // http://docs.opencv.org/master/d4/da8/group__imgcodecs.html#ga461f9ac09887e47797a54567df3b8b63
 //
-func IMEncode(fileExt FileExt, img Mat) (buf []byte, err error) {
+func IMEncode(fileExt FileExt, img Mat) (buf *NativeByteBuffer, err error) {
 	cfileExt := C.CString(string(fileExt))
 	defer C.free(unsafe.Pointer(cfileExt))
 
-	b := C.Image_IMEncode(cfileExt, img.Ptr())
-	defer C.ByteArray_Release(b)
-	return toGoBytes(b), nil
+	buffer := newNativeByteBuffer()
+	C.Image_IMEncode(cfileExt, img.Ptr(), buffer.nativePointer())
+	return buffer, nil
 }
 
 // IMEncodeWithParams encodes an image Mat into a memory buffer.
@@ -216,7 +216,7 @@ func IMEncode(fileExt FileExt, img Mat) (buf []byte, err error) {
 // For further details, please see:
 // http://docs.opencv.org/master/d4/da8/group__imgcodecs.html#ga461f9ac09887e47797a54567df3b8b63
 //
-func IMEncodeWithParams(fileExt FileExt, img Mat, params []int) (buf []byte, err error) {
+func IMEncodeWithParams(fileExt FileExt, img Mat, params []int) (buf *NativeByteBuffer, err error) {
 	cfileExt := C.CString(string(fileExt))
 	defer C.free(unsafe.Pointer(cfileExt))
 
@@ -230,9 +230,9 @@ func IMEncodeWithParams(fileExt FileExt, img Mat, params []int) (buf []byte, err
 	paramsVector.val = (*C.int)(&cparams[0])
 	paramsVector.length = (C.int)(len(cparams))
 
-	b := C.Image_IMEncode_WithParams(cfileExt, img.Ptr(), paramsVector)
-	defer C.ByteArray_Release(b)
-	return toGoBytes(b), nil
+	b := newNativeByteBuffer()
+	C.Image_IMEncode_WithParams(cfileExt, img.Ptr(), paramsVector, b.nativePointer())
+	return b, nil
 }
 
 // IMDecode reads an image from a buffer in memory.

--- a/imgcodecs.h
+++ b/imgcodecs.h
@@ -13,8 +13,9 @@ extern "C" {
 Mat Image_IMRead(const char* filename, int flags);
 bool Image_IMWrite(const char* filename, Mat img);
 bool Image_IMWrite_WithParams(const char* filename, Mat img, IntVector params);
-struct ByteArray Image_IMEncode(const char* fileExt, Mat img);
-struct ByteArray Image_IMEncode_WithParams(const char* fileExt, Mat img, IntVector params);
+void Image_IMEncode(const char* fileExt, Mat img, void* vector);
+
+void Image_IMEncode_WithParams(const char* fileExt, Mat img, IntVector params, void* vector);
 Mat Image_IMDecode(ByteArray buf, int flags);
 
 #ifdef __cplusplus

--- a/imgcodecs_test.go
+++ b/imgcodecs_test.go
@@ -64,8 +64,10 @@ func TestIMEncode(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if len(buf) < 43000 {
-		t.Errorf("Wrong buffer size in IMEncode test. Should have been %v\n", len(buf))
+	defer buf.Close()
+	bytes := buf.GetBytes()
+	if len(bytes) < 43000 {
+		t.Errorf("Wrong buffer size in IMEncode test. Should have been %v\n", len(bytes))
 	}
 }
 
@@ -86,9 +88,10 @@ func ExampleIMEncodeWithParams() {
 			io.WriteString(w, err.Error())
 			return
 		}
+		defer buffer.Close()
 		w.Header().Set("Content-Type", "image/jpeg")
 		w.WriteHeader(http.StatusOK)
-		w.Write(buffer)
+		w.Write(buffer.GetBytes())
 	}
 
 	http.HandleFunc("/img", imgHandler)
@@ -107,19 +110,21 @@ func TestIMEncodeWithParams(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if len(buf) < 18000 {
-		t.Errorf("Wrong buffer size in IMEncode test. Should have been %v\n", len(buf))
+	defer buf.Close()
+	if buf.Len() < 18000 {
+		t.Errorf("Wrong buffer size in IMEncode test. Should have been %v\n", buf.Len())
 	}
 
 	buf2, err := IMEncodeWithParams(JPEGFileExt, img, []int{IMWriteJpegQuality, 100})
 	if err != nil {
 		t.Error(err)
 	}
-	if len(buf2) < 18000 {
-		t.Errorf("Wrong buffer size in IMEncode test. Should have been %v\n", len(buf))
+	defer buf2.Close()
+	if buf2.Len() < 18000 {
+		t.Errorf("Wrong buffer size in IMEncode test. Should have been %v\n", buf2.Len())
 	}
 
-	if len(buf) >= len(buf2) {
+	if buf.Len() >= buf2.Len() {
 		t.Errorf("Jpeg quality parameter does not work correctly\n")
 	}
 }


### PR DESCRIPTION
Currently IMEncode implemented the following way:
1) In Image_IMEncode std::vector is allocated and filled by cv::imencode
2) In Image_IMEncode function toByteArray allocated another native array
and copies the data from the vector
3) In IMEncode the result of Image_IMEncode is further copied to golang
allocated byte array.

Hence there are 2 additional copies of the data for each call to
IMEncode.
This is highly inefficient, especially if this needs to be performed
frequently.

The solution is to avoid copies altogether (though with a slight API
cost).
First we introduce NativeByteBuffer struct which is just a wrapper for
std::vector. Note that it is hard-coded 24 bytes (std::vector is 3
pointers of data, and this will never change as this will force
recompilation of probably every existing c++ application).

Second We call Image_IMEncode with this "preallocated" and
pre-initialied std::vector.

Finally the "func (buffer *NativeByteBuffer) GetBytes() []byte" function
returns a hand-made slice from the underlying std::vector buffer.

Note that we both provide a "Close" function and register "finalizer" to
clear the native buffer when NativeByteBuffer goes out of scope.

Usage Example:

buf, err := IMEncode(PNGFileExt, img)
defer buf.Close()
bytes := buf.GetBytes()