### PR TITLE
cuda: use Stream for thread-safe concurrency

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,12 +1,12 @@
 # to build this docker image:
 #   docker build -f Dockerfile.gpu .
-FROM gocv/opencv:4.5.3-gpu AS gocv-gpu
+FROM gocv/opencv:4.5.3-gpu-cuda-11 AS gocv-gpu
 
 ENV GOPATH /go
 
 COPY . /go/src/gocv.io/x/gocv/
 
 WORKDIR /go/src/gocv.io/x/gocv
-RUN go build -tags example -o /build/gocv_cuda_version ./cmd/cuda/
+RUN go build -tags cuda -o /build/gocv_cuda_version ./cmd/cuda/
 
 CMD ["/build/gocv_cuda_version"]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -212,9 +212,9 @@ Your pull requests will be greatly appreciated!
 - [ ] **core. - WORK STARTED** The following functions still need implementation:
     - [ ] [cv::cuda::convertFp16](https://docs.opencv.org/master/d8/d40/group__cudacore__init.html#gaa1c52258763197958eb9e6681917f723)
     - [ ] [cv::cuda::deviceSupports](https://docs.opencv.org/master/d8/d40/group__cudacore__init.html#ga170b10cc9af4aa8cce8c0afdb4b1d08c)
-    - [ ] [cv::cuda::getDevice](https://docs.opencv.org/master/d8/d40/group__cudacore__init.html#ga6ded4ed8e4fc483a9863d31f34ec9c0e)
-    - [ ] [cv::cuda::resetDevice](https://docs.opencv.org/master/d8/d40/group__cudacore__init.html#ga6153b6f461101374e655a54fc77e725e)
-    - [ ] [cv::cuda::setDevice](https://docs.opencv.org/master/d8/d40/group__cudacore__init.html#gaefa34186b185de47851836dba537828b)
+    - [X] [cv::cuda::getDevice](https://docs.opencv.org/master/d8/d40/group__cudacore__init.html#ga6ded4ed8e4fc483a9863d31f34ec9c0e)
+    - [X] [cv::cuda::resetDevice](https://docs.opencv.org/master/d8/d40/group__cudacore__init.html#ga6153b6f461101374e655a54fc77e725e)
+    - [X] [cv::cuda::setDevice](https://docs.opencv.org/master/d8/d40/group__cudacore__init.html#gaefa34186b185de47851836dba537828b)
 
 - [ ] **cudaarithm. Operations on Matrices - WORK STARTED** The following functions still need implementation:
     - [ ] **core** The following functions still need implementation:
@@ -353,6 +353,7 @@ Your pull requests will be greatly appreciated!
 
 - [ ] alphamat. Alpha Matting
 - [ ] aruco. ArUco Marker Detection
+- [ ] barcode. Barcode detecting and decoding methods
 - [X] **bgsegm. Improved Background-Foreground Segmentation Methods - WORK STARTED**
 - [ ] bioinspired. Biologically inspired vision models and derivated tools
 - [ ] ccalib. Custom Calibration Pattern for 3D reconstruction
@@ -372,11 +373,12 @@ Your pull requests will be greatly appreciated!
 - [ ] intensity_transform. The module brings implementations of intensity transformation algorithms to adjust image contrast.
 - [ ] line_descriptor. Binary descriptors for lines extracted from an image
 - [ ] mcc. Macbeth Chart module
-- [ ] matlab. MATLAB Bridge
 - [ ] optflow. Optical Flow Algorithms
 - [ ] ovis. OGRE 3D Visualiser
 - [ ] phase_unwrapping. Phase Unwrapping API
 - [ ] plot. Plot function for Mat data
+- [ ] quality. Image Quality Analysis (IQA) API
+- [ ] rapid. silhouette based 3D object tracking
 - [ ] reg. Image Registration
 - [ ] rgbd. RGB-Depth Processing
 - [ ] saliency. Saliency API
@@ -390,6 +392,7 @@ Your pull requests will be greatly appreciated!
 - [ ] **tracking. Tracking API - WORK STARTED**
 - [ ] videostab. Video Stabilization
 - [ ] viz. 3D Visualizer
+- [ ] wechat_qrcode. WeChat QR code detector for detecting and parsing QR code.
 - [ ] **xfeatures2d. Extra 2D Features Framework - WORK STARTED**
 - [ ] ximgproc. Extended Image Processing
 - [ ] xobjdetect. Extended object detection

--- a/cuda/arithm.cpp
+++ b/cuda/arithm.cpp
@@ -2,14 +2,27 @@
 #include "arithm.h"
 #include <string.h>
 
-void GpuAbs(GpuMat src, GpuMat dst) {
-    cv::cuda::abs(*src, *dst);
+void GpuAbs(GpuMat src, GpuMat dst, Stream s) {
+    if (s == NULL) {
+        cv::cuda::abs(*src, *dst);
+        return;
+    }
+    cv::cuda::abs(*src, *dst, *s);
 }
 
-void GpuThreshold(GpuMat src, GpuMat dst, double thresh, double maxval, int typ) {
-    cv::cuda::threshold(*src, *dst, thresh, maxval, typ);
+void GpuThreshold(GpuMat src, GpuMat dst, double thresh, double maxval, int typ, Stream s) {
+    if (s == NULL) {
+        cv::cuda::threshold(*src, *dst, thresh, maxval, typ);
+        return;
+    }
+
+    cv::cuda::threshold(*src, *dst, thresh, maxval, typ, *s);
 }
 
-void GpuFlip(GpuMat src, GpuMat dst, int flipCode) {
-    cv::cuda::flip(*src, *dst, flipCode);
+void GpuFlip(GpuMat src, GpuMat dst, int flipCode, Stream s) {
+    if (s == NULL) {
+        cv::cuda::flip(*src, *dst, flipCode);
+        return;
+    }
+    cv::cuda::flip(*src, *dst, flipCode, *s);
 }

--- a/cuda/arithm.go
+++ b/cuda/arithm.go
@@ -16,7 +16,17 @@ import "gocv.io/x/gocv"
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga54a72bd772494ab34d05406fd76df2b6
 //
 func Abs(src GpuMat, dst *GpuMat) {
-	C.GpuAbs(src.p, dst.p)
+	C.GpuAbs(src.p, dst.p, nil)
+}
+
+// AbsWithStream computes an absolute value of each matrix element
+// using a Stream for concurrency.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga54a72bd772494ab34d05406fd76df2b6
+//
+func AbsWithStream(src GpuMat, dst *GpuMat, stream Stream) {
+	C.GpuAbs(src.p, dst.p, stream.p)
 }
 
 // Threshold applies a fixed-level threshold to each array element.
@@ -25,7 +35,17 @@ func Abs(src GpuMat, dst *GpuMat) {
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga40f1c94ae9a9456df3cad48e3cb008e1
 //
 func Threshold(src GpuMat, dst *GpuMat, thresh, maxval float64, typ gocv.ThresholdType) {
-	C.GpuThreshold(src.p, dst.p, C.double(thresh), C.double(maxval), C.int(typ))
+	C.GpuThreshold(src.p, dst.p, C.double(thresh), C.double(maxval), C.int(typ), nil)
+}
+
+// ThresholdWithStream applies a fixed-level threshold to each array element
+// using a Stream for concurrency.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga40f1c94ae9a9456df3cad48e3cb008e1
+//
+func ThresholdWithStream(src GpuMat, dst *GpuMat, thresh, maxval float64, typ gocv.ThresholdType, s Stream) {
+	C.GpuThreshold(src.p, dst.p, C.double(thresh), C.double(maxval), C.int(typ), s.p)
 }
 
 // Flip flips a 2D matrix around vertical, horizontal, or both axes.
@@ -34,5 +54,15 @@ func Threshold(src GpuMat, dst *GpuMat, thresh, maxval float64, typ gocv.Thresho
 // https://docs.opencv.org/master/de/d09/group__cudaarithm__core.html#ga4d0a3f2b46e8f0f1ec2b5ac178dcd871
 //
 func Flip(src GpuMat, dst *GpuMat, flipCode int) {
-	C.GpuFlip(src.p, dst.p, C.int(flipCode))
+	C.GpuFlip(src.p, dst.p, C.int(flipCode), nil)
+}
+
+// FlipWithStream flips a 2D matrix around vertical, horizontal, or both axes
+// using a Stream for concurrency.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/de/d09/group__cudaarithm__core.html#ga4d0a3f2b46e8f0f1ec2b5ac178dcd871
+//
+func FlipWithStream(src GpuMat, dst *GpuMat, flipCode int, stream Stream) {
+	C.GpuFlip(src.p, dst.p, C.int(flipCode), stream.p)
 }

--- a/cuda/arithm.h
+++ b/cuda/arithm.h
@@ -11,9 +11,9 @@ extern "C" {
 #endif
 #include "cuda.h"
 
-void GpuAbs(GpuMat src, GpuMat dst);
-void GpuThreshold(GpuMat src, GpuMat dst, double thresh, double maxval, int typ);
-void GpuFlip(GpuMat src, GpuMat dst, int flipCode);
+void GpuAbs(GpuMat src, GpuMat dst, Stream s);
+void GpuThreshold(GpuMat src, GpuMat dst, double thresh, double maxval, int typ, Stream s);
+void GpuFlip(GpuMat src, GpuMat dst, int flipCode, Stream s);
 
 #ifdef __cplusplus
 }

--- a/cuda/arithm_test.go
+++ b/cuda/arithm_test.go
@@ -29,6 +29,30 @@ func TestAbs(t *testing.T) {
 	}
 }
 
+func TestAbsWithStream(t *testing.T) {
+	src := gocv.IMRead("../images/gocvlogo.jpg", gocv.IMReadColor)
+	if src.Empty() {
+		t.Error("Invalid read of Mat in Abs test")
+	}
+	defer src.Close()
+
+	var cimg, dimg, s = NewGpuMat(), NewGpuMat(), NewStream()
+	defer cimg.Close()
+	defer dimg.Close()
+	defer s.Close()
+
+	cimg.Upload(src)
+
+	dest := gocv.NewMat()
+	defer dest.Close()
+
+	AbsWithStream(cimg, &dimg, s)
+	dimg.Download(&dest)
+	if dest.Empty() || src.Rows() != dest.Rows() || src.Cols() != dest.Cols() {
+		t.Error("Invalid Abs test")
+	}
+}
+
 func TestThreshold(t *testing.T) {
 	src := gocv.IMRead("../images/gocvlogo.jpg", gocv.IMReadColor)
 	if src.Empty() {
@@ -52,6 +76,30 @@ func TestThreshold(t *testing.T) {
 	}
 }
 
+func TestThresholdWithStream(t *testing.T) {
+	src := gocv.IMRead("../images/gocvlogo.jpg", gocv.IMReadColor)
+	if src.Empty() {
+		t.Error("Invalid read of Mat in Threshold test")
+	}
+	defer src.Close()
+
+	var cimg, dimg, s = NewGpuMat(), NewGpuMat(), NewStream()
+	defer cimg.Close()
+	defer dimg.Close()
+	defer s.Close()
+
+	cimg.Upload(src)
+
+	dest := gocv.NewMat()
+	defer dest.Close()
+
+	ThresholdWithStream(cimg, &dimg, 25, 255, gocv.ThresholdBinary, s)
+	dimg.Download(&dest)
+	if dest.Empty() || src.Rows() != dest.Rows() || src.Cols() != dest.Cols() {
+		t.Error("Invalid Threshold test")
+	}
+}
+
 func TestFlip(t *testing.T) {
 	src := gocv.IMRead("../images/gocvlogo.jpg", gocv.IMReadColor)
 	if src.Empty() {
@@ -69,6 +117,30 @@ func TestFlip(t *testing.T) {
 	defer dest.Close()
 
 	Flip(cimg, &dimg, 0)
+	dimg.Download(&dest)
+	if dest.Empty() || src.Rows() != dest.Rows() || src.Cols() != dest.Cols() {
+		t.Error("Invalid Flip test")
+	}
+}
+
+func TestFlipWithStream(t *testing.T) {
+	src := gocv.IMRead("../images/gocvlogo.jpg", gocv.IMReadColor)
+	if src.Empty() {
+		t.Error("Invalid read of Mat in Flip test")
+	}
+	defer src.Close()
+
+	var cimg, dimg, s = NewGpuMat(), NewGpuMat(), NewStream()
+	defer cimg.Close()
+	defer dimg.Close()
+	defer s.Close()
+
+	cimg.Upload(src)
+
+	dest := gocv.NewMat()
+	defer dest.Close()
+
+	FlipWithStream(cimg, &dimg, 0, s)
 	dimg.Download(&dest)
 	if dest.Empty() || src.Rows() != dest.Rows() || src.Cols() != dest.Cols() {
 		t.Error("Invalid Flip test")

--- a/cuda/arithm_test.go
+++ b/cuda/arithm_test.go
@@ -41,13 +41,15 @@ func TestAbsWithStream(t *testing.T) {
 	defer dimg.Close()
 	defer s.Close()
 
-	cimg.Upload(src)
-
 	dest := gocv.NewMat()
 	defer dest.Close()
 
+	cimg.UploadWithStream(src, s)
 	AbsWithStream(cimg, &dimg, s)
-	dimg.Download(&dest)
+	dimg.DownloadWithStream(&dest, s)
+
+	s.WaitForCompletion()
+
 	if dest.Empty() || src.Rows() != dest.Rows() || src.Cols() != dest.Cols() {
 		t.Error("Invalid Abs test")
 	}
@@ -88,13 +90,15 @@ func TestThresholdWithStream(t *testing.T) {
 	defer dimg.Close()
 	defer s.Close()
 
-	cimg.Upload(src)
-
 	dest := gocv.NewMat()
 	defer dest.Close()
 
+	cimg.UploadWithStream(src, s)
 	ThresholdWithStream(cimg, &dimg, 25, 255, gocv.ThresholdBinary, s)
-	dimg.Download(&dest)
+	dimg.DownloadWithStream(&dest, s)
+
+	s.WaitForCompletion()
+
 	if dest.Empty() || src.Rows() != dest.Rows() || src.Cols() != dest.Cols() {
 		t.Error("Invalid Threshold test")
 	}
@@ -135,13 +139,15 @@ func TestFlipWithStream(t *testing.T) {
 	defer dimg.Close()
 	defer s.Close()
 
-	cimg.Upload(src)
-
 	dest := gocv.NewMat()
 	defer dest.Close()
 
+	cimg.UploadWithStream(src, s)
 	FlipWithStream(cimg, &dimg, 0, s)
-	dimg.Download(&dest)
+	dimg.DownloadWithStream(&dest, s)
+
+	s.WaitForCompletion()
+
 	if dest.Empty() || src.Rows() != dest.Rows() || src.Cols() != dest.Cols() {
 		t.Error("Invalid Flip test")
 	}

--- a/cuda/bgsegm.cpp
+++ b/cuda/bgsegm.cpp
@@ -8,8 +8,12 @@ void CudaBackgroundSubtractorMOG2_Close(CudaBackgroundSubtractorMOG2 b) {
     delete b;
 }
 
-void CudaBackgroundSubtractorMOG2_Apply(CudaBackgroundSubtractorMOG2 b, GpuMat src, GpuMat dst) {
-    (*b)->apply(*src, *dst);
+void CudaBackgroundSubtractorMOG2_Apply(CudaBackgroundSubtractorMOG2 b, GpuMat src, GpuMat dst, Stream s) {
+    if (s == NULL) {
+        (*b)->apply(*src, *dst);
+        return;
+    }
+    (*b)->apply(*src, *dst, -1.0, *s);
 }
 
 CudaBackgroundSubtractorMOG CudaBackgroundSubtractorMOG_Create() {
@@ -20,6 +24,10 @@ void CudaBackgroundSubtractorMOG_Close(CudaBackgroundSubtractorMOG b) {
     delete b;
 }
 
-void CudaBackgroundSubtractorMOG_Apply(CudaBackgroundSubtractorMOG b, GpuMat src, GpuMat dst) {
-    (*b)->apply(*src, *dst);
+void CudaBackgroundSubtractorMOG_Apply(CudaBackgroundSubtractorMOG b, GpuMat src, GpuMat dst, Stream s) {
+    if (s == NULL) {
+        (*b)->apply(*src, *dst);
+        return;
+    }
+    (*b)->apply(*src, *dst, -1.0, *s);
 }

--- a/cuda/bgsegm.go
+++ b/cuda/bgsegm.go
@@ -43,7 +43,18 @@ func (b *BackgroundSubtractorMOG2) Close() error {
 // https://docs.opencv.org/master/df/d23/classcv_1_1cuda_1_1BackgroundSubtractorMOG2.html#a92408f07bf1268c1b778cb186b3113b0
 //
 func (b *BackgroundSubtractorMOG2) Apply(src GpuMat, dst *GpuMat) {
-	C.CudaBackgroundSubtractorMOG2_Apply((C.CudaBackgroundSubtractorMOG2)(b.p), src.p, dst.p)
+	C.CudaBackgroundSubtractorMOG2_Apply((C.CudaBackgroundSubtractorMOG2)(b.p), src.p, dst.p, nil)
+	return
+}
+
+// ApplyWithStream computes a foreground mask using the current BackgroundSubtractorMOG2
+// using a Stream for concurrency.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/df/d23/classcv_1_1cuda_1_1BackgroundSubtractorMOG2.html#a92408f07bf1268c1b778cb186b3113b0
+//
+func (b *BackgroundSubtractorMOG2) ApplyWithStream(src GpuMat, dst *GpuMat, s Stream) {
+	C.CudaBackgroundSubtractorMOG2_Apply((C.CudaBackgroundSubtractorMOG2)(b.p), src.p, dst.p, s.p)
 	return
 }
 
@@ -71,6 +82,17 @@ func (b *BackgroundSubtractorMOG) Close() error {
 // https://docs.opencv.org/master/d1/dfe/classcv_1_1cuda_1_1BackgroundSubtractorMOG.html#a8f52d2f7abd1c77c84243efc53972cbf
 //
 func (b *BackgroundSubtractorMOG) Apply(src GpuMat, dst *GpuMat) {
-	C.CudaBackgroundSubtractorMOG_Apply((C.CudaBackgroundSubtractorMOG)(b.p), src.p, dst.p)
+	C.CudaBackgroundSubtractorMOG_Apply((C.CudaBackgroundSubtractorMOG)(b.p), src.p, dst.p, nil)
+	return
+}
+
+// ApplyWithStream computes a foreground mask using the current BackgroundSubtractorMOG
+// using a Stream for concurrency.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d1/dfe/classcv_1_1cuda_1_1BackgroundSubtractorMOG.html#a8f52d2f7abd1c77c84243efc53972cbf
+//
+func (b *BackgroundSubtractorMOG) ApplyWithStream(src GpuMat, dst *GpuMat, s Stream) {
+	C.CudaBackgroundSubtractorMOG_Apply((C.CudaBackgroundSubtractorMOG)(b.p), src.p, dst.p, s.p)
 	return
 }

--- a/cuda/bgsegm.h
+++ b/cuda/bgsegm.h
@@ -21,11 +21,11 @@ typedef void* CudaBackgroundSubtractorMOG;
 
 CudaBackgroundSubtractorMOG2 CudaBackgroundSubtractorMOG2_Create();
 void CudaBackgroundSubtractorMOG2_Close(CudaBackgroundSubtractorMOG2 b);
-void CudaBackgroundSubtractorMOG2_Apply(CudaBackgroundSubtractorMOG2 b, GpuMat src, GpuMat dst);
+void CudaBackgroundSubtractorMOG2_Apply(CudaBackgroundSubtractorMOG2 b, GpuMat src, GpuMat dst, Stream s);
 
 CudaBackgroundSubtractorMOG CudaBackgroundSubtractorMOG_Create();
 void CudaBackgroundSubtractorMOG_Close(CudaBackgroundSubtractorMOG b);
-void CudaBackgroundSubtractorMOG_Apply(CudaBackgroundSubtractorMOG b, GpuMat src, GpuMat dst);
+void CudaBackgroundSubtractorMOG_Apply(CudaBackgroundSubtractorMOG b, GpuMat src, GpuMat dst, Stream s);
 
 #ifdef __cplusplus
 }

--- a/cuda/bgsegm_test.go
+++ b/cuda/bgsegm_test.go
@@ -46,17 +46,17 @@ func TestCudaMOG2WithStream(t *testing.T) {
 	defer dimg.Close()
 	defer s.Close()
 
-	cimg.Upload(img)
-
 	dst := gocv.NewMat()
 	defer dst.Close()
 
 	mog2 := NewBackgroundSubtractorMOG2()
 	defer mog2.Close()
 
+	cimg.UploadWithStream(img, s)
 	mog2.ApplyWithStream(cimg, &dimg, s)
+	dimg.DownloadWithStream(&dst, s)
 
-	dimg.Download(&dst)
+	s.WaitForCompletion()
 
 	if dst.Empty() {
 		t.Error("Error in TestCudaMOG2 test")
@@ -103,17 +103,17 @@ func TestCudaMOGWithStream(t *testing.T) {
 	defer dimg.Close()
 	defer s.Close()
 
-	cimg.Upload(img)
-
 	dst := gocv.NewMat()
 	defer dst.Close()
 
 	mog2 := NewBackgroundSubtractorMOG()
 	defer mog2.Close()
 
+	cimg.UploadWithStream(img, s)
 	mog2.ApplyWithStream(cimg, &dimg, s)
+	dimg.DownloadWithStream(&dst, s)
 
-	dimg.Download(&dst)
+	s.WaitForCompletion()
 
 	if dst.Empty() {
 		t.Error("Error in TestCudaMOG test")

--- a/cuda/bgsegm_test.go
+++ b/cuda/bgsegm_test.go
@@ -1,8 +1,9 @@
 package cuda
 
 import (
-	"gocv.io/x/gocv"
 	"testing"
+
+	"gocv.io/x/gocv"
 )
 
 func TestCudaMOG2(t *testing.T) {
@@ -33,6 +34,35 @@ func TestCudaMOG2(t *testing.T) {
 	}
 }
 
+func TestCudaMOG2WithStream(t *testing.T) {
+	img := gocv.IMRead("../images/face.jpg", gocv.IMReadColor)
+	if img.Empty() {
+		t.Error("Invalid Mat in CudaMOG2 test")
+	}
+	defer img.Close()
+
+	var cimg, dimg, s = NewGpuMat(), NewGpuMat(), NewStream()
+	defer cimg.Close()
+	defer dimg.Close()
+	defer s.Close()
+
+	cimg.Upload(img)
+
+	dst := gocv.NewMat()
+	defer dst.Close()
+
+	mog2 := NewBackgroundSubtractorMOG2()
+	defer mog2.Close()
+
+	mog2.ApplyWithStream(cimg, &dimg, s)
+
+	dimg.Download(&dst)
+
+	if dst.Empty() {
+		t.Error("Error in TestCudaMOG2 test")
+	}
+}
+
 func TestCudaMOG(t *testing.T) {
 	img := gocv.IMRead("../images/face.jpg", gocv.IMReadColor)
 	if img.Empty() {
@@ -53,6 +83,35 @@ func TestCudaMOG(t *testing.T) {
 	defer mog2.Close()
 
 	mog2.Apply(cimg, &dimg)
+
+	dimg.Download(&dst)
+
+	if dst.Empty() {
+		t.Error("Error in TestCudaMOG test")
+	}
+}
+
+func TestCudaMOGWithStream(t *testing.T) {
+	img := gocv.IMRead("../images/face.jpg", gocv.IMReadColor)
+	if img.Empty() {
+		t.Error("Invalid Mat in CudaMOG test")
+	}
+	defer img.Close()
+
+	var cimg, dimg, s = NewGpuMat(), NewGpuMat(), NewStream()
+	defer cimg.Close()
+	defer dimg.Close()
+	defer s.Close()
+
+	cimg.Upload(img)
+
+	dst := gocv.NewMat()
+	defer dst.Close()
+
+	mog2 := NewBackgroundSubtractorMOG()
+	defer mog2.Close()
+
+	mog2.ApplyWithStream(cimg, &dimg, s)
 
 	dimg.Download(&dst)
 

--- a/cuda/cuda.cpp
+++ b/cuda/cuda.cpp
@@ -48,6 +48,18 @@ int GetCudaEnabledDeviceCount(){
     return cv::cuda::getCudaEnabledDeviceCount();
 }
 
+int GetCudaDevice() {
+    return cv::cuda::getDevice();
+}
+
+void SetCudaDevice(int device) {
+    cv::cuda::setDevice(device);
+}
+
+void ResetCudaDevice(){
+    cv::cuda::resetDevice();
+}
+
 void GpuMat_ConvertTo(GpuMat m, GpuMat dst, int type, Stream s) {
     if (s == NULL) {
         m->convertTo(*dst, type);

--- a/cuda/cuda.cpp
+++ b/cuda/cuda.cpp
@@ -8,6 +8,10 @@ GpuMat GpuMat_NewFromMat(Mat mat) {
     return new cv::cuda::GpuMat(*mat);
 }
 
+GpuMat GpuMat_NewWithSize(int rows, int cols, int type) {
+    return new cv::cuda::GpuMat(rows, cols, type);
+}
+
 void GpuMat_Upload(GpuMat m, Mat data, Stream s){
     if (s == NULL) {
         m->upload(*data);

--- a/cuda/cuda.cpp
+++ b/cuda/cuda.cpp
@@ -8,12 +8,20 @@ GpuMat GpuMat_NewFromMat(Mat mat) {
     return new cv::cuda::GpuMat(*mat);
 }
 
-void GpuMat_Upload(GpuMat m,Mat data){
-    m->upload(*data);
+void GpuMat_Upload(GpuMat m, Mat data, Stream s){
+    if (s == NULL) {
+        m->upload(*data);
+        return;
+    }
+    m->upload(*data, *s);
 }
 
-void GpuMat_Download(GpuMat m,Mat dst){
-    m->download(*dst);
+void GpuMat_Download(GpuMat m, Mat dst, Stream s){
+    if (s == NULL) {
+        m->download(*dst);
+        return;
+    }
+    m->download(*dst, *s);
 }
 
 int GpuMat_Empty(GpuMat m){
@@ -36,8 +44,24 @@ int GetCudaEnabledDeviceCount(){
     return cv::cuda::getCudaEnabledDeviceCount();
 }
 
-void GpuMat_ConvertTo(GpuMat m, GpuMat dst, int type) {
-    m->convertTo(*dst, type);
+void GpuMat_ConvertTo(GpuMat m, GpuMat dst, int type, Stream s) {
+    if (s == NULL) {
+        m->convertTo(*dst, type);
+        return;
+    }
+    m->convertTo(*dst, type, *s);
+}
+
+void GpuMat_CopyTo(GpuMat m, GpuMat dst, Stream s) {
+    if (s == NULL) {
+        m->copyTo(*dst);
+        return;
+    }
+    m->copyTo(*dst, *s);
+}
+
+void GpuMat_Reshape(GpuMat m, int cn, int rows) {
+    m->reshape(cn, rows);
 }
 
 int GpuMat_Cols(GpuMat m) {
@@ -62,4 +86,12 @@ Stream Stream_New() {
 
 void Stream_Close(Stream s){
     delete s;
+}
+
+bool Stream_QueryIfComplete(Stream s) {
+    return s->queryIfComplete();
+}
+
+void Stream_WaitForCompletion(Stream s) {
+    s->waitForCompletion();
 }

--- a/cuda/cuda.cpp
+++ b/cuda/cuda.cpp
@@ -60,8 +60,8 @@ void GpuMat_CopyTo(GpuMat m, GpuMat dst, Stream s) {
     m->copyTo(*dst, *s);
 }
 
-void GpuMat_Reshape(GpuMat m, int cn, int rows) {
-    m->reshape(cn, rows);
+GpuMat GpuMat_Reshape(GpuMat m, int cn, int rows) {
+    return new cv::cuda::GpuMat(m->reshape(cn, rows));
 }
 
 int GpuMat_Cols(GpuMat m) {

--- a/cuda/cuda.cpp
+++ b/cuda/cuda.cpp
@@ -55,3 +55,11 @@ int GpuMat_Channels(GpuMat m) {
 int GpuMat_Type(GpuMat m) {
     return m->type();
 }
+
+Stream Stream_New() {
+    return new cv::cuda::Stream();
+}
+
+void Stream_Close(Stream s){
+    delete s;
+}

--- a/cuda/cuda.go
+++ b/cuda/cuda.go
@@ -77,6 +77,11 @@ func NewGpuMatFromMat(mat gocv.Mat) GpuMat {
 	return newGpuMat(C.GpuMat_NewFromMat(C.Mat(mat.Ptr())))
 }
 
+// NewGpuMatWithSize returns a new GpuMat with a specific size and type.
+func NewGpuMatWithSize(rows int, cols int, mt gocv.MatType) GpuMat {
+	return newGpuMat(C.GpuMat_NewWithSize(C.int(rows), C.int(cols), C.int(mt)))
+}
+
 func newGpuMat(p C.GpuMat) GpuMat {
 	return GpuMat{p: p}
 }

--- a/cuda/cuda.go
+++ b/cuda/cuda.go
@@ -102,6 +102,36 @@ func GetCudaEnabledDeviceCount() int {
 	return int(C.GetCudaEnabledDeviceCount())
 }
 
+// GetDevice returns the current device index.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d8/d40/group__cudacore__init.html#ga6ded4ed8e4fc483a9863d31f34ec9c0e
+//
+func GetDevice() int {
+	return int(C.GetCudaDevice())
+}
+
+// SetDevice sets a device and initializes it for the current thread.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d8/d40/group__cudacore__init.html#gaefa34186b185de47851836dba537828b
+//
+func SetDevice(device int) {
+	C.SetCudaDevice(C.int(device))
+}
+
+// ResetDevice explicitly destroys and cleans up all resources associated
+// with the current device in the current process.
+//
+// Any subsequent API call to this device will reinitialize the device.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d8/d40/group__cudacore__init.html#ga6153b6f461101374e655a54fc77e725e
+//
+func ResetDevice() {
+	C.ResetCudaDevice()
+}
+
 // ConvertTo converts GpuMat into destination GpuMat.
 //
 // For further details, please see:

--- a/cuda/cuda.go
+++ b/cuda/cuda.go
@@ -157,15 +157,14 @@ func (m *GpuMat) Type() gocv.MatType {
 	return gocv.MatType(C.GpuMat_Type(m.p))
 }
 
-// Reshape changes the GpuMat to have the same data
-// with a different number of channels and/or different number of rows
+// Reshape creates a new GpuMat with the same data
+// but with a different number of channels and/or different number of rows.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d60/classcv_1_1cuda_1_1GpuMat.html#a408e22ed824d1ddf59f58bda895017a8
 //
-func (m *GpuMat) Reshape(cn int, rows int) {
-	C.GpuMat_Reshape(m.p, C.int(cn), C.int(rows))
-	return
+func (m *GpuMat) Reshape(cn int, rows int) GpuMat {
+	return newGpuMat(C.GpuMat_Reshape(m.p, C.int(cn), C.int(rows)))
 }
 
 // Stream asynchronous stream used for CUDA operations.

--- a/cuda/cuda.go
+++ b/cuda/cuda.go
@@ -109,3 +109,23 @@ func (m *GpuMat) Channels() int {
 func (m *GpuMat) Type() gocv.MatType {
 	return gocv.MatType(C.GpuMat_Type(m.p))
 }
+
+// Stream asynchronous stream used for CUDA operations.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d9/df3/classcv_1_1cuda_1_1Stream.html#aa6434e2f5f29bd81406732b39951c246
+type Stream struct {
+	p C.Stream
+}
+
+// NewStream returns a new empty Stream.
+func NewStream() Stream {
+	return Stream{p: C.Stream_New()}
+}
+
+// Close the Stream.
+func (s *Stream) Close() error {
+	C.Stream_Close(s.p)
+	s.p = nil
+	return nil
+}

--- a/cuda/cuda.go
+++ b/cuda/cuda.go
@@ -27,7 +27,16 @@ type GpuMat struct {
 // https://docs.opencv.org/master/d0/d60/classcv_1_1cuda_1_1GpuMat.html#a00ef5bfe18d14623dcf578a35e40a46b
 //
 func (g *GpuMat) Upload(data gocv.Mat) {
-	C.GpuMat_Upload(g.p, C.Mat(data.Ptr()))
+	C.GpuMat_Upload(g.p, C.Mat(data.Ptr()), nil)
+}
+
+// UploadWithStream performs data upload to GpuMat (non-blocking call)
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d0/d60/classcv_1_1cuda_1_1GpuMat.html#a00ef5bfe18d14623dcf578a35e40a46b
+//
+func (g *GpuMat) UploadWithStream(data gocv.Mat, s Stream) {
+	C.GpuMat_Upload(g.p, C.Mat(data.Ptr()), s.p)
 }
 
 // Download performs data download from GpuMat (Blocking call)
@@ -35,7 +44,15 @@ func (g *GpuMat) Upload(data gocv.Mat) {
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d60/classcv_1_1cuda_1_1GpuMat.html#a027e74e4364ddfd9687b58aa5db8d4e8
 func (g *GpuMat) Download(dst *gocv.Mat) {
-	C.GpuMat_Download(g.p, C.Mat(dst.Ptr()))
+	C.GpuMat_Download(g.p, C.Mat(dst.Ptr()), nil)
+}
+
+// DownloadWithStream performs data download from GpuMat (non-blocking call)
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d0/d60/classcv_1_1cuda_1_1GpuMat.html#a027e74e4364ddfd9687b58aa5db8d4e8
+func (g *GpuMat) DownloadWithStream(dst *gocv.Mat, s Stream) {
+	C.GpuMat_Download(g.p, C.Mat(dst.Ptr()), s.p)
 }
 
 // Empty returns true if GpuMat is empty
@@ -86,7 +103,37 @@ func GetCudaEnabledDeviceCount() int {
 // https://docs.opencv.org/master/d0/d60/classcv_1_1cuda_1_1GpuMat.html#a3a1b076e54d8a8503014e27a5440d98a
 //
 func (m *GpuMat) ConvertTo(dst *GpuMat, mt gocv.MatType) {
-	C.GpuMat_ConvertTo(m.p, dst.p, C.int(mt))
+	C.GpuMat_ConvertTo(m.p, dst.p, C.int(mt), nil)
+	return
+}
+
+// ConvertToWithStream converts GpuMat into destination GpuMat.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d0/d60/classcv_1_1cuda_1_1GpuMat.html#a3a1b076e54d8a8503014e27a5440d98a
+//
+func (m *GpuMat) ConvertToWithStream(dst *GpuMat, mt gocv.MatType, s Stream) {
+	C.GpuMat_ConvertTo(m.p, dst.p, C.int(mt), s.p)
+	return
+}
+
+// CopyTo copies GpuMat into destination GpuMat.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d0/d60/classcv_1_1cuda_1_1GpuMat.html#a948c562ee340c0678a44884bde1f5a3e
+//
+func (m *GpuMat) CopyTo(dst *GpuMat) {
+	C.GpuMat_CopyTo(m.p, dst.p, nil)
+	return
+}
+
+// CopyToWithStream copies GpuMat into destination GpuMat.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d0/d60/classcv_1_1cuda_1_1GpuMat.html#a948c562ee340c0678a44884bde1f5a3e
+//
+func (m *GpuMat) CopyToWithStream(dst *GpuMat, s Stream) {
+	C.GpuMat_CopyTo(m.p, dst.p, s.p)
 	return
 }
 
@@ -110,6 +157,17 @@ func (m *GpuMat) Type() gocv.MatType {
 	return gocv.MatType(C.GpuMat_Type(m.p))
 }
 
+// Reshape changes the GpuMat to have the same data
+// with a different number of channels and/or different number of rows
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d0/d60/classcv_1_1cuda_1_1GpuMat.html#a408e22ed824d1ddf59f58bda895017a8
+//
+func (m *GpuMat) Reshape(cn int, rows int) {
+	C.GpuMat_Reshape(m.p, C.int(cn), C.int(rows))
+	return
+}
+
 // Stream asynchronous stream used for CUDA operations.
 //
 // For further details, please see:
@@ -128,4 +186,22 @@ func (s *Stream) Close() error {
 	C.Stream_Close(s.p)
 	s.p = nil
 	return nil
+}
+
+// QueryIfComplete returns true if the current stream queue is finished
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d9/df3/classcv_1_1cuda_1_1Stream.html#a9fab618395d42fa31987506e42fab1b4
+//
+func (s *Stream) QueryIfComplete() bool {
+	return bool(C.Stream_QueryIfComplete(s.p))
+}
+
+// WaitForCompletion blocks the current CPU thread until all operations in the stream are complete.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d9/df3/classcv_1_1cuda_1_1Stream.html#a0e1d939503e8faad741ab584b720bca6
+//
+func (s *Stream) WaitForCompletion() {
+	C.Stream_WaitForCompletion(s.p)
 }

--- a/cuda/cuda.h
+++ b/cuda/cuda.h
@@ -36,6 +36,9 @@ int GpuMat_Type(GpuMat m);
 void PrintCudaDeviceInfo(int device);
 void PrintShortCudaDeviceInfo(int device);
 int GetCudaEnabledDeviceCount();
+int GetCudaDevice();
+void SetCudaDevice(int device);
+void ResetCudaDevice();
 
 Stream Stream_New();
 void Stream_Close(Stream s);

--- a/cuda/cuda.h
+++ b/cuda/cuda.h
@@ -20,11 +20,13 @@ typedef void* Stream;
 
 GpuMat GpuMat_New();
 GpuMat GpuMat_NewFromMat(Mat mat);
-void GpuMat_Upload(GpuMat m,Mat data);
-void GpuMat_Download(GpuMat m,Mat dst);
+void GpuMat_Upload(GpuMat m, Mat data, Stream s);
+void GpuMat_Download(GpuMat m, Mat dst, Stream s);
 void GpuMat_Close(GpuMat m);
 int GpuMat_Empty(GpuMat m);
-void GpuMat_ConvertTo(GpuMat m, GpuMat dst, int type);
+void GpuMat_ConvertTo(GpuMat m, GpuMat dst, int type, Stream s);
+void GpuMat_CopyTo(GpuMat m, GpuMat dst, Stream s);
+void GpuMat_Reshape(GpuMat m, int cn, int rows);
 int GpuMat_Cols(GpuMat m);
 int GpuMat_Rows(GpuMat m);
 int GpuMat_Channels(GpuMat m);
@@ -36,6 +38,8 @@ int GetCudaEnabledDeviceCount();
 
 Stream Stream_New();
 void Stream_Close(Stream s);
+bool Stream_QueryIfComplete(Stream s);
+void Stream_WaitForCompletion(Stream s);
 
 #ifdef __cplusplus
 }

--- a/cuda/cuda.h
+++ b/cuda/cuda.h
@@ -20,6 +20,7 @@ typedef void* Stream;
 
 GpuMat GpuMat_New();
 GpuMat GpuMat_NewFromMat(Mat mat);
+GpuMat GpuMat_NewWithSize(int rows, int cols, int type);
 void GpuMat_Upload(GpuMat m, Mat data, Stream s);
 void GpuMat_Download(GpuMat m, Mat dst, Stream s);
 void GpuMat_Close(GpuMat m);

--- a/cuda/cuda.h
+++ b/cuda/cuda.h
@@ -12,8 +12,10 @@ extern "C" {
 
 #ifdef __cplusplus
 typedef cv::cuda::GpuMat* GpuMat;
+typedef cv::cuda::Stream* Stream;
 #else
 typedef void* GpuMat;
+typedef void* Stream;
 #endif
 
 GpuMat GpuMat_New();
@@ -31,6 +33,9 @@ int GpuMat_Type(GpuMat m);
 void PrintCudaDeviceInfo(int device);
 void PrintShortCudaDeviceInfo(int device);
 int GetCudaEnabledDeviceCount();
+
+Stream Stream_New();
+void Stream_Close(Stream s);
 
 #ifdef __cplusplus
 }

--- a/cuda/cuda.h
+++ b/cuda/cuda.h
@@ -26,7 +26,7 @@ void GpuMat_Close(GpuMat m);
 int GpuMat_Empty(GpuMat m);
 void GpuMat_ConvertTo(GpuMat m, GpuMat dst, int type, Stream s);
 void GpuMat_CopyTo(GpuMat m, GpuMat dst, Stream s);
-void GpuMat_Reshape(GpuMat m, int cn, int rows);
+GpuMat GpuMat_Reshape(GpuMat m, int cn, int rows);
 int GpuMat_Cols(GpuMat m);
 int GpuMat_Rows(GpuMat m);
 int GpuMat_Channels(GpuMat m);

--- a/cuda/cuda_test.go
+++ b/cuda/cuda_test.go
@@ -51,6 +51,27 @@ func TestNewGpuMatFromMatWithSize(t *testing.T) {
 	}
 }
 
+func TestNewGpuMatWithSize(t *testing.T) {
+	gpumat := NewGpuMatWithSize(100, 200, gocv.MatTypeCV32FC4)
+	defer gpumat.Close()
+
+	if gpumat.Empty() {
+		t.Error("New GpuMat should be not empty")
+	}
+
+	if gpumat.Rows() != 100 {
+		t.Error("incorrect number of rows for GpuMat")
+	}
+
+	if gpumat.Cols() != 200 {
+		t.Error("incorrect number of cols for GpuMat")
+	}
+
+	if gpumat.Type() != gocv.MatTypeCV32FC4 {
+		t.Error("incorrect type for GpuMat")
+	}
+}
+
 func TestGetCudaEnabledDeviceCount(t *testing.T) {
 	if GetCudaEnabledDeviceCount() < 1 {
 		t.Fatal("expected atleast one cuda enabled device")

--- a/cuda/filters.cpp
+++ b/cuda/filters.cpp
@@ -16,10 +16,13 @@ void GaussianFilter_Close(GaussianFilter gf) {
     delete gf;
 }
 
-GpuMat GaussianFilter_Apply(GaussianFilter gf, GpuMat img) {
+GpuMat GaussianFilter_Apply(GaussianFilter gf, GpuMat img, Stream s) {
     GpuMat dst = new cv::cuda::GpuMat();
-    (*gf)->apply(*img, *dst);
-
+    if (s == NULL) {
+        (*gf)->apply(*img, *dst);
+    } else {
+        (*gf)->apply(*img, *dst, *s);
+    }
     return dst;
 }
 
@@ -35,9 +38,13 @@ void SobelFilter_Close(SobelFilter sf) {
     delete sf;
 }
 
-GpuMat SobelFilter_Apply(SobelFilter sf, GpuMat img) {
+GpuMat SobelFilter_Apply(SobelFilter sf, GpuMat img, Stream s) {
     GpuMat dst = new cv::cuda::GpuMat();
-    (*sf)->apply(*img, *dst);
+    if (s == NULL) {
+        (*sf)->apply(*img, *dst);
+    } else {
+        (*sf)->apply(*img, *dst, *s);
+    }
 
     return dst;
 }

--- a/cuda/filters.cpp
+++ b/cuda/filters.cpp
@@ -16,14 +16,13 @@ void GaussianFilter_Close(GaussianFilter gf) {
     delete gf;
 }
 
-GpuMat GaussianFilter_Apply(GaussianFilter gf, GpuMat img, Stream s) {
-    GpuMat dst = new cv::cuda::GpuMat();
+void GaussianFilter_Apply(GaussianFilter gf, GpuMat img, GpuMat dst, Stream s) {
     if (s == NULL) {
         (*gf)->apply(*img, *dst);
     } else {
         (*gf)->apply(*img, *dst, *s);
     }
-    return dst;
+    return;
 }
 
 SobelFilter CreateSobelFilter(int srcType, int dstType, int dx, int dy) {
@@ -38,13 +37,12 @@ void SobelFilter_Close(SobelFilter sf) {
     delete sf;
 }
 
-GpuMat SobelFilter_Apply(SobelFilter sf, GpuMat img, Stream s) {
-    GpuMat dst = new cv::cuda::GpuMat();
+void SobelFilter_Apply(SobelFilter sf, GpuMat img, GpuMat dst, Stream s) {
     if (s == NULL) {
         (*sf)->apply(*img, *dst);
     } else {
         (*sf)->apply(*img, *dst, *s);
     }
 
-    return dst;
+    return;
 }

--- a/cuda/filters.go
+++ b/cuda/filters.go
@@ -45,8 +45,9 @@ func (gf *GaussianFilter) Close() error {
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d2b/classcv_1_1cuda_1_1Filter.html#a20b58d13871027473b4c39cc698cf80f
 //
-func (gf *GaussianFilter) Apply(img GpuMat) GpuMat {
-	return newGpuMat(C.GaussianFilter_Apply(C.GaussianFilter(gf.p), img.p, nil))
+func (gf *GaussianFilter) Apply(img GpuMat, dst *GpuMat) {
+	C.GaussianFilter_Apply(C.GaussianFilter(gf.p), img.p, dst.p, nil)
+	return
 }
 
 // ApplyWithStream applies the Gaussian filter
@@ -55,8 +56,9 @@ func (gf *GaussianFilter) Apply(img GpuMat) GpuMat {
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d2b/classcv_1_1cuda_1_1Filter.html#a20b58d13871027473b4c39cc698cf80f
 //
-func (gf *GaussianFilter) ApplyWithStream(img GpuMat, s Stream) GpuMat {
-	return newGpuMat(C.GaussianFilter_Apply(C.GaussianFilter(gf.p), img.p, s.p))
+func (gf *GaussianFilter) ApplyWithStream(img GpuMat, dst *GpuMat, s Stream) {
+	C.GaussianFilter_Apply(C.GaussianFilter(gf.p), img.p, dst.p, s.p)
+	return
 }
 
 // SobelFilter
@@ -90,8 +92,9 @@ func (sf *SobelFilter) Close() error {
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d2b/classcv_1_1cuda_1_1Filter.html#a20b58d13871027473b4c39cc698cf80f
 //
-func (sf *SobelFilter) Apply(img GpuMat) GpuMat {
-	return newGpuMat(C.SobelFilter_Apply(C.SobelFilter(sf.p), img.p, nil))
+func (sf *SobelFilter) Apply(img GpuMat, dst *GpuMat) {
+	C.SobelFilter_Apply(C.SobelFilter(sf.p), img.p, dst.p, nil)
+	return
 }
 
 // ApplyWithStream applies the Sobel filter
@@ -100,6 +103,7 @@ func (sf *SobelFilter) Apply(img GpuMat) GpuMat {
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d2b/classcv_1_1cuda_1_1Filter.html#a20b58d13871027473b4c39cc698cf80f
 //
-func (sf *SobelFilter) ApplyWithStream(img GpuMat, s Stream) GpuMat {
-	return newGpuMat(C.SobelFilter_Apply(C.SobelFilter(sf.p), img.p, s.p))
+func (sf *SobelFilter) ApplyWithStream(img GpuMat, dst *GpuMat, s Stream) {
+	C.SobelFilter_Apply(C.SobelFilter(sf.p), img.p, dst.p, s.p)
+	return
 }

--- a/cuda/filters.go
+++ b/cuda/filters.go
@@ -46,7 +46,17 @@ func (gf *GaussianFilter) Close() error {
 // https://docs.opencv.org/master/dc/d2b/classcv_1_1cuda_1_1Filter.html#a20b58d13871027473b4c39cc698cf80f
 //
 func (gf *GaussianFilter) Apply(img GpuMat) GpuMat {
-	return newGpuMat(C.GaussianFilter_Apply(C.GaussianFilter(gf.p), img.p))
+	return newGpuMat(C.GaussianFilter_Apply(C.GaussianFilter(gf.p), img.p, nil))
+}
+
+// ApplyWithStream applies the Gaussian filter
+// using a Stream for concurrency.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/dc/d2b/classcv_1_1cuda_1_1Filter.html#a20b58d13871027473b4c39cc698cf80f
+//
+func (gf *GaussianFilter) ApplyWithStream(img GpuMat, s Stream) GpuMat {
+	return newGpuMat(C.GaussianFilter_Apply(C.GaussianFilter(gf.p), img.p, s.p))
 }
 
 // SobelFilter
@@ -81,5 +91,15 @@ func (sf *SobelFilter) Close() error {
 // https://docs.opencv.org/master/dc/d2b/classcv_1_1cuda_1_1Filter.html#a20b58d13871027473b4c39cc698cf80f
 //
 func (sf *SobelFilter) Apply(img GpuMat) GpuMat {
-	return newGpuMat(C.SobelFilter_Apply(C.SobelFilter(sf.p), img.p))
+	return newGpuMat(C.SobelFilter_Apply(C.SobelFilter(sf.p), img.p, nil))
+}
+
+// ApplyWithStream applies the Sobel filter
+// using a Stream for concurrency.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/dc/d2b/classcv_1_1cuda_1_1Filter.html#a20b58d13871027473b4c39cc698cf80f
+//
+func (sf *SobelFilter) ApplyWithStream(img GpuMat, s Stream) GpuMat {
+	return newGpuMat(C.SobelFilter_Apply(C.SobelFilter(sf.p), img.p, s.p))
 }

--- a/cuda/filters.h
+++ b/cuda/filters.h
@@ -23,13 +23,13 @@ typedef void* SobelFilter;
 GaussianFilter CreateGaussianFilter(int srcType, int dstType, Size ksize, double sigma1);
 GaussianFilter CreateGaussianFilterWithParams(int srcType, int dstType, Size ksize, double sigma1, double sigma2, int rowBorderMode, int columnBorderMode);
 void GaussianFilter_Close(GaussianFilter gf);
-GpuMat GaussianFilter_Apply(GaussianFilter gf, GpuMat img);
+GpuMat GaussianFilter_Apply(GaussianFilter gf, GpuMat img, Stream s);
 
 // SobelFilter
 SobelFilter CreateSobelFilter(int srcType, int dstType, int dx, int dy);
 SobelFilter CreateSobelFilterWithParams(int srcType, int dstType, int dx, int dy, int ksize, double scale, int rowBorderMode, int columnBorderMode);
 void SobelFilter_Close(SobelFilter sf);
-GpuMat SobelFilter_Apply(SobelFilter sf, GpuMat img);
+GpuMat SobelFilter_Apply(SobelFilter sf, GpuMat img, Stream s);
 
 #ifdef __cplusplus
 }

--- a/cuda/filters.h
+++ b/cuda/filters.h
@@ -23,13 +23,13 @@ typedef void* SobelFilter;
 GaussianFilter CreateGaussianFilter(int srcType, int dstType, Size ksize, double sigma1);
 GaussianFilter CreateGaussianFilterWithParams(int srcType, int dstType, Size ksize, double sigma1, double sigma2, int rowBorderMode, int columnBorderMode);
 void GaussianFilter_Close(GaussianFilter gf);
-GpuMat GaussianFilter_Apply(GaussianFilter gf, GpuMat img, Stream s);
+void GaussianFilter_Apply(GaussianFilter gf, GpuMat img, GpuMat dst, Stream s);
 
 // SobelFilter
 SobelFilter CreateSobelFilter(int srcType, int dstType, int dx, int dy);
 SobelFilter CreateSobelFilterWithParams(int srcType, int dstType, int dx, int dy, int ksize, double scale, int rowBorderMode, int columnBorderMode);
 void SobelFilter_Close(SobelFilter sf);
-GpuMat SobelFilter_Apply(SobelFilter sf, GpuMat img, Stream s);
+void SobelFilter_Apply(SobelFilter sf, GpuMat img, GpuMat dst, Stream s);
 
 #ifdef __cplusplus
 }

--- a/cuda/filters_test.go
+++ b/cuda/filters_test.go
@@ -41,6 +41,43 @@ func TestGaussianFilter_Apply(t *testing.T) {
 	}
 }
 
+func TestGaussianFilter_ApplyWithStream(t *testing.T) {
+	src := gocv.IMRead("../images/face-detect.jpg", gocv.IMReadColor)
+	if src.Empty() {
+		t.Error("Invalid read of Mat in GaussianFilter test")
+	}
+	defer src.Close()
+
+	cimg := NewGpuMat()
+	defer cimg.Close()
+
+	cimg.Upload(src)
+
+	filter := NewGaussianFilter(src.Type(), src.Type(), image.Pt(23, 23), 30)
+	defer filter.Close()
+
+	stream := NewStream()
+	defer stream.Close()
+
+	dimg := filter.ApplyWithStream(cimg, stream)
+	defer dimg.Close()
+
+	dest := gocv.NewMat()
+	defer dest.Close()
+
+	dimg.Download(&dest)
+
+	if dest.Empty() {
+		t.Error("Empty GaussianFilter test")
+	}
+	if src.Rows() != dest.Rows() {
+		t.Error("Invalid GaussianFilter test rows")
+	}
+	if src.Cols() != dest.Cols() {
+		t.Error("Invalid GaussianFilter test cols")
+	}
+}
+
 func TestSobelFilter_Apply(t *testing.T) {
 	src := gocv.IMRead("../images/face-detect.jpg", gocv.IMReadGrayScale)
 	if src.Empty() {
@@ -57,6 +94,43 @@ func TestSobelFilter_Apply(t *testing.T) {
 	defer filter.Close()
 
 	dimg := filter.Apply(cimg)
+	defer dimg.Close()
+
+	dest := gocv.NewMat()
+	defer dest.Close()
+
+	dimg.Download(&dest)
+
+	if dest.Empty() {
+		t.Error("Empty SobelFilter test")
+	}
+	if src.Rows() != dest.Rows() {
+		t.Error("Invalid SobelFilter test rows")
+	}
+	if src.Cols() != dest.Cols() {
+		t.Error("Invalid SobelFilter test cols")
+	}
+}
+
+func TestSobelFilter_ApplyWithStream(t *testing.T) {
+	src := gocv.IMRead("../images/face-detect.jpg", gocv.IMReadGrayScale)
+	if src.Empty() {
+		t.Error("Invalid read of Mat in SobelFilter test")
+	}
+	defer src.Close()
+
+	cimg := NewGpuMat()
+	defer cimg.Close()
+
+	cimg.Upload(src)
+
+	filter := NewSobelFilter(src.Type(), src.Type(), 0, 1)
+	defer filter.Close()
+
+	stream := NewStream()
+	defer stream.Close()
+
+	dimg := filter.ApplyWithStream(cimg, stream)
 	defer dimg.Close()
 
 	dest := gocv.NewMat()

--- a/cuda/filters_test.go
+++ b/cuda/filters_test.go
@@ -14,16 +14,16 @@ func TestGaussianFilter_Apply(t *testing.T) {
 	}
 	defer src.Close()
 
-	cimg := NewGpuMat()
+	cimg, dimg := NewGpuMat(), NewGpuMat()
 	defer cimg.Close()
+	defer dimg.Close()
 
 	cimg.Upload(src)
 
 	filter := NewGaussianFilter(src.Type(), src.Type(), image.Pt(23, 23), 30)
 	defer filter.Close()
 
-	dimg := filter.Apply(cimg)
-	defer dimg.Close()
+	filter.Apply(cimg, &dimg)
 
 	dest := gocv.NewMat()
 	defer dest.Close()
@@ -48,10 +48,9 @@ func TestGaussianFilter_ApplyWithStream(t *testing.T) {
 	}
 	defer src.Close()
 
-	cimg := NewGpuMat()
+	cimg, dimg := NewGpuMat(), NewGpuMat()
 	defer cimg.Close()
-
-	cimg.Upload(src)
+	defer dimg.Close()
 
 	filter := NewGaussianFilter(src.Type(), src.Type(), image.Pt(23, 23), 30)
 	defer filter.Close()
@@ -59,13 +58,14 @@ func TestGaussianFilter_ApplyWithStream(t *testing.T) {
 	stream := NewStream()
 	defer stream.Close()
 
-	dimg := filter.ApplyWithStream(cimg, stream)
-	defer dimg.Close()
-
 	dest := gocv.NewMat()
 	defer dest.Close()
 
-	dimg.Download(&dest)
+	cimg.UploadWithStream(src, stream)
+	filter.ApplyWithStream(cimg, &dimg, stream)
+	dimg.DownloadWithStream(&dest, stream)
+
+	stream.WaitForCompletion()
 
 	if dest.Empty() {
 		t.Error("Empty GaussianFilter test")
@@ -85,20 +85,18 @@ func TestSobelFilter_Apply(t *testing.T) {
 	}
 	defer src.Close()
 
-	cimg := NewGpuMat()
+	cimg, dimg := NewGpuMat(), NewGpuMat()
 	defer cimg.Close()
-
-	cimg.Upload(src)
+	defer dimg.Close()
 
 	filter := NewSobelFilter(src.Type(), src.Type(), 0, 1)
 	defer filter.Close()
 
-	dimg := filter.Apply(cimg)
-	defer dimg.Close()
-
 	dest := gocv.NewMat()
 	defer dest.Close()
 
+	cimg.Upload(src)
+	filter.Apply(cimg, &dimg)
 	dimg.Download(&dest)
 
 	if dest.Empty() {
@@ -119,10 +117,9 @@ func TestSobelFilter_ApplyWithStream(t *testing.T) {
 	}
 	defer src.Close()
 
-	cimg := NewGpuMat()
+	cimg, dimg := NewGpuMat(), NewGpuMat()
 	defer cimg.Close()
-
-	cimg.Upload(src)
+	defer dimg.Close()
 
 	filter := NewSobelFilter(src.Type(), src.Type(), 0, 1)
 	defer filter.Close()
@@ -130,13 +127,14 @@ func TestSobelFilter_ApplyWithStream(t *testing.T) {
 	stream := NewStream()
 	defer stream.Close()
 
-	dimg := filter.ApplyWithStream(cimg, stream)
-	defer dimg.Close()
-
 	dest := gocv.NewMat()
 	defer dest.Close()
 
-	dimg.Download(&dest)
+	cimg.UploadWithStream(src, stream)
+	filter.ApplyWithStream(cimg, &dimg, stream)
+	dimg.DownloadWithStream(&dest, stream)
+
+	stream.WaitForCompletion()
 
 	if dest.Empty() {
 		t.Error("Empty SobelFilter test")

--- a/cuda/imgproc.cpp
+++ b/cuda/imgproc.cpp
@@ -22,14 +22,13 @@ void CannyEdgeDetector_Close(CannyEdgeDetector det) {
     delete det;
 }
 
-GpuMat CannyEdgeDetector_Detect(CannyEdgeDetector det, GpuMat img, Stream s) {    
-    GpuMat dst = new cv::cuda::GpuMat();
+void CannyEdgeDetector_Detect(CannyEdgeDetector det, GpuMat img, GpuMat dst, Stream s) {
     if (s == NULL) {
         (*det)->detect(*img, *dst);
     } else {
         (*det)->detect(*img, *dst, *s);
     }
-    return dst;
+    return;
 }
 
 int CannyEdgeDetector_GetAppertureSize(CannyEdgeDetector det) {
@@ -76,14 +75,13 @@ void HoughLinesDetector_Close(HoughLinesDetector hld) {
     delete hld;
 }
 
-GpuMat HoughLinesDetector_Detect(HoughLinesDetector hld, GpuMat img, Stream s) {
-    GpuMat dst = new cv::cuda::GpuMat();
+void HoughLinesDetector_Detect(HoughLinesDetector hld, GpuMat img, GpuMat dst, Stream s) {
     if (s == NULL) {
         (*hld)->detect(*img, *dst);
     } else {
         (*hld)->detect(*img, *dst, *s);
     }
-    return dst;
+    return;
 }
 
 HoughSegmentDetector HoughSegmentDetector_Create(double rho, double theta, int minLineLength, int maxLineGap) {
@@ -94,12 +92,11 @@ void HoughSegmentDetector_Close(HoughSegmentDetector hsd) {
     delete hsd;
 }
 
-GpuMat HoughSegmentDetector_Detect(HoughSegmentDetector hsd, GpuMat img, Stream s) {
-    GpuMat dst = new cv::cuda::GpuMat();
+void HoughSegmentDetector_Detect(HoughSegmentDetector hsd, GpuMat img, GpuMat dst, Stream s) {
     if (s == NULL) {
         (*hsd)->detect(*img, *dst);
     } else {
         (*hsd)->detect(*img, *dst, *s);
     }
-    return dst;
+    return;
 }

--- a/cuda/imgproc.cpp
+++ b/cuda/imgproc.cpp
@@ -2,8 +2,12 @@
 #include "imgproc.h"
 #include <string.h>
 
-void GpuCvtColor(GpuMat src, GpuMat dst, int code) {
-    cv::cuda::cvtColor(*src, *dst, code);
+void GpuCvtColor(GpuMat src, GpuMat dst, int code, Stream s) {
+    if (s == NULL) {
+        cv::cuda::cvtColor(*src, *dst, code);
+        return;
+    }
+    cv::cuda::cvtColor(*src, *dst, code, 0, *s);
 }
 
 CannyEdgeDetector CreateCannyEdgeDetector(double lowThresh, double highThresh) {
@@ -18,10 +22,13 @@ void CannyEdgeDetector_Close(CannyEdgeDetector det) {
     delete det;
 }
 
-GpuMat CannyEdgeDetector_Detect(CannyEdgeDetector det, GpuMat img) {    
+GpuMat CannyEdgeDetector_Detect(CannyEdgeDetector det, GpuMat img, Stream s) {    
     GpuMat dst = new cv::cuda::GpuMat();
-    (*det)->detect(*img, *dst);
-
+    if (s == NULL) {
+        (*det)->detect(*img, *dst);
+    } else {
+        (*det)->detect(*img, *dst, *s);
+    }
     return dst;
 }
 
@@ -69,10 +76,13 @@ void HoughLinesDetector_Close(HoughLinesDetector hld) {
     delete hld;
 }
 
-GpuMat HoughLinesDetector_Detect(HoughLinesDetector hld, GpuMat img) {
+GpuMat HoughLinesDetector_Detect(HoughLinesDetector hld, GpuMat img, Stream s) {
     GpuMat dst = new cv::cuda::GpuMat();
-    (*hld)->detect(*img, *dst);
-
+    if (s == NULL) {
+        (*hld)->detect(*img, *dst);
+    } else {
+        (*hld)->detect(*img, *dst, *s);
+    }
     return dst;
 }
 
@@ -84,9 +94,12 @@ void HoughSegmentDetector_Close(HoughSegmentDetector hsd) {
     delete hsd;
 }
 
-GpuMat HoughSegmentDetector_Detect(HoughSegmentDetector hsd, GpuMat img) {
+GpuMat HoughSegmentDetector_Detect(HoughSegmentDetector hsd, GpuMat img, Stream s) {
     GpuMat dst = new cv::cuda::GpuMat();
-    (*hsd)->detect(*img, *dst);
-
+    if (s == NULL) {
+        (*hsd)->detect(*img, *dst);
+    } else {
+        (*hsd)->detect(*img, *dst, *s);
+    }
     return dst;
 }

--- a/cuda/imgproc.go
+++ b/cuda/imgproc.go
@@ -45,7 +45,17 @@ func (h *CannyEdgeDetector) Close() error {
 // https://docs.opencv.org/master/d0/d43/classcv_1_1cuda_1_1CannyEdgeDetector.html#a6438cf8453f2dfd6703ceb50056de309
 //
 func (h *CannyEdgeDetector) Detect(img GpuMat) GpuMat {
-	return newGpuMat(C.CannyEdgeDetector_Detect(C.CannyEdgeDetector(h.p), img.p))
+	return newGpuMat(C.CannyEdgeDetector_Detect(C.CannyEdgeDetector(h.p), img.p, nil))
+}
+
+// DetectWithStream finds edges in an image using the Canny algorithm
+// using a Stream for concurrency.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d0/d43/classcv_1_1cuda_1_1CannyEdgeDetector.html#a6438cf8453f2dfd6703ceb50056de309
+//
+func (h *CannyEdgeDetector) DetectWithStream(img GpuMat, s Stream) GpuMat {
+	return newGpuMat(C.CannyEdgeDetector_Detect(C.CannyEdgeDetector(h.p), img.p, s.p))
 }
 
 // GetAppertureSize
@@ -128,7 +138,19 @@ func (h *CannyEdgeDetector) SetLowThreshold(lowThresh float64) {
 // https://docs.opencv.org/master/db/d8c/group__cudaimgproc__color.html#ga48d0f208181d5ca370d8ff6b62cbe826
 //
 func CvtColor(src GpuMat, dst *GpuMat, code gocv.ColorConversionCode) {
-	C.GpuCvtColor(src.p, dst.p, C.int(code))
+	C.GpuCvtColor(src.p, dst.p, C.int(code), nil)
+}
+
+// CvtColorWithStream converts an image from one color space to another
+// using a Stream for concurrency.
+// It converts the src Mat image to the dst Mat using the
+// code param containing the desired ColorConversionCode color space.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/db/d8c/group__cudaimgproc__color.html#ga48d0f208181d5ca370d8ff6b62cbe826
+//
+func CvtColorWithStream(src GpuMat, dst *GpuMat, code gocv.ColorConversionCode, s Stream) {
+	C.GpuCvtColor(src.p, dst.p, C.int(code), s.p)
 }
 
 // HoughLinesDetector
@@ -157,13 +179,23 @@ func (h *HoughLinesDetector) Close() error {
 	return nil
 }
 
-// Detect finds lines in a binary image using the classical Hough transform
+// Detect finds lines in a binary image using the classical Hough transform.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/dcd/classcv_1_1cuda_1_1HoughLinesDetector.html#a18ff6d0886833ac6215054e191ae2520
 //
 func (h *HoughLinesDetector) Detect(img GpuMat) GpuMat {
-	return newGpuMat(C.HoughLinesDetector_Detect(C.HoughLinesDetector(h.p), img.p))
+	return newGpuMat(C.HoughLinesDetector_Detect(C.HoughLinesDetector(h.p), img.p, nil))
+}
+
+// DetectWithStream finds lines in a binary image using the classical Hough transform
+// using a Stream for concurrency.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d2/dcd/classcv_1_1cuda_1_1HoughLinesDetector.html#a18ff6d0886833ac6215054e191ae2520
+//
+func (h *HoughLinesDetector) DetectWithStream(img GpuMat, s Stream) GpuMat {
+	return newGpuMat(C.HoughLinesDetector_Detect(C.HoughLinesDetector(h.p), img.p, s.p))
 }
 
 // HoughSegmentDetector
@@ -188,10 +220,19 @@ func (h *HoughSegmentDetector) Close() error {
 }
 
 // Detect finds lines in a binary image using the Hough probabilistic transform.
-//
 // For further details, please see:
 // https://docs.opencv.org/master/d6/df9/classcv_1_1cuda_1_1HoughSegmentDetector.html#a739bf84825ca455966d69dd75ca0ea6e
 //
 func (h *HoughSegmentDetector) Detect(img GpuMat) GpuMat {
-	return newGpuMat(C.HoughSegmentDetector_Detect(C.HoughSegmentDetector(h.p), img.p))
+	return newGpuMat(C.HoughSegmentDetector_Detect(C.HoughSegmentDetector(h.p), img.p, nil))
+}
+
+// DetectWithStream finds lines in a binary image using the Hough probabilistic transform
+// using a Stream for concurrency.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d6/df9/classcv_1_1cuda_1_1HoughSegmentDetector.html#a739bf84825ca455966d69dd75ca0ea6e
+//
+func (h *HoughSegmentDetector) DetectWithStream(img GpuMat, s Stream) GpuMat {
+	return newGpuMat(C.HoughSegmentDetector_Detect(C.HoughSegmentDetector(h.p), img.p, s.p))
 }

--- a/cuda/imgproc.go
+++ b/cuda/imgproc.go
@@ -44,8 +44,9 @@ func (h *CannyEdgeDetector) Close() error {
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d43/classcv_1_1cuda_1_1CannyEdgeDetector.html#a6438cf8453f2dfd6703ceb50056de309
 //
-func (h *CannyEdgeDetector) Detect(img GpuMat) GpuMat {
-	return newGpuMat(C.CannyEdgeDetector_Detect(C.CannyEdgeDetector(h.p), img.p, nil))
+func (h *CannyEdgeDetector) Detect(img GpuMat, dst *GpuMat) {
+	C.CannyEdgeDetector_Detect(C.CannyEdgeDetector(h.p), img.p, dst.p, nil)
+	return
 }
 
 // DetectWithStream finds edges in an image using the Canny algorithm
@@ -54,8 +55,9 @@ func (h *CannyEdgeDetector) Detect(img GpuMat) GpuMat {
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d43/classcv_1_1cuda_1_1CannyEdgeDetector.html#a6438cf8453f2dfd6703ceb50056de309
 //
-func (h *CannyEdgeDetector) DetectWithStream(img GpuMat, s Stream) GpuMat {
-	return newGpuMat(C.CannyEdgeDetector_Detect(C.CannyEdgeDetector(h.p), img.p, s.p))
+func (h *CannyEdgeDetector) DetectWithStream(img GpuMat, dst *GpuMat, s Stream) {
+	C.CannyEdgeDetector_Detect(C.CannyEdgeDetector(h.p), img.p, dst.p, s.p)
+	return
 }
 
 // GetAppertureSize
@@ -184,8 +186,9 @@ func (h *HoughLinesDetector) Close() error {
 // For further details, please see:
 // https://docs.opencv.org/master/d2/dcd/classcv_1_1cuda_1_1HoughLinesDetector.html#a18ff6d0886833ac6215054e191ae2520
 //
-func (h *HoughLinesDetector) Detect(img GpuMat) GpuMat {
-	return newGpuMat(C.HoughLinesDetector_Detect(C.HoughLinesDetector(h.p), img.p, nil))
+func (h *HoughLinesDetector) Detect(img GpuMat, dst *GpuMat) {
+	C.HoughLinesDetector_Detect(C.HoughLinesDetector(h.p), img.p, dst.p, nil)
+	return
 }
 
 // DetectWithStream finds lines in a binary image using the classical Hough transform
@@ -194,8 +197,9 @@ func (h *HoughLinesDetector) Detect(img GpuMat) GpuMat {
 // For further details, please see:
 // https://docs.opencv.org/master/d2/dcd/classcv_1_1cuda_1_1HoughLinesDetector.html#a18ff6d0886833ac6215054e191ae2520
 //
-func (h *HoughLinesDetector) DetectWithStream(img GpuMat, s Stream) GpuMat {
-	return newGpuMat(C.HoughLinesDetector_Detect(C.HoughLinesDetector(h.p), img.p, s.p))
+func (h *HoughLinesDetector) DetectWithStream(img GpuMat, dst *GpuMat, s Stream) {
+	C.HoughLinesDetector_Detect(C.HoughLinesDetector(h.p), img.p, dst.p, s.p)
+	return
 }
 
 // HoughSegmentDetector
@@ -223,8 +227,9 @@ func (h *HoughSegmentDetector) Close() error {
 // For further details, please see:
 // https://docs.opencv.org/master/d6/df9/classcv_1_1cuda_1_1HoughSegmentDetector.html#a739bf84825ca455966d69dd75ca0ea6e
 //
-func (h *HoughSegmentDetector) Detect(img GpuMat) GpuMat {
-	return newGpuMat(C.HoughSegmentDetector_Detect(C.HoughSegmentDetector(h.p), img.p, nil))
+func (h *HoughSegmentDetector) Detect(img GpuMat, dst *GpuMat) {
+	C.HoughSegmentDetector_Detect(C.HoughSegmentDetector(h.p), img.p, dst.p, nil)
+	return
 }
 
 // DetectWithStream finds lines in a binary image using the Hough probabilistic transform
@@ -233,6 +238,7 @@ func (h *HoughSegmentDetector) Detect(img GpuMat) GpuMat {
 // For further details, please see:
 // https://docs.opencv.org/master/d6/df9/classcv_1_1cuda_1_1HoughSegmentDetector.html#a739bf84825ca455966d69dd75ca0ea6e
 //
-func (h *HoughSegmentDetector) DetectWithStream(img GpuMat, s Stream) GpuMat {
-	return newGpuMat(C.HoughSegmentDetector_Detect(C.HoughSegmentDetector(h.p), img.p, s.p))
+func (h *HoughSegmentDetector) DetectWithStream(img GpuMat, dst *GpuMat, s Stream) {
+	C.HoughSegmentDetector_Detect(C.HoughSegmentDetector(h.p), img.p, dst.p, s.p)
+	return
 }

--- a/cuda/imgproc.h
+++ b/cuda/imgproc.h
@@ -29,7 +29,7 @@ void GpuCvtColor(GpuMat src, GpuMat dst, int code, Stream s);
 CannyEdgeDetector CreateCannyEdgeDetector(double lowThresh, double highThresh);
 CannyEdgeDetector CreateCannyEdgeDetectorWithParams(double lowThresh, double highThresh, int appertureSize, bool L2gradient);
 void CannyEdgeDetector_Close(CannyEdgeDetector det);
-GpuMat CannyEdgeDetector_Detect(CannyEdgeDetector det, GpuMat img, Stream s);
+void CannyEdgeDetector_Detect(CannyEdgeDetector det, GpuMat img, GpuMat dst, Stream s);
 int CannyEdgeDetector_GetAppertureSize(CannyEdgeDetector det);
 double CannyEdgeDetector_GetHighThreshold(CannyEdgeDetector det);
 bool CannyEdgeDetector_GetL2Gradient(CannyEdgeDetector det);
@@ -43,12 +43,12 @@ void CannyEdgeDetector_SetLowThreshold(CannyEdgeDetector det, double lowThresh);
 HoughLinesDetector HoughLinesDetector_Create(double rho, double theta, int threshold);
 HoughLinesDetector HoughLinesDetector_CreateWithParams(double rho, double theta, int threshold, bool sort, int maxlines);
 void HoughLinesDetector_Close(HoughLinesDetector hld);
-GpuMat HoughLinesDetector_Detect(HoughLinesDetector hld, GpuMat img, Stream s);
+void HoughLinesDetector_Detect(HoughLinesDetector hld, GpuMat img, GpuMat dst, Stream s);
 
 // HoughSegmentDetector
 HoughSegmentDetector HoughSegmentDetector_Create(double rho, double theta, int minLineLength, int maxLineGap);
 void HoughSegmentDetector_Close(HoughSegmentDetector hsd);
-GpuMat HoughSegmentDetector_Detect(HoughSegmentDetector hsd, GpuMat img, Stream s);
+void HoughSegmentDetector_Detect(HoughSegmentDetector hsd, GpuMat img, GpuMat dst, Stream s);
 
 #ifdef __cplusplus
 }

--- a/cuda/imgproc.h
+++ b/cuda/imgproc.h
@@ -23,13 +23,13 @@ typedef void* HoughSegmentDetector;
 #endif
 
 // standalone functions
-void GpuCvtColor(GpuMat src, GpuMat dst, int code);
+void GpuCvtColor(GpuMat src, GpuMat dst, int code, Stream s);
 
 // CannyEdgeDetector
 CannyEdgeDetector CreateCannyEdgeDetector(double lowThresh, double highThresh);
 CannyEdgeDetector CreateCannyEdgeDetectorWithParams(double lowThresh, double highThresh, int appertureSize, bool L2gradient);
 void CannyEdgeDetector_Close(CannyEdgeDetector det);
-GpuMat CannyEdgeDetector_Detect(CannyEdgeDetector det, GpuMat img);
+GpuMat CannyEdgeDetector_Detect(CannyEdgeDetector det, GpuMat img, Stream s);
 int CannyEdgeDetector_GetAppertureSize(CannyEdgeDetector det);
 double CannyEdgeDetector_GetHighThreshold(CannyEdgeDetector det);
 bool CannyEdgeDetector_GetL2Gradient(CannyEdgeDetector det);
@@ -43,12 +43,12 @@ void CannyEdgeDetector_SetLowThreshold(CannyEdgeDetector det, double lowThresh);
 HoughLinesDetector HoughLinesDetector_Create(double rho, double theta, int threshold);
 HoughLinesDetector HoughLinesDetector_CreateWithParams(double rho, double theta, int threshold, bool sort, int maxlines);
 void HoughLinesDetector_Close(HoughLinesDetector hld);
-GpuMat HoughLinesDetector_Detect(HoughLinesDetector hld, GpuMat img);
+GpuMat HoughLinesDetector_Detect(HoughLinesDetector hld, GpuMat img, Stream s);
 
 // HoughSegmentDetector
 HoughSegmentDetector HoughSegmentDetector_Create(double rho, double theta, int minLineLength, int maxLineGap);
 void HoughSegmentDetector_Close(HoughSegmentDetector hsd);
-GpuMat HoughSegmentDetector_Detect(HoughSegmentDetector hsd, GpuMat img);
+GpuMat HoughSegmentDetector_Detect(HoughSegmentDetector hsd, GpuMat img, Stream s);
 
 #ifdef __cplusplus
 }

--- a/cuda/imgproc_test.go
+++ b/cuda/imgproc_test.go
@@ -166,7 +166,7 @@ func TestHoughSegment_Calc(t *testing.T) {
 	}
 	defer src.Close()
 
-	cimg, mimg := NewGpuMat(), NewGpuMat()
+	cimg, mimg, dimg := NewGpuMat(), NewGpuMat(), NewGpuMat()
 	defer cimg.Close()
 	defer mimg.Close()
 	defer dimg.Close()
@@ -183,8 +183,9 @@ func TestHoughSegment_Calc(t *testing.T) {
 	cimg.Upload(src)
 	canny.Detect(cimg, &mimg)
 	detector.Detect(mimg, &dimg)
-	dimg.Reshape(0, dimg.Cols())
-	dimg.Download(&dest)
+	fimg := dimg.Reshape(0, dimg.Cols())
+	defer fimg.Close()
+	fimg.Download(&dest)
 
 	if dest.Empty() {
 		t.Error("Empty HoughSegment test")
@@ -244,8 +245,9 @@ func TestHoughSegment_CalcWithStream(t *testing.T) {
 	cimg.UploadWithStream(src, stream)
 	canny.DetectWithStream(cimg, &mimg, stream)
 	detector.DetectWithStream(mimg, &dimg, stream)
-	dimg.Reshape(0, dimg.Cols())
-	dimg.DownloadWithStream(&dest, stream)
+	fimg := dimg.Reshape(0, dimg.Cols())
+	defer fimg.Close()
+	fimg.DownloadWithStream(&dest, stream)
 
 	stream.WaitForCompletion()
 

--- a/cuda/imgproc_test.go
+++ b/cuda/imgproc_test.go
@@ -103,6 +103,68 @@ func TestHoughLines_Calc(t *testing.T) {
 	}
 }
 
+func TestHoughLines_CalcWithStream(t *testing.T) {
+	src := gocv.IMRead("../images/face-detect.jpg", gocv.IMReadGrayScale)
+	if src.Empty() {
+		t.Error("Invalid read of Mat in HoughLines test")
+	}
+	defer src.Close()
+
+	cimg := NewGpuMat()
+	defer cimg.Close()
+
+	cimg.Upload(src)
+
+	canny := NewCannyEdgeDetector(100, 200)
+	defer canny.Close()
+
+	stream := NewStream()
+	defer stream.Close()
+
+	mimg := canny.DetectWithStream(cimg, stream)
+	defer mimg.Close()
+
+	detector := NewHoughLinesDetectorWithParams(1, math.Pi/180, 50, true, 4096)
+	defer detector.Close()
+
+	dimg := detector.DetectWithStream(mimg, stream)
+	defer dimg.Close()
+
+	dest := gocv.NewMat()
+	defer dest.Close()
+
+	dimg.Download(&dest)
+
+	if dest.Empty() {
+		t.Error("Empty HoughLines test")
+	}
+
+	if dest.Rows() != 2 {
+		t.Errorf("Invalid HoughLines test rows: %v", dest.Rows())
+	}
+	if dest.Cols() != 1588 {
+		t.Errorf("Invalid HoughLines test cols: %v", dest.Cols())
+	}
+
+	expected := map[float32]float32{
+		21:  1.5707964,
+		337: 0.034906585,
+		85:  1.5707964,
+		276: 0,
+		329: 0.034906585,
+	}
+
+	actual := make(map[float32]float32)
+	for i := 0; i < dest.Cols(); i += 2 {
+		actual[dest.GetFloatAt(0, i)] = dest.GetFloatAt(0, i+1)
+	}
+
+	for k, v := range expected {
+		s32 := strconv.FormatFloat(float64(k), 'f', -1, 32)
+		verify.Values(t, s32, actual[k], v)
+	}
+}
+
 func TestHoughSegment_Calc(t *testing.T) {
 	src := gocv.IMRead("../images/face-detect.jpg", gocv.IMReadGrayScale)
 	if src.Empty() {
@@ -136,11 +198,14 @@ func TestHoughSegment_Calc(t *testing.T) {
 		t.Error("Empty HoughSegment test")
 	}
 
-	if dest.Rows() != 1 {
-		t.Errorf("Invalid HoughSegment test rows: %v", dest.Rows())
+	final := dest.Reshape(0, dest.Cols())
+	defer final.Close()
+
+	if final.Rows() != 5 {
+		t.Errorf("Invalid HoughSegment test rows: %v", final.Rows())
 	}
-	if dest.Cols() != 5 {
-		t.Errorf("Invalid HoughSegment test cols: %v", dest.Cols())
+	if final.Cols() != 1 {
+		t.Errorf("Invalid HoughSegment test cols: %v", final.Cols())
 	}
 
 	type point struct {
@@ -153,9 +218,75 @@ func TestHoughSegment_Calc(t *testing.T) {
 	}
 
 	actual := make(map[point]point)
-	for i := 0; i < dest.Cols(); i += 4 {
-		actual[point{dest.GetVeciAt(0, i)[0], dest.GetVeciAt(0, i)[1]}] =
-			point{dest.GetVeciAt(0, i)[2], dest.GetVeciAt(0, i)[3]}
+	for i := 0; i < final.Rows(); i += 4 {
+		actual[point{final.GetVeciAt(i, 0)[0], final.GetVeciAt(i, 0)[1]}] =
+			point{final.GetVeciAt(i, 0)[2], final.GetVeciAt(i, 0)[3]}
+	}
+
+	for k, v := range expected {
+		verify.Values(t, fmt.Sprintf("%d %d", k.X, k.Y), actual[k], v)
+	}
+}
+
+func TestHoughSegment_CalcWithStream(t *testing.T) {
+	src := gocv.IMRead("../images/face-detect.jpg", gocv.IMReadGrayScale)
+	if src.Empty() {
+		t.Error("Invalid read of Mat in HoughSegment test")
+	}
+	defer src.Close()
+
+	cimg := NewGpuMat()
+	defer cimg.Close()
+
+	cimg.Upload(src)
+
+	canny := NewCannyEdgeDetector(50, 100)
+	defer canny.Close()
+
+	stream := NewStream()
+	defer stream.Close()
+
+	mimg := canny.DetectWithStream(cimg, stream)
+	defer mimg.Close()
+
+	detector := NewHoughSegmentDetector(1, math.Pi/180, 150, 50)
+	defer detector.Close()
+
+	dimg := detector.DetectWithStream(mimg, stream)
+	defer dimg.Close()
+
+	dest := gocv.NewMat()
+	defer dest.Close()
+
+	dimg.Download(&dest)
+
+	if dest.Empty() {
+		t.Error("Empty HoughSegment test")
+	}
+
+	final := dest.Reshape(0, dest.Cols())
+	defer final.Close()
+
+	if final.Rows() != 5 {
+		t.Errorf("Invalid HoughSegment test rows: %v", final.Rows())
+	}
+	if final.Cols() != 1 {
+		t.Errorf("Invalid HoughSegment test cols: %v", final.Cols())
+	}
+
+	type point struct {
+		X, Y int32
+	}
+
+	expected := map[point]point{
+		{1, 21}:   {398, 21},
+		{304, 21}: {10, 315},
+	}
+
+	actual := make(map[point]point)
+	for i := 0; i < final.Rows(); i += 4 {
+		actual[point{final.GetVeciAt(i, 0)[0], final.GetVeciAt(i, 0)[1]}] =
+			point{final.GetVeciAt(i, 0)[2], final.GetVeciAt(i, 0)[3]}
 	}
 
 	for k, v := range expected {

--- a/cuda/warping.cpp
+++ b/cuda/warping.cpp
@@ -1,46 +1,84 @@
 #include "warping.h"
 
-void CudaResize(GpuMat src, GpuMat dst, Size dsize, double fx, double fy, int interp) {
+void CudaResize(GpuMat src, GpuMat dst, Size dsize, double fx, double fy, int interp, Stream s) {
     cv::Size sz(dsize.width, dsize.height);
-    cv::cuda::resize(*src, *dst, sz, fx, fy, interp);
+
+    if (s == NULL) {
+        cv::cuda::resize(*src, *dst, sz, fx, fy, interp);
+        return;
+    }
+    cv::cuda::resize(*src, *dst, sz, fx, fy, interp, *s);
 }
 
-void CudaPyrDown(GpuMat src, GpuMat dst) {
-    cv::cuda::pyrDown(*src, *dst);
+void CudaPyrDown(GpuMat src, GpuMat dst, Stream s) {
+    if (s == NULL) {
+        cv::cuda::pyrDown(*src, *dst);
+        return;
+    }
+    cv::cuda::pyrDown(*src, *dst, *s);
 }
 
-void CudaPyrUp(GpuMat src, GpuMat dst) {
-    cv::cuda::pyrUp(*src, *dst);
+void CudaPyrUp(GpuMat src, GpuMat dst, Stream s) {
+    if (s == NULL) {
+        cv::cuda::pyrUp(*src, *dst);
+        return;
+    }
+    cv::cuda::pyrUp(*src, *dst, *s);
 }
 
-void CudaBuildWarpAffineMaps(GpuMat M, bool inverse, Size dsize, GpuMat xmap, GpuMat ymap) {
+void CudaBuildWarpAffineMaps(GpuMat M, bool inverse, Size dsize, GpuMat xmap, GpuMat ymap, Stream s) {
     cv::Size sz(dsize.width, dsize.height);
-    cv::cuda::buildWarpAffineMaps(*M, inverse, sz, *xmap, *ymap);
+    if (s == NULL) {
+        cv::cuda::buildWarpAffineMaps(*M, inverse, sz, *xmap, *ymap);
+        return;
+    }
+    cv::cuda::buildWarpAffineMaps(*M, inverse, sz, *xmap, *ymap, *s);
 }
 
-void CudaBuildWarpPerspectiveMaps(GpuMat M, bool inverse, Size dsize, GpuMat xmap, GpuMat ymap) {
+void CudaBuildWarpPerspectiveMaps(GpuMat M, bool inverse, Size dsize, GpuMat xmap, GpuMat ymap, Stream s) {
     cv::Size sz(dsize.width, dsize.height);
-    cv::cuda::buildWarpPerspectiveMaps(*M, inverse, sz, *xmap, *ymap);
+    if (s == NULL) {
+        cv::cuda::buildWarpPerspectiveMaps(*M, inverse, sz, *xmap, *ymap);
+        return;
+    }
+    cv::cuda::buildWarpPerspectiveMaps(*M, inverse, sz, *xmap, *ymap, *s);
 }
 
-void CudaRemap(GpuMat src, GpuMat dst, GpuMat xmap, GpuMat ymap, int interp, int borderMode, Scalar borderValue) {
+void CudaRemap(GpuMat src, GpuMat dst, GpuMat xmap, GpuMat ymap, int interp, int borderMode, Scalar borderValue, Stream s) {
     cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
-    cv::cuda::remap(*src, *dst, *xmap, *ymap, interp, borderMode, c);
+    if (s == NULL) {
+        cv::cuda::remap(*src, *dst, *xmap, *ymap, interp, borderMode, c);
+        return;
+    }
+    cv::cuda::remap(*src, *dst, *xmap, *ymap, interp, borderMode, c, *s);
 }
 
-void CudaRotate(GpuMat src, GpuMat dst, Size dsize, double angle, double xShift, double yShift, int interp) {  
+void CudaRotate(GpuMat src, GpuMat dst, Size dsize, double angle, double xShift, double yShift, int interp, Stream s) {
     cv::Size sz(dsize.width, dsize.height);
-    cv::cuda::rotate(*src, *dst, sz, angle, xShift, yShift, interp);
+    if (s == NULL) {
+        cv::cuda::rotate(*src, *dst, sz, angle, xShift, yShift, interp);
+        return;
+    }
+    cv::cuda::rotate(*src, *dst, sz, angle, xShift, yShift, interp, *s);
 }
 
-void CudaWarpAffine(GpuMat src, GpuMat dst, GpuMat M, Size dsize, int flags, int borderMode, Scalar borderValue) {
+void CudaWarpAffine(GpuMat src, GpuMat dst, GpuMat M, Size dsize, int flags, int borderMode, Scalar borderValue, Stream s) {
     cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
     cv::Size sz(dsize.width, dsize.height);
-    cv::cuda::warpAffine(*src, *dst, *M, sz, flags, borderMode, c);
+
+    if (s == NULL) {
+        cv::cuda::warpAffine(*src, *dst, *M, sz, flags, borderMode, c);
+        return;
+    }
+    cv::cuda::warpAffine(*src, *dst, *M, sz, flags, borderMode, c, *s);
 }
 
-void CudaWarpPerspective(GpuMat src, GpuMat dst, GpuMat M, Size dsize, int flags, int borderMode, Scalar borderValue) {
+void CudaWarpPerspective(GpuMat src, GpuMat dst, GpuMat M, Size dsize, int flags, int borderMode, Scalar borderValue, Stream s) {
     cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
     cv::Size sz(dsize.width, dsize.height);
-    cv::cuda::warpPerspective(*src, *dst, *M, sz, flags, borderMode, c);
+    if (s == NULL) {
+        cv::cuda::warpPerspective(*src, *dst, *M, sz, flags, borderMode, c);
+        return;
+    }
+    cv::cuda::warpPerspective(*src, *dst, *M, sz, flags, borderMode, c, *s);
 }

--- a/cuda/warping.go
+++ b/cuda/warping.go
@@ -77,7 +77,21 @@ func Resize(src GpuMat, dst *GpuMat, sz image.Point, fx, fy float64, interp Inte
 		height: C.int(sz.Y),
 	}
 
-	C.CudaResize(src.p, dst.p, pSize, C.double(fx), C.double(fy), C.int(interp))
+	C.CudaResize(src.p, dst.p, pSize, C.double(fx), C.double(fy), C.int(interp), nil)
+}
+
+// ResizeWithStream resizes an image
+// using a Stream for concurrency.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga4f5fa0770d1c9efbadb9be1b92a6452a
+func ResizeWithStream(src GpuMat, dst *GpuMat, sz image.Point, fx, fy float64, interp InterpolationFlags, s Stream) {
+	pSize := C.struct_Size{
+		width:  C.int(sz.X),
+		height: C.int(sz.Y),
+	}
+
+	C.CudaResize(src.p, dst.p, pSize, C.double(fx), C.double(fy), C.int(interp), s.p)
 }
 
 // Rotate rotates an image around the origin (0,0) and then shifts it.
@@ -89,7 +103,20 @@ func Rotate(src GpuMat, dst *GpuMat, sz image.Point, angle, xShift, yShift float
 		width:  C.int(sz.X),
 		height: C.int(sz.Y),
 	}
-	C.CudaRotate(src.p, dst.p, pSize, C.double(angle), C.double(xShift), C.double(yShift), C.int(interp))
+	C.CudaRotate(src.p, dst.p, pSize, C.double(angle), C.double(xShift), C.double(yShift), C.int(interp), nil)
+}
+
+// RotateWithStream rotates an image around the origin (0,0) and then shifts it
+// using a Stream for concurrency.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga55d958eceb0f871e04b1be0adc6ef1b5
+func RotateWithStream(src GpuMat, dst *GpuMat, sz image.Point, angle, xShift, yShift float64, interp InterpolationFlags, s Stream) {
+	pSize := C.struct_Size{
+		width:  C.int(sz.X),
+		height: C.int(sz.Y),
+	}
+	C.CudaRotate(src.p, dst.p, pSize, C.double(angle), C.double(xShift), C.double(yShift), C.int(interp), s.p)
 }
 
 // Remap applies a generic geometrical transformation to an image.
@@ -103,7 +130,22 @@ func Remap(src GpuMat, dst, xmap, ymap *GpuMat, interpolation InterpolationFlags
 		val3: C.double(borderValue.R),
 		val4: C.double(borderValue.A),
 	}
-	C.CudaRemap(src.p, dst.p, xmap.p, ymap.p, C.int(interpolation), C.int(borderMode), bv)
+	C.CudaRemap(src.p, dst.p, xmap.p, ymap.p, C.int(interpolation), C.int(borderMode), bv, nil)
+}
+
+// RemapWithStream applies a generic geometrical transformation to an image
+// using a Stream for concurrency.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga0ece6c76e8efa3171adb8432d842beb0
+func RemapWithStream(src GpuMat, dst, xmap, ymap *GpuMat, interpolation InterpolationFlags, borderMode BorderType, borderValue color.RGBA, s Stream) {
+	bv := C.struct_Scalar{
+		val1: C.double(borderValue.B),
+		val2: C.double(borderValue.G),
+		val3: C.double(borderValue.R),
+		val4: C.double(borderValue.A),
+	}
+	C.CudaRemap(src.p, dst.p, xmap.p, ymap.p, C.int(interpolation), C.int(borderMode), bv, s.p)
 }
 
 // PyrDown blurs an image and downsamples it.
@@ -111,7 +153,16 @@ func Remap(src GpuMat, dst, xmap, ymap *GpuMat, interpolation InterpolationFlags
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga9c8456de9792d96431e065f407c7a91b
 func PyrDown(src GpuMat, dst *GpuMat) {
-	C.CudaPyrDown(src.p, dst.p)
+	C.CudaPyrDown(src.p, dst.p, nil)
+}
+
+// PyrDownWithStream blurs an image and downsamples it
+// using a Stream for concurrency.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga9c8456de9792d96431e065f407c7a91b
+func PyrDownWithStream(src GpuMat, dst *GpuMat, s Stream) {
+	C.CudaPyrDown(src.p, dst.p, s.p)
 }
 
 // PyrUp upsamples an image and then blurs it.
@@ -119,7 +170,16 @@ func PyrDown(src GpuMat, dst *GpuMat) {
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga2048da0dfdb9e4a726232c5cef7e5747
 func PyrUp(src GpuMat, dst *GpuMat) {
-	C.CudaPyrUp(src.p, dst.p)
+	C.CudaPyrUp(src.p, dst.p, nil)
+}
+
+// PyrUpWithStream upsamples an image and then blurs it
+// using a Stream for concurrency.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga2048da0dfdb9e4a726232c5cef7e5747
+func PyrUpWithStream(src GpuMat, dst *GpuMat, s Stream) {
+	C.CudaPyrUp(src.p, dst.p, s.p)
 }
 
 // WarpPerspective applies a perspective transformation to an image.
@@ -138,7 +198,27 @@ func WarpPerspective(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point, flags In
 		val4: C.double(borderValue.A),
 	}
 
-	C.CudaWarpPerspective(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv)
+	C.CudaWarpPerspective(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv, nil)
+}
+
+// WarpPerspectiveWithStream applies a perspective transformation to an image
+// using a Stream for concurrency.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga7a6cf95065536712de6b155f3440ccff
+func WarpPerspectiveWithStream(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point, flags InterpolationFlags, borderType BorderType, borderValue color.RGBA, s Stream) {
+	pSize := C.struct_Size{
+		width:  C.int(sz.X),
+		height: C.int(sz.Y),
+	}
+	bv := C.struct_Scalar{
+		val1: C.double(borderValue.B),
+		val2: C.double(borderValue.G),
+		val3: C.double(borderValue.R),
+		val4: C.double(borderValue.A),
+	}
+
+	C.CudaWarpPerspective(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv, s.p)
 }
 
 // WarpAffine applies an affine transformation to an image. For more parameters please check WarpAffineWithParams
@@ -157,7 +237,29 @@ func WarpAffine(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point, flags Interpo
 		val4: C.double(borderValue.A),
 	}
 
-	C.CudaWarpAffine(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv)
+	C.CudaWarpAffine(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv, nil)
+}
+
+// WarpAffineWithStream applies an affine transformation to an image
+// using a Stream for concurrency.
+//
+// For more parameters please check WarpAffineWithParams
+//
+// For further details, please see:
+// https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga9e8dd9e73b96bdc8e27d85c0e83f1130
+func WarpAffineWithStream(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point, flags InterpolationFlags, borderType BorderType, borderValue color.RGBA, s Stream) {
+	pSize := C.struct_Size{
+		width:  C.int(sz.X),
+		height: C.int(sz.Y),
+	}
+	bv := C.struct_Scalar{
+		val1: C.double(borderValue.B),
+		val2: C.double(borderValue.G),
+		val3: C.double(borderValue.R),
+		val4: C.double(borderValue.A),
+	}
+
+	C.CudaWarpAffine(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv, s.p)
 }
 
 // BuildWarpAffineMaps builds transformation maps for affine transformation.
@@ -170,7 +272,21 @@ func BuildWarpAffineMaps(M GpuMat, inverse bool, sz image.Point, xmap, ymap *Gpu
 		height: C.int(sz.Y),
 	}
 
-	C.CudaBuildWarpAffineMaps(M.p, C.bool(inverse), pSize, xmap.p, ymap.p)
+	C.CudaBuildWarpAffineMaps(M.p, C.bool(inverse), pSize, xmap.p, ymap.p, nil)
+}
+
+// BuildWarpAffineMapsWithStream builds transformation maps for affine transformation
+// using a Stream for concurrency.
+//
+// For further details. please see:
+// https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga63504590a96e4cc702d994281d17bc1c
+func BuildWarpAffineMapsWithStream(M GpuMat, inverse bool, sz image.Point, xmap, ymap *GpuMat, s Stream) {
+	pSize := C.struct_Size{
+		width:  C.int(sz.X),
+		height: C.int(sz.Y),
+	}
+
+	C.CudaBuildWarpAffineMaps(M.p, C.bool(inverse), pSize, xmap.p, ymap.p, s.p)
 }
 
 // BuildWarpPerspectiveMaps builds transformation maps for perspective transformation.
@@ -183,5 +299,19 @@ func BuildWarpPerspectiveMaps(M GpuMat, inverse bool, sz image.Point, xmap, ymap
 		height: C.int(sz.Y),
 	}
 
-	C.CudaBuildWarpPerspectiveMaps(M.p, C.bool(inverse), pSize, xmap.p, ymap.p)
+	C.CudaBuildWarpPerspectiveMaps(M.p, C.bool(inverse), pSize, xmap.p, ymap.p, nil)
+}
+
+// BuildWarpPerspectiveMapsWithStream builds transformation maps for perspective transformation
+// using a Stream for concurrency.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga8d16e3003703bd3b89cca98c913ef864
+func BuildWarpPerspectiveMapsWithStream(M GpuMat, inverse bool, sz image.Point, xmap, ymap *GpuMat, s Stream) {
+	pSize := C.struct_Size{
+		width:  C.int(sz.X),
+		height: C.int(sz.Y),
+	}
+
+	C.CudaBuildWarpPerspectiveMaps(M.p, C.bool(inverse), pSize, xmap.p, ymap.p, s.p)
 }

--- a/cuda/warping.h
+++ b/cuda/warping.h
@@ -11,15 +11,15 @@ extern "C" {
 #include "../core.h"
 #include "cuda.h"
 
-void CudaResize(GpuMat src, GpuMat dst, Size dsize, double fx, double fy, int interp);
-void CudaPyrDown(GpuMat src, GpuMat dst);
-void CudaPyrUp(GpuMat src, GpuMat dst);
-void CudaBuildWarpAffineMaps(GpuMat M, bool inverse, Size dsize, GpuMat xmap, GpuMat ymap);
-void CudaBuildWarpPerspectiveMaps(GpuMat M, bool inverse, Size dsize, GpuMat xmap, GpuMat ymap);
-void CudaRemap(GpuMat src, GpuMat dst, GpuMat xmap, GpuMat ymap, int interp, int borderMode, Scalar borderValue);
-void CudaRotate(GpuMat src, GpuMat dst, Size dsize, double angle, double xShift, double yShift, int interp);
-void CudaWarpAffine(GpuMat src, GpuMat dst, GpuMat M, Size dsize, int flags, int borderMode, Scalar borderValue);
-void CudaWarpPerspective(GpuMat src, GpuMat dst, GpuMat M, Size dsize, int flags, int borderMode, Scalar borderValue);
+void CudaResize(GpuMat src, GpuMat dst, Size dsize, double fx, double fy, int interp, Stream s);
+void CudaPyrDown(GpuMat src, GpuMat dst, Stream s);
+void CudaPyrUp(GpuMat src, GpuMat dst, Stream s);
+void CudaBuildWarpAffineMaps(GpuMat M, bool inverse, Size dsize, GpuMat xmap, GpuMat ymap, Stream s);
+void CudaBuildWarpPerspectiveMaps(GpuMat M, bool inverse, Size dsize, GpuMat xmap, GpuMat ymap, Stream s);
+void CudaRemap(GpuMat src, GpuMat dst, GpuMat xmap, GpuMat ymap, int interp, int borderMode, Scalar borderValue, Stream s);
+void CudaRotate(GpuMat src, GpuMat dst, Size dsize, double angle, double xShift, double yShift, int interp, Stream s);
+void CudaWarpAffine(GpuMat src, GpuMat dst, GpuMat M, Size dsize, int flags, int borderMode, Scalar borderValue, Stream s);
+void CudaWarpPerspective(GpuMat src, GpuMat dst, GpuMat M, Size dsize, int flags, int borderMode, Scalar borderValue, Stream s);
 #ifdef __cplusplus
 }
 #endif

--- a/cuda/warping_test.go
+++ b/cuda/warping_test.go
@@ -38,6 +38,38 @@ func TestResize(t *testing.T) {
 	}
 }
 
+func TestResizeWithStream(t *testing.T) {
+	src := gocv.IMRead("../images/gocvlogo.jpg", gocv.IMReadColor)
+	if src.Empty() {
+		t.Error("Invalid read of Mat in Resize test")
+	}
+	defer src.Close()
+
+	var cimg, dimg = NewGpuMat(), NewGpuMat()
+	defer cimg.Close()
+	defer dimg.Close()
+
+	cimg.Upload(src)
+
+	dst := gocv.NewMat()
+	defer dst.Close()
+
+	stream := NewStream()
+	defer stream.Close()
+
+	ResizeWithStream(cimg, &dimg, image.Point{}, 0.5, 0.5, InterpolationDefault, stream)
+	dimg.Download(&dst)
+	if dst.Cols() != 200 || dst.Rows() != 172 {
+		t.Errorf("Expected dst size of 200x172 got %dx%d", dst.Cols(), dst.Rows())
+	}
+
+	ResizeWithStream(cimg, &dimg, image.Pt(440, 377), 0, 0, InterpolationCubic, stream)
+	dimg.Download(&dst)
+	if dst.Cols() != 440 || dst.Rows() != 377 {
+		t.Errorf("Expected dst size of 440x377 got %dx%d", dst.Cols(), dst.Rows())
+	}
+}
+
 func TestPyrDown(t *testing.T) {
 	src := gocv.IMRead("../images/face-detect.jpg", gocv.IMReadColor)
 	if src.Empty() {
@@ -55,6 +87,32 @@ func TestPyrDown(t *testing.T) {
 	defer dst.Close()
 
 	PyrDown(gsrc, &gdst)
+	gdst.Download(&dst)
+	if dst.Empty() && math.Abs(float64(src.Cols()-2*dst.Cols())) < 2.0 && math.Abs(float64(src.Rows()-2*dst.Rows())) < 2.0 {
+		t.Error("Invalid PyrDown test")
+	}
+}
+
+func TestPyrDownWithStream(t *testing.T) {
+	src := gocv.IMRead("../images/face-detect.jpg", gocv.IMReadColor)
+	if src.Empty() {
+		t.Error("Invalid read of Mat in PyrDown test")
+	}
+	defer src.Close()
+
+	var gsrc, gdst = NewGpuMat(), NewGpuMat()
+	defer gsrc.Close()
+	defer gdst.Close()
+
+	gsrc.Upload(src)
+
+	dst := gocv.NewMat()
+	defer dst.Close()
+
+	stream := NewStream()
+	defer stream.Close()
+
+	PyrDownWithStream(gsrc, &gdst, stream)
 	gdst.Download(&dst)
 	if dst.Empty() && math.Abs(float64(src.Cols()-2*dst.Cols())) < 2.0 && math.Abs(float64(src.Rows()-2*dst.Rows())) < 2.0 {
 		t.Error("Invalid PyrDown test")
@@ -83,6 +141,31 @@ func TestPyrUp(t *testing.T) {
 	}
 }
 
+func TestPyrUpWithStream(t *testing.T) {
+	src := gocv.IMRead("../images/face-detect.jpg", gocv.IMReadColor)
+	if src.Empty() {
+		t.Error("Invalid read of Mat in PyrUp test")
+	}
+	defer src.Close()
+
+	var gsrc, gdst = NewGpuMat(), NewGpuMat()
+	defer gsrc.Close()
+	defer gdst.Close()
+
+	gsrc.Upload(src)
+
+	dst := gocv.NewMat()
+	defer dst.Close()
+
+	stream := NewStream()
+	defer stream.Close()
+
+	PyrDownWithStream(gsrc, &gdst, stream)
+	if dst.Empty() && math.Abs(float64(2*src.Cols()-dst.Cols())) < 2.0 && math.Abs(float64(2*src.Rows()-dst.Rows())) < 2.0 {
+		t.Error("Invalid PyrUp test")
+	}
+}
+
 func TestRemap(t *testing.T) {
 	src := gocv.IMRead("../images/gocvlogo.jpg", gocv.IMReadUnchanged)
 	defer src.Close()
@@ -101,6 +184,34 @@ func TestRemap(t *testing.T) {
 	gmap1.Upload(map1)
 	gmap2.Upload(map2)
 	Remap(gsrc, &gdst, &gmap1, &gmap2, InterpolationDefault, BorderConstant, color.RGBA{0, 0, 0, 0})
+	gdst.Download(&dst)
+	if ok := dst.Empty(); ok {
+		t.Errorf("Remap(): dst is empty")
+	}
+}
+
+func TestRemapWithStream(t *testing.T) {
+	src := gocv.IMRead("../images/gocvlogo.jpg", gocv.IMReadUnchanged)
+	defer src.Close()
+
+	dst := gocv.NewMat()
+	defer dst.Close()
+
+	map1 := gocv.NewMatWithSize(256, 256, gocv.MatTypeCV32F)
+	defer map1.Close()
+	map1.SetFloatAt(50, 50, 25.4)
+	map2 := gocv.NewMatWithSize(256, 256, gocv.MatTypeCV32F)
+	defer map2.Close()
+
+	gsrc, gdst, gmap1, gmap2 := NewGpuMat(), NewGpuMat(), NewGpuMat(), NewGpuMat()
+	gsrc.Upload(src)
+	gmap1.Upload(map1)
+	gmap2.Upload(map2)
+
+	stream := NewStream()
+	defer stream.Close()
+
+	RemapWithStream(gsrc, &gdst, &gmap1, &gmap2, InterpolationDefault, BorderConstant, color.RGBA{0, 0, 0, 0}, stream)
 	gdst.Download(&dst)
 	if ok := dst.Empty(); ok {
 		t.Errorf("Remap(): dst is empty")


### PR DESCRIPTION
This PR is to introduce the use of the `Stream` for thread-safe concurrency when using GPU.

How to use:

```go
	cimg, mimg, dimg := NewGpuMat(), NewGpuMat(), NewGpuMat()
	defer cimg.Close()
	defer mimg.Close()
	defer dimg.Close()

	stream := NewStream()
	defer stream.Close()

	canny := NewCannyEdgeDetector(50, 100)
	defer canny.Close()

	detector := NewHoughSegmentDetector(1, math.Pi/180, 150, 50)
	defer detector.Close()

	dest := gocv.NewMat()
	defer dest.Close()

	cimg.UploadWithStream(src, stream)
	canny.DetectWithStream(cimg, &mimg, stream)
	detector.DetectWithStream(mimg, &dimg, stream)
	dimg.DownloadWithStream(&dest, stream)

	stream.WaitForCompletion()
```