### PR TITLE
Update README.md to include export step for installation on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,11 @@ You can install it by using Homebrew:
 
 To verify your installation you can run one of the included examples.
 
-First, change the current directory to the location of the GoCV repo:
+To start, you will need to set the `PKG_CONFIG_PATH` environment variable (replacing `4.5.3` if needed):
+
+	export PKG_CONFIG_PATH="/opt/homebrew/Cellar/opencv/4.5.3/lib/pkgconfig"
+
+Next, change the current directory to the location of the GoCV repo:
 
 	cd $HOME/folder/with/your/src/gocv
 


### PR DESCRIPTION
Adding in an important step to running GoCV on macOS. Without setting this environment variable, users running macOS may encounter an error similar to this one:

    
    Package opencv4 was not found in the pkg-config search path.
    Perhaps you should add the directory containing `opencv4.pc'
    to the PKG_CONFIG_PATH environment variable
    No package 'opencv4' found
    pkg-config: exit status 1