### PR TITLE
Add: findChessboardCornersSB

### DIFF
--- a/calib3d.cpp
+++ b/calib3d.cpp
@@ -54,6 +54,16 @@ bool FindChessboardCorners(Mat image, Size patternSize, Mat corners, int flags) 
     return cv::findChessboardCorners(*image, sz, *corners, flags);
 }
 
+bool FindChessboardCornersSB(Mat image, Size patternSize, Mat corners, int flags) {
+    cv::Size sz(patternSize.width, patternSize.height);
+    return cv::findChessboardCornersSB(*image, sz, *corners, flags);
+}
+
+bool FindChessboardCornersSBWithMeta(Mat image, Size patternSize, Mat corners, int flags, Mat meta) {
+    cv::Size sz(patternSize.width, patternSize.height);
+    return cv::findChessboardCornersSB(*image, sz, *corners, flags, *meta);
+}
+
 void DrawChessboardCorners(Mat image, Size patternSize, Mat corners, bool patternWasFound) {
     cv::Size sz(patternSize.width, patternSize.height);
     cv::drawChessboardCorners(*image, sz, *corners, patternWasFound);

--- a/calib3d.go
+++ b/calib3d.go
@@ -131,8 +131,8 @@ func GetOptimalNewCameraMatrixWithParams(cameraMatrix Mat, distCoeffs Mat, image
 //
 func CalibrateCamera(objectPoints Points3fVector, imagePoints Points2fVector, imageSize image.Point,
 	cameraMatrix *Mat, distCoeffs *Mat, rvecs *Mat, tvecs *Mat, calibFlag CalibFlag) float64 {
-	sz := C.struct_Size {
-		width: C.int(imageSize.X),
+	sz := C.struct_Size{
+		width:  C.int(imageSize.X),
 		height: C.int(imageSize.Y),
 	}
 
@@ -167,9 +167,13 @@ const (
 	CalibCBFilterQuads
 	//  Run a fast check on the image that looks for chessboard corners, and shortcut the call if none is found. This can drastically speed up the call in the degenerate condition when no chessboard is observed.
 	CalibCBFastCheck
+	//  Run an exhaustive search to improve detection rate.
 	CalibCBExhaustive
+	//  Up sample input image to improve sub-pixel accuracy due to aliasing effects.
 	CalibCBAccuracy
+	//  The detected pattern is allowed to be larger than patternSize (see description).
 	CalibCBLarger
+	//  The detected pattern must have a marker (see description). This should be used if an accurate camera calibration is required.
 	CalibCBMarker
 )
 
@@ -184,6 +188,32 @@ func FindChessboardCorners(image Mat, patternSize image.Point, corners *Mat, fla
 		height: C.int(patternSize.Y),
 	}
 	return bool(C.FindChessboardCorners(image.Ptr(), sz, corners.Ptr(), C.int(flags)))
+}
+
+// FindChessboardCorners finds the positions of internal corners of the chessboard using a sector based approach.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d9/d0c/group__calib3d.html#gadc5bcb05cb21cf1e50963df26986d7c9
+//
+func FindChessboardCornersSB(image Mat, patternSize image.Point, corners *Mat, flags CalibCBFlag) bool {
+	sz := C.struct_Size{
+		width:  C.int(patternSize.X),
+		height: C.int(patternSize.Y),
+	}
+	return bool(C.FindChessboardCornersSB(image.Ptr(), sz, corners.Ptr(), C.int(flags)))
+}
+
+// FindChessboardCornersSBWithMeta finds the positions of internal corners of the chessboard using a sector based approach.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d9/d0c/group__calib3d.html#ga93efa9b0aa890de240ca32b11253dd4a
+//
+func FindChessboardCornersSBWithMeta(image Mat, patternSize image.Point, corners *Mat, flags CalibCBFlag, meta *Mat) bool {
+	sz := C.struct_Size{
+		width:  C.int(patternSize.X),
+		height: C.int(patternSize.Y),
+	}
+	return bool(C.FindChessboardCornersSBWithMeta(image.Ptr(), sz, corners.Ptr(), C.int(flags), meta.Ptr()))
 }
 
 // DrawChessboardCorners renders the detected chessboard corners.

--- a/calib3d.h
+++ b/calib3d.h
@@ -23,6 +23,8 @@ double CalibrateCamera(Points3fVector objectPoints, Points2fVector imagePoints, 
 void Undistort(Mat src, Mat dst, Mat cameraMatrix, Mat distCoeffs, Mat newCameraMatrix);
 void UndistortPoints(Mat distorted, Mat undistorted, Mat k, Mat d, Mat r, Mat p);
 bool FindChessboardCorners(Mat image, Size patternSize, Mat corners, int flags);
+bool FindChessboardCornersSB(Mat image, Size patternSize, Mat corners, int flags);
+bool FindChessboardCornersSBWithMeta(Mat image, Size patternSize, Mat corners, int flags, Mat meta);
 void DrawChessboardCorners(Mat image, Size patternSize, Mat corners, bool patternWasFound);
 Mat EstimateAffinePartial2D(Point2fVector from, Point2fVector to);
 

--- a/calib3d_test.go
+++ b/calib3d_test.go
@@ -383,6 +383,69 @@ func TestFindAndDrawChessboard(t *testing.T) {
 	}
 }
 
+func TestFindAndDrawChessboardSB(t *testing.T) {
+	img := IMRead("images/chessboard_4x6.png", IMReadUnchanged)
+	if img.Empty() {
+		t.Error("Invalid read of chessboard image")
+		return
+	}
+	defer img.Close()
+
+	corners := NewMat()
+	defer corners.Close()
+
+	found := FindChessboardCornersSB(img, image.Point{X: 4, Y: 6}, &corners, 0)
+	if found == false {
+		t.Error("chessboard pattern not found")
+		return
+	}
+	if corners.Empty() {
+		t.Error("chessboard pattern not found")
+		return
+	}
+
+	img2 := NewMatWithSize(150, 150, MatTypeCV8U)
+	defer img2.Close()
+
+	DrawChessboardCorners(&img2, image.Pt(4, 6), corners, true)
+	if img2.Empty() {
+		t.Error("Error in DrawChessboardCorners test")
+	}
+}
+
+func TestFindChessboardCornersSBWithMeta(t *testing.T) {
+	img := IMRead("images/chessboard_4x6.png", IMReadUnchanged)
+	if img.Empty() {
+		t.Error("Invalid read of chessboard image")
+		return
+	}
+	defer img.Close()
+
+	corners := NewMat()
+	defer corners.Close()
+
+	meta := NewMat()
+	defer meta.Close()
+
+	found := FindChessboardCornersSBWithMeta(img, image.Point{X: 4, Y: 6}, &corners, 0, &meta)
+	if found == false {
+		t.Error("chessboard pattern not found")
+		return
+	}
+	if corners.Empty() {
+		t.Error("chessboard pattern not found")
+		return
+	}
+
+	img2 := NewMatWithSize(150, 150, MatTypeCV8U)
+	defer img2.Close()
+
+	DrawChessboardCorners(&img2, image.Pt(4, 6), corners, true)
+	if img2.Empty() {
+		t.Error("Error in DrawChessboardCorners test")
+	}
+}
+
 func TestCalibrateCamera(t *testing.T) {
 	img := IMRead("images/chessboard_4x6_distort.png", IMReadGrayScale)
 	if img.Empty() {


### PR DESCRIPTION
``` go

// FindChessboardCorners finds the positions of internal corners of the chessboard using a sector based approach.
//
// For further details, please see:
// https://docs.opencv.org/master/d9/d0c/group__calib3d.html#gadc5bcb05cb21cf1e50963df26986d7c9
//
func FindChessboardCornersSB(image Mat, patternSize image.Point, corners *Mat, flags CalibCBFlag) bool {
	sz := C.struct_Size{
		width:  C.int(patternSize.X),
		height: C.int(patternSize.Y),
	}
	return bool(C.FindChessboardCornersSB(image.Ptr(), sz, corners.Ptr(), C.int(flags)))
}

// FindChessboardCornersSBWithMeta finds the positions of internal corners of the chessboard using a sector based approach.
//
// For further details, please see:
// https://docs.opencv.org/master/d9/d0c/group__calib3d.html#ga93efa9b0aa890de240ca32b11253dd4a
//
func FindChessboardCornersSBWithMeta(image Mat, patternSize image.Point, corners *Mat, flags CalibCBFlag, meta *Mat) bool {
	sz := C.struct_Size{
		width:  C.int(patternSize.X),
		height: C.int(patternSize.Y),
	}
	return bool(C.FindChessboardCornersSBWithMeta(image.Ptr(), sz, corners.Ptr(), C.int(flags), meta.Ptr()))
}

```