### PR TITLE
Fix open video capture with api test

### DIFF
--- a/videoio_test.go
+++ b/videoio_test.go
@@ -89,7 +89,7 @@ func TestVideoCaptureWithAPI(t *testing.T) {
 	})
 
 	t.Run("video capture valid int string with api", func(t *testing.T) {
-		vc5, err := OpenVideoCaptureWithAPI("1", VideoCaptureAny)
+		vc5, err := OpenVideoCaptureWithAPI("99", VideoCaptureAny)
 		defer vc5.Close()
 		if err == nil {
 			t.Errorf("should return error opening device")

--- a/videoio_test.go
+++ b/videoio_test.go
@@ -88,7 +88,7 @@ func TestVideoCaptureWithAPI(t *testing.T) {
 		}
 	})
 
-	t.Run("video capture valid int string with api", func(t *testing.T) {
+	t.Run("video capture valid int string with api no available device", func(t *testing.T) {
 		vc5, err := OpenVideoCaptureWithAPI("99", VideoCaptureAny)
 		defer vc5.Close()
 		if err == nil {


### PR DESCRIPTION
If tested with multiple devices connected, test fails because it should fail on deviceId 1, assuming that you have no more than 1 video device. Changing to 99 "assures" that in normal conditions test passes.