### PR TITLE
fix: panic if repeat defer mat.Close

### DIFF
--- a/mat_noprofile.go
+++ b/mat_noprofile.go
@@ -20,6 +20,9 @@ func newMat(p C.Mat) Mat {
 
 // Close the Mat object.
 func (m *Mat) Close() error {
+	if m.p == nil {
+		return nil
+	}
 	C.Mat_Close(m.p)
 	m.p = nil
 	m.d = nil

--- a/mat_noprofile.go
+++ b/mat_noprofile.go
@@ -7,6 +7,7 @@ package gocv
 #include "core.h"
 */
 import "C"
+import "errors"
 
 // addMatToProfile does nothing if matprofile tag is not set.
 func addMatToProfile(p C.Mat) {
@@ -21,7 +22,7 @@ func newMat(p C.Mat) Mat {
 // Close the Mat object.
 func (m *Mat) Close() error {
 	if m.p == nil {
-		return nil
+		return errors.New("duplicate Mat close")
 	}
 	C.Mat_Close(m.p)
 	m.p = nil

--- a/mat_profile.go
+++ b/mat_profile.go
@@ -73,6 +73,9 @@ func newMat(p C.Mat) Mat {
 
 // Close the Mat object.
 func (m *Mat) Close() error {
+	if m.p == nil {
+		return nil
+	}
 	// NOTE: The pointer must be removed from the profile before it is deleted to
 	// avoid a data race.
 	MatProfile.Remove(m.p)

--- a/mat_profile.go
+++ b/mat_profile.go
@@ -74,7 +74,7 @@ func newMat(p C.Mat) Mat {
 // Close the Mat object.
 func (m *Mat) Close() error {
 	if m.p == nil {
-		return nil
+		return errors.New("duplicate Mat close")
 	}
 	// NOTE: The pointer must be removed from the profile before it is deleted to
 	// avoid a data race.


### PR DESCRIPTION
Simple code where problem was found:

```package main

import (
	"fmt"
	"gocv.io/x/gocv"
)

func main() {
	mat1 := gocv.NewMat()
	defer mat1.Close()
	mat2 := gocv.NewMat()
	mat1 = mat2
	defer mat2.Close()
}
```

If did't check on nil in func Close, get panic

```fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0x7ff60000003c pc=0x4e3a79]

runtime stack:
runtime.throw(0x532266, 0x2a)
        /usr/local/go/src/runtime/panic.go:1116 +0x72
runtime.sigpanic()
        /usr/local/go/src/runtime/signal_unix.go:726 +0x4ac

goroutine 1 [syscall]:
runtime.cgocall(0x4d83a0, 0xc000050ea0, 0x0)
        /usr/local/go/src/runtime/cgocall.go:133 +0x5b fp=0xc000050e70 sp=0xc000050e38 pc=0x43b3bb
gocv.io/x/gocv._Cfunc_Mat_Close(0x7ff6f2380ce0)
        _cgo_gotypes.go:3080 +0x45 fp=0xc000050ea0 sp=0xc000050e70 pc=0x4d40c5```

