### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 .PHONY: test deps download build clean astyle cmds docker
 
 # GoCV version to use.
-GOCV_VERSION?="v0.26.0"
+GOCV_VERSION?="v0.29.0"
 
 # OpenCV version to use.
-OPENCV_VERSION?=4.5.3
+OPENCV_VERSION?=4.5.4
 
 # Go version to use when building Docker image
 GOVERSION?=1.16.2


### PR DESCRIPTION
Hi gocv team,
Thanks a lot for your amazing work!
Your release note states that your latest version (0.29.0) updates to OpenCV **4.5.4** but the makefile opencv version var was not updated accordingly.
Also the GOCV_VERSION var does not seems up to date.
I guess it is an oversight?  ¯_(ツ)_/¯