### PR TITLE
dnn: Fix dangling pointers returned by `GetLayerNames`

### DIFF
--- a/Dockerfile.opencv-openvino
+++ b/Dockerfile.opencv-openvino
@@ -5,10 +5,11 @@ LABEL maintainer="hybridgroup"
 ENV DEBIAN_FRONTEND=noninteractive
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
-            git build-essential cmake pkg-config unzip libgtk2.0-dev \
+            git build-essential cmake pkg-config unzip libgtk2.0-dev libgtk-3-0 \
             wget curl ca-certificates libcurl4-openssl-dev libssl-dev \
             libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev \
-            libjpeg-dev libpng-dev libtiff-dev libdc1394-22-dev && \
+            libjpeg-dev libpng-dev libtiff-dev libdc1394-22-dev libcanberra-gtk-module \
+            libcanberra-gtk3-module && \
             rm -rf /var/lib/apt/lists/*
 
 ARG OPENCV_VERSION="4.6.0"
@@ -39,7 +40,6 @@ RUN curl -Lo opencv.zip https://github.com/opencv/opencv/archive/${OPENCV_VERSIO
             -D BUILD_opencv_python3=NO \
             -D WITH_TBB=ON \
             -D WITH_OPENVINO=1 \
-            -D ENABLE_FAST_MATH=1 \
             -D OPENCV_GENERATE_PKGCONFIG=ON .. && \
     make -j $(nproc --all) && \
     make preinstall && make install && ldconfig && \

--- a/dnn.cpp
+++ b/dnn.cpp
@@ -143,7 +143,6 @@ void Net_GetLayerNames(Net net, CStrings* names) {
 
     names->length = cstrs.size();
     names->strs = strs;
-    return;
 }
 
 Mat Net_BlobFromImage(Mat image, double scalefactor, Size size, Scalar mean, bool swapRB,

--- a/dnn_test.go
+++ b/dnn_test.go
@@ -56,8 +56,27 @@ func checkNet(t *testing.T, net Net) {
 		t.Errorf("Invalid len layer names in ReadNet test: %d\n", len(lnames))
 	}
 
-	if len(lnames) == 142 && lnames[1] != "conv1/relu_7x7" {
-		t.Errorf("Invalid layer name in ReadNet test: %s\n", lnames[1])
+	m := map[int]string{
+		0:   "conv1/7x7_s2",
+		10:  "inception_3a/1x1",
+		20:  "inception_3a/pool",
+		30:  "inception_3b/5x5_reduce",
+		40:  "inception_4a/relu_1x1",
+		50:  "inception_4a/pool_proj",
+		60:  "inception_4b/relu_5x5_reduce",
+		70:  "inception_4c/relu_3x3_reduce",
+		80:  "inception_4c/output",
+		90:  "inception_4d/relu_5x5",
+		100: "inception_4e/relu_3x3",
+		110: "inception_5a/1x1",
+		120: "inception_5a/pool",
+		130: "inception_5b/5x5_reduce",
+		140: "loss3/classifier"}
+
+	for k, v := range m {
+		if lnames[k] != v {
+			t.Errorf("Invalid layer name in ReadNet test: \"%s\" (expected=\"%s\")\n", lnames[k], v)
+		}
 	}
 
 	prob := net.ForwardLayers([]string{"prob"})


### PR DESCRIPTION
`GetLayerNames` returns an array of `char` pointers to `cstrings` in a `vector<string>`; unfortunately, once the vector is out of scope, the strings are destroyed. `GetLayerNames` callers are then left with dangling pointers.

This change fixes the problem by expanding the `strs` buffer returned by `GetLayerNames` and copying the vector's cstrings into it.

**Testing**: 
_**See [this comment](https://github.com/hybridgroup/gocv/pull/927#issuecomment-1191250252)**_

Here's an example of the bug in action:
``` go

	n := net.GetLayerNames()

	for i, l := range n {
		fmt.Printf("Layer %d: %s\n", i, l)
	}
```

Before fix:
``` bash
$ go test -tags customenv,static
Layer 0: @�
Layer 1: 0�
...
```

After fix:
``` bash
$ go test -tags customenv,static
Layer 0: detector/yolo-v3-tiny/Conv_12/BiasAdd/YoloRegion
Layer 1: detector/yolo-v3-tiny/Conv_9/BiasAdd/YoloRegion
...
```