### PR TITLE
Fixed memory leaks in motion detection example

### DIFF
--- a/cmd/motion-detect/main.go
+++ b/cmd/motion-detect/main.go
@@ -79,8 +79,8 @@ func main() {
 
 		// then dilate
 		kernel := gocv.GetStructuringElement(gocv.MorphRect, image.Pt(3, 3))
-		defer kernel.Close()
 		gocv.Dilate(imgThresh, &imgThresh, kernel)
+		kernel.Close()
 
 		// now find contours
 		contours := gocv.FindContours(imgThresh, gocv.RetrievalExternal, gocv.ChainApproxSimple)
@@ -98,6 +98,8 @@ func main() {
 			rect := gocv.BoundingRect(contours.At(i))
 			gocv.Rectangle(&img, rect, color.RGBA{0, 0, 255, 0}, 2)
 		}
+
+		contours.Close()
 
 		gocv.PutText(&img, status, image.Pt(10, 20), gocv.FontHersheyPlain, 1.2, statusColor, 2)
 


### PR DESCRIPTION
I noticed a memory leak in `cmd/motion-detect/main.go`: objects `kernel` and `contours` weren't being disposed of properly.