### PR TITLE
core: avoid index out of range panic in NewPointsVectorFromPoints

### DIFF
--- a/core.go
+++ b/core.go
@@ -2119,6 +2119,9 @@ func NewPointsVector() PointsVector {
 // NewPointsVectorFromPoints returns a new PointsVector that has been
 // initialized to a slice of slices of image.Point.
 func NewPointsVectorFromPoints(pts [][]image.Point) PointsVector {
+	if len(pts) <= 0 {
+		return NewPointsVector()
+	}
 	points := make([]C.struct_Points, len(pts))
 
 	for i, pt := range pts {


### PR DESCRIPTION
In core.go, the `NewPointsVectorFromPoints` function has been implemented without validity check, it always accesses `points[0]` even if the `points` slice is empty. 
To avoid causing index out of range panic, I suggest returning a new empty `PointsVector` when input `pts` is empty.