### PR TITLE
Update main.go

### DIFF
--- a/cmd/ssd-facedetect/main.go
+++ b/cmd/ssd-facedetect/main.go
@@ -87,8 +87,8 @@ func main() {
 		W := float32(img.Cols())
 		H := float32(img.Rows())
 
-		// convert image Mat to 96x128 blob that the detector can analyze
-		blob := gocv.BlobFromImage(img, 1.0, image.Pt(128, 96), gocv.NewScalar(104.0, 177.0, 123.0, 0), false, false)
+		// convert image Mat to 300x300 blob that the detector can analyze
+		blob := gocv.BlobFromImage(img, 1.0, image.Pt(300, 300), gocv.NewScalar(104.0, 177.0, 123.0, 0), false, false)
 		defer blob.Close()
 
 		// feed the blob into the classifier


### PR DESCRIPTION
when size was iamge.Pt(128, 96), run this example on macOS, gocv v0.29, got error like this:
```Start reading device: 0
[ERROR:0@1.213] global /tmp/opencv-20220307-81903-1l5gslk/opencv-4.5.5/modules/dnn/src/dnn.cpp (3907) getLayerShapesRecursively OPENCV/DNN: [Convolution]:(conv8_2_h): getMemoryShapes() post validation failed. inputs=1 outputs=1/1 blobs=2 inplace=0
[ERROR:0@1.213] global /tmp/opencv-20220307-81903-1l5gslk/opencv-4.5.5/modules/dnn/src/dnn.cpp (3910) getLayerShapesRecursively     input[0] = [ 1 64 2 2 ]
[ERROR:0@1.213] global /tmp/opencv-20220307-81903-1l5gslk/opencv-4.5.5/modules/dnn/src/dnn.cpp (3914) getLayerShapesRecursively     output[0] = [ 1 128 0 0 ]
[ERROR:0@1.213] global /tmp/opencv-20220307-81903-1l5gslk/opencv-4.5.5/modules/dnn/src/dnn.cpp (3918) getLayerShapesRecursively     blobs[0] = CV_32FC1 [ 128 64 3 3 ]
[ERROR:0@1.213] global /tmp/opencv-20220307-81903-1l5gslk/opencv-4.5.5/modules/dnn/src/dnn.cpp (3918) getLayerShapesRecursively     blobs[1] = CV_32FC1 [ 128 1 ]
[ERROR:0@1.213] global /tmp/opencv-20220307-81903-1l5gslk/opencv-4.5.5/modules/dnn/src/dnn.cpp (3920) getLayerShapesRecursively Exception message: OpenCV(4.5.5) /tmp/opencv-20220307-81903-1l5gslk/opencv-4.5.5/modules/dnn/src/dnn.cpp:3899: error: (-2:Unspecified error) in function 'void cv::dnn::dnn4_v20211220::Net::Impl::getLayerShapesRecursively(int, cv::dnn::dnn4_v20211220::Net::Impl::LayersShapesMap &)'
>  (expected: 'total(os[i]) > 0'), where
>     'total(os[i])' is 0
> must be greater than
>     '0' is 0

libc++abi: terminating with uncaught exception of type cv::Exception: OpenCV(4.5.5) /tmp/opencv-20220307-81903-1l5gslk/opencv-4.5.5/modules/dnn/src/dnn.cpp:3899: error: (-2:Unspecified error) in function 'void cv::dnn::dnn4_v20211220::Net::Impl::getLayerShapesRecursively(int, cv::dnn::dnn4_v20211220::Net::Impl::LayersShapesMap &)'
>  (expected: 'total(os[i]) > 0'), where
>     'total(os[i])' is 0
> must be greater than
>     '0' is 0

SIGABRT: abort
PC=0x7ff80327700e m=0 sigcode=0
signal arrived during cgo execution

goroutine 1 [syscall, locked to thread]:
runtime.cgocall(0x4098b30, 0xc00004ab88)
	/usr/local/Cellar/go/1.17.8/libexec/src/runtime/cgocall.go:156 +0x5c fp=0xc00004ab60 sp=0xc00004ab28 pc=0x40044fc
gocv.io/x/gocv._Cfunc_Net_Forward(0x60000000e020, 0x600000004360)
	_cgo_gotypes.go:5658 +0x4d fp=0xc00004ab88 sp=0xc00004ab60 pc=0x4091d4d
gocv.io/x/gocv.(*Net).Forward.func2(0x600000004360, 0xd)
	/Users/ztyu/workspace/gocv/dnn.go:169 +0x4c fp=0xc00004abc8 sp=0xc00004ab88 pc=0x40931ac
gocv.io/x/gocv.(*Net).Forward(0x600002624120, {0x40cf057, 0x0})
	/Users/ztyu/workspace/gocv/dnn.go:169 +0x6d fp=0xc00004ac28 sp=0xc00004abc8 pc=0x40930cd
main.main()
	/Users/ztyu/workspace/rsAnalyzer/test2.go:83 +0x7cb fp=0xc00004af80 sp=0xc00004ac28 pc=0x40954cb
runtime.main()
	/usr/local/Cellar/go/1.17.8/libexec/src/runtime/proc.go:255 +0x227 fp=0xc00004afe0 sp=0xc00004af80 pc=0x4034367
runtime.goexit()
	/usr/local/Cellar/go/1.17.8/libexec/src/runtime/asm_amd64.s:1581 +0x1 fp=0xc00004afe8 sp=0xc00004afe0 pc=0x405d9e1

rax    0x0
rbx    0xf0e7600
rcx    0x7ff7bfefe938
rdx    0x0
rdi    0x103
rsi    0x6
rbp    0x7ff7bfefe960
rsp    0x7ff7bfefe938
r8     0x7ff7bfefe800
r9     0x7ff80326bf78
r10    0x0
r11    0x246
r12    0x103
r13    0x3000000008
r14    0x6
r15    0x16
rip    0x7ff80327700e
rflags 0x246
cs     0x7
fs     0x0
gs     0x0
exit status 2
```

after change size to image.Pt(300, 300), it running successfully.