### PR TITLE
Add Mat.ElemSize

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -210,6 +210,10 @@ int Mat_Total(Mat m) {
     return m->total();
 }
 
+int Mat_ElemSize(Mat m){
+    return m->elemSize();
+}
+
 void Mat_Size(Mat m, IntVector* res) {
     cv::MatSize ms(m->size);
     int* ids = new int[ms.dims()];

--- a/core.go
+++ b/core.go
@@ -668,6 +668,11 @@ func (m *Mat) Step() int {
 	return int(C.Mat_Step(m.p))
 }
 
+// ElemSize returns the matrix element size in bytes.
+func (m *Mat) ElemSize() int {
+	return int(C.Mat_ElemSize(m.p))
+}
+
 // GetUCharAt returns a value from a specific row/col
 // in this Mat expecting it to be of type uchar aka CV_8U.
 func (m *Mat) GetUCharAt(row int, col int) uint8 {

--- a/core.h
+++ b/core.h
@@ -304,6 +304,7 @@ int Mat_Cols(Mat m);
 int Mat_Channels(Mat m);
 int Mat_Type(Mat m);
 int Mat_Step(Mat m);
+int Mat_ElemSize(Mat m);
 Mat Eye(int rows, int cols, int type);
 Mat Zeros(int rows, int cols, int type);
 Mat Ones(int rows, int cols, int type);

--- a/core_test.go
+++ b/core_test.go
@@ -3020,21 +3020,25 @@ func TestNewPoints3fVector(t *testing.T) {
 
 func TestElemSize(t *testing.T) {
 	m1 := NewMat()
+	defer m1.Close()
 	if m1.ElemSize() != 0 {
 		t.Error("incorrect element size")
 	}
 
 	m2 := NewMatWithSize(2, 2, MatTypeCV16S)
+	defer m2.Close()
 	if m2.ElemSize() != 2 {
 		t.Error("incorrect element size of MatTypeCV16S")
 	}
 
 	m3 := NewMatWithSize(2, 2, MatTypeCV16SC3)
+	defer m3.Close()
 	if m3.ElemSize() != 6 {
 		t.Error("incorrect element size of MatTypeCV16SC3")
 	}
 
 	m4 := NewMatWithSize(2, 2, MatTypeCV32SC4)
+	defer m4.Close()
 	if m4.ElemSize() != 16 {
 		t.Error("incorrect element size of MatTypeCV32SC4")
 		return

--- a/core_test.go
+++ b/core_test.go
@@ -3017,3 +3017,26 @@ func TestNewPoints3fVector(t *testing.T) {
 		t.Fatal("unable to append to Points3fVector")
 	}
 }
+
+func TestElemSize(t *testing.T) {
+	m1 := NewMat()
+	if m1.ElemSize() != 0 {
+		t.Error("incorrect element size")
+	}
+
+	m2 := NewMatWithSize(2, 2, MatTypeCV16S)
+	if m2.ElemSize() != 2 {
+		t.Error("incorrect element size of MatTypeCV16S")
+	}
+
+	m3 := NewMatWithSize(2, 2, MatTypeCV16SC3)
+	if m3.ElemSize() != 6 {
+		t.Error("incorrect element size of MatTypeCV16SC3")
+	}
+
+	m4 := NewMatWithSize(2, 2, MatTypeCV32SC4)
+	if m4.ElemSize() != 16 {
+		t.Error("incorrect element size of MatTypeCV32SC4")
+		return
+	}
+}


### PR DESCRIPTION
This method alongside of `Mat.Total` could help to tell the number of bytes occupied by the matrix.