### PR TITLE
contrib/ximgproc: implement root filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ count.out
 /build
 .idea/
 contrib/data.yaml
+contrib/testOilPainting.png

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -395,6 +395,6 @@ Your pull requests will be greatly appreciated!
 - [ ] viz. 3D Visualizer
 - [X] **wechat_qrcode. WeChat QR code detector for detecting and parsing QR code**
 - [ ] **xfeatures2d. Extra 2D Features Framework - WORK STARTED**
-- [ ] ximgproc. Extended Image Processing
+- [ ] **ximgproc. Extended Image Processing- WORK STARTED**
 - [ ] xobjdetect. Extended object detection
 - [ ] **xphoto. Additional photo processing algorithms - WORK STARTED**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -395,6 +395,6 @@ Your pull requests will be greatly appreciated!
 - [ ] viz. 3D Visualizer
 - [X] **wechat_qrcode. WeChat QR code detector for detecting and parsing QR code**
 - [ ] **xfeatures2d. Extra 2D Features Framework - WORK STARTED**
-- [ ] **ximgproc. Extended Image Processing- WORK STARTED**
+- [ ] **ximgproc. Extended Image Processing - WORK STARTED**
 - [ ] xobjdetect. Extended object detection
 - [ ] **xphoto. Additional photo processing algorithms - WORK STARTED**

--- a/cgo.go
+++ b/cgo.go
@@ -9,6 +9,6 @@ package gocv
 #cgo !windows pkg-config: opencv4
 #cgo CXXFLAGS:   --std=c++11
 #cgo windows  CPPFLAGS:   -IC:/opencv/build/install/include
-#cgo windows  LDFLAGS:    -LC:/opencv/build/install/x64/mingw/lib -lopencv_core455 -lopencv_face455 -lopencv_videoio455 -lopencv_imgproc455 -lopencv_highgui455 -lopencv_imgcodecs455 -lopencv_objdetect455 -lopencv_features2d455 -lopencv_video455 -lopencv_dnn455 -lopencv_xfeatures2d455 -lopencv_plot455 -lopencv_tracking455 -lopencv_img_hash455 -lopencv_calib3d455 -lopencv_bgsegm455 -lopencv_photo455 -lopencv_aruco455 -lopencv_wechat_qrcode455
+#cgo windows  LDFLAGS:    -LC:/opencv/build/install/x64/mingw/lib -lopencv_core455 -lopencv_face455 -lopencv_videoio455 -lopencv_imgproc455 -lopencv_highgui455 -lopencv_imgcodecs455 -lopencv_objdetect455 -lopencv_features2d455 -lopencv_video455 -lopencv_dnn455 -lopencv_xfeatures2d455 -lopencv_plot455 -lopencv_tracking455 -lopencv_img_hash455 -lopencv_calib3d455 -lopencv_bgsegm455 -lopencv_photo455 -lopencv_aruco455 -lopencv_wechat_qrcode455 -lopencv_ximgproc455
 */
 import "C"

--- a/contrib/cgo.go
+++ b/contrib/cgo.go
@@ -9,6 +9,6 @@ package contrib
 #cgo !windows pkg-config: opencv4
 #cgo CXXFLAGS:   --std=c++11
 #cgo windows  CPPFLAGS:   -IC:/opencv/build/install/include
-#cgo windows  LDFLAGS:    -LC:/opencv/build/install/x64/mingw/lib -lopencv_core455 -lopencv_face455 -lopencv_videoio455 -lopencv_imgproc455 -lopencv_highgui455 -lopencv_imgcodecs455 -lopencv_objdetect455 -lopencv_features2d455 -lopencv_video455 -lopencv_dnn455 -lopencv_xfeatures2d455 -lopencv_plot455 -lopencv_tracking455 -lopencv_img_hash455 -lopencv_calib3d455 -lopencv_bgsegm455 -lopencv_xphoto455 -lopencv_aruco455 -lopencv_wechat_qrcode455
+#cgo windows  LDFLAGS:    -LC:/opencv/build/install/x64/mingw/lib -lopencv_core455 -lopencv_face455 -lopencv_videoio455 -lopencv_imgproc455 -lopencv_highgui455 -lopencv_imgcodecs455 -lopencv_objdetect455 -lopencv_features2d455 -lopencv_video455 -lopencv_dnn455 -lopencv_xfeatures2d455 -lopencv_plot455 -lopencv_tracking455 -lopencv_img_hash455 -lopencv_calib3d455 -lopencv_bgsegm455 -lopencv_xphoto455 -lopencv_aruco455 -lopencv_wechat_qrcode455 -lopencv_ximgproc455
 */
 import "C"

--- a/contrib/ximgproc.cpp
+++ b/contrib/ximgproc.cpp
@@ -1,5 +1,9 @@
 #include "ximgproc.h"
 
+void anisotropicDiffusion(Mat src, Mat dst, float alpha, float K, int niters) {
+    cv::ximgproc::anisotropicDiffusion(*src, *dst, alpha, K, niters);	
+}
+
 void edgePreservingFilter(Mat src, Mat dst, int d, float threshold) {
     cv::ximgproc::edgePreservingFilter(*src, *dst, d, threshold);
 }

--- a/contrib/ximgproc.cpp
+++ b/contrib/ximgproc.cpp
@@ -12,6 +12,10 @@ void niBlackThreshold(Mat src, Mat dst, float maxValue, int type, int blockSize,
     cv::ximgproc::niBlackThreshold(*src, *dst, maxValue, type, blockSize, k, binarizationMethod, r);
 }
 
+void PeiLinNormalization(Mat src, Mat dst) {
+    cv::ximgproc::PeiLinNormalization(*src, *dst);
+}
+
 void thinning(Mat src, Mat dst, int typ) {
     cv::ximgproc::thinning(*src, *dst, typ);
 }

--- a/contrib/ximgproc.cpp
+++ b/contrib/ximgproc.cpp
@@ -1,0 +1,13 @@
+#include "ximgproc.h"
+
+void edgePreservingFilter(Mat src, Mat dst, int d, float threshold) {
+    cv::ximgproc::edgePreservingFilter(*src, *dst, d, threshold);
+}
+
+void niBlackThreshold(Mat src, Mat dst, float maxValue, int type, int blockSize, float k, int binarizationMethod, float r) {
+    cv::ximgproc::niBlackThreshold(*src, *dst, maxValue, type, blockSize, k, binarizationMethod, r);
+}
+
+void thinning(Mat src, Mat dst, int typ) {
+    cv::ximgproc::thinning(*src, *dst, typ);
+}

--- a/contrib/ximgproc.go
+++ b/contrib/ximgproc.go
@@ -1,0 +1,60 @@
+package contrib
+
+/*
+#include <stdlib.h>
+#include "ximgproc.h"
+*/
+import "C"
+import (
+	"gocv.io/x/gocv"
+)
+
+// EdgePreservingFilter smoothes an image using the Edge-Preserving filter.
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/df/d2d/group__ximgproc.html#ga86fcda65ced0aafa2741088d82e9161c
+//
+func EdgePreservingFilter(src gocv.Mat, dst *gocv.Mat, d int, threshold float32) {
+	C.edgePreservingFilter(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.int(d), C.float(threshold))
+}
+
+type BinarizationMethod int
+
+const (
+	BinarizationNiblack BinarizationMethod = iota
+	BinarizationSauvola
+	BinarizationWolf
+	BinarizationNICK
+)
+
+// NiblackThreshold performs thresholding on input images using Niblack's technique 
+// or some of the popular variations it inspired.
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/df/d2d/group__ximgproc.html#gab042a5032bbb85275f1fd3e04e7c7660
+//
+func NiblackThreshold(src gocv.Mat, dst *gocv.Mat, maxValue float32,
+	typ gocv.ThresholdType, blockSize int, k float32, binarizationMethod BinarizationMethod, r float32) {
+	C.niBlackThreshold(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.float(maxValue), C.int(typ),
+		C.int(blockSize), C.float(k), C.int(binarizationMethod), C.float(r))
+}
+
+type ThinningType int
+
+const (
+	ThinningZhangSuen ThinningType = iota
+	ThinningGuoHall
+)
+
+// Thinning applies a binary blob thinning operation, to achieve a skeletization 
+// of the input image.
+//
+// The function transforms a binary blob image into a skeletized form using the
+// technique of Zhang-Suen.
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/df/d2d/group__ximgproc.html#ga37002c6ca80c978edb6ead5d6b39740c
+//
+func Thinning(src gocv.Mat, dst *gocv.Mat, typ ThinningType) {
+	C.thinning(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.int(typ))
+}

--- a/contrib/ximgproc.go
+++ b/contrib/ximgproc.go
@@ -9,6 +9,17 @@ import (
 	"gocv.io/x/gocv"
 )
 
+// AnisotropicDiffusion performs anisotropic diffusion on an image.
+//
+// The function applies Perona-Malik anisotropic diffusion to an image.
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/df/d2d/group__ximgproc.html#gaffedd976e0a8efb5938107acab185ec2
+//
+func AnisotropicDiffusion(src gocv.Mat, dst *gocv.Mat, alpha float32, k float32, niters int) {
+	C.anisotropicDiffusion(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.float(alpha), C.float(k), C.int(niters))
+}
+
 // EdgePreservingFilter smoothes an image using the Edge-Preserving filter.
 //
 // For further details, please see:

--- a/contrib/ximgproc.go
+++ b/contrib/ximgproc.go
@@ -50,6 +50,16 @@ func NiblackThreshold(src gocv.Mat, dst *gocv.Mat, maxValue float32,
 		C.int(blockSize), C.float(k), C.int(binarizationMethod), C.float(r))
 }
 
+// PeiLinNormalization calculates an affine transformation that normalize
+// given image using Pei&Lin Normalization.
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/df/d2d/group__ximgproc.html#ga50d064b92f63916f4162474eea22d656
+//
+func PeiLinNormalization(src gocv.Mat, dst *gocv.Mat) {
+	C.PeiLinNormalization(C.Mat(src.Ptr()), C.Mat(dst.Ptr()))
+}
+
 type ThinningType int
 
 const (

--- a/contrib/ximgproc.h
+++ b/contrib/ximgproc.h
@@ -1,0 +1,20 @@
+#ifndef _OPENCV3_XIMGPROC_H_
+#define _OPENCV3_XIMGPROC_H_
+
+#ifdef __cplusplus
+#include <opencv2/opencv.hpp>
+#include <opencv2/ximgproc.hpp>
+extern "C" {
+#endif
+
+#include "../core.h"
+
+void edgePreservingFilter(Mat src, Mat dst, int d, float threshold);
+void niBlackThreshold(Mat src, Mat dst, float maxValue, int type, int blockSize, float k, int binarizationMethod, float r);
+void thinning(Mat src, Mat dst, int typ);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //_OPENCV3_XIMGPROC_H

--- a/contrib/ximgproc.h
+++ b/contrib/ximgproc.h
@@ -9,6 +9,7 @@ extern "C" {
 
 #include "../core.h"
 
+void anisotropicDiffusion(Mat src, Mat dst, float alpha, float K, int niters);
 void edgePreservingFilter(Mat src, Mat dst, int d, float threshold);
 void niBlackThreshold(Mat src, Mat dst, float maxValue, int type, int blockSize, float k, int binarizationMethod, float r);
 void thinning(Mat src, Mat dst, int typ);

--- a/contrib/ximgproc.h
+++ b/contrib/ximgproc.h
@@ -12,6 +12,7 @@ extern "C" {
 void anisotropicDiffusion(Mat src, Mat dst, float alpha, float K, int niters);
 void edgePreservingFilter(Mat src, Mat dst, int d, float threshold);
 void niBlackThreshold(Mat src, Mat dst, float maxValue, int type, int blockSize, float k, int binarizationMethod, float r);
+void PeiLinNormalization(Mat src, Mat dst);
 void thinning(Mat src, Mat dst, int typ);
 
 #ifdef __cplusplus

--- a/contrib/ximgproc_test.go
+++ b/contrib/ximgproc_test.go
@@ -5,6 +5,19 @@ import (
 	"testing"
 )
 
+func TestAnisotropicDiffusion(t *testing.T) {
+	src := gocv.NewMatWithSize(200, 200, gocv.MatTypeCV8UC3)
+	defer src.Close()
+	dst := gocv.NewMat()
+	defer dst.Close()
+
+	AnisotropicDiffusion(src, &dst, 0.5, 0.5, 100)
+
+	if src.Empty() || dst.Rows() != src.Rows() {
+		t.Error("invalid AnisotropicDiffusion test")
+	}
+}
+
 func TestEdgePreservingFilter(t *testing.T) {
 	src := gocv.NewMatWithSize(200, 200, gocv.MatTypeCV8UC3)
 	defer src.Close()

--- a/contrib/ximgproc_test.go
+++ b/contrib/ximgproc_test.go
@@ -44,6 +44,19 @@ func TestNiblackThreshold(t *testing.T) {
 	}
 }
 
+func TestPeiLinNormalization(t *testing.T) {
+	src := gocv.NewMatWithSize(200, 200, gocv.MatTypeCV8UC1)
+	defer src.Close()
+	dst := gocv.NewMat()
+	defer dst.Close()
+
+	PeiLinNormalization(src, &dst)
+
+	if src.Empty() || dst.Rows() != 2 || dst.Cols() != 3 {
+		t.Error("invalid PeiLinNormalization test", dst.Rows(), dst.Cols())
+	}
+}
+
 func TestThinning(t *testing.T) {
 	src := gocv.NewMatWithSize(200, 200, gocv.MatTypeCV8UC1)
 	defer src.Close()

--- a/contrib/ximgproc_test.go
+++ b/contrib/ximgproc_test.go
@@ -1,0 +1,45 @@
+package contrib
+
+import (
+	"gocv.io/x/gocv"
+	"testing"
+)
+
+func TestEdgePreservingFilter(t *testing.T) {
+	src := gocv.NewMatWithSize(200, 200, gocv.MatTypeCV8UC3)
+	defer src.Close()
+	dst := gocv.NewMat()
+	defer dst.Close()
+
+	EdgePreservingFilter(src, &dst, 3, 0.5)
+
+	if src.Empty() || dst.Rows() != src.Rows() {
+		t.Error("invalid EdgePreservingFilter test")
+	}
+}
+
+func TestNiblackThreshold(t *testing.T) {
+	src := gocv.NewMatWithSize(200, 200, gocv.MatTypeCV8UC1)
+	defer src.Close()
+	dst := gocv.NewMat()
+	defer dst.Close()
+
+	NiblackThreshold(src, &dst, 127.0, gocv.ThresholdBinary, 3, 0.5, BinarizationNiblack, 128)
+
+	if src.Empty() || dst.Rows() != src.Rows() {
+		t.Error("invalid NiblackThreshold test")
+	}
+}
+
+func TestThinning(t *testing.T) {
+	src := gocv.NewMatWithSize(200, 200, gocv.MatTypeCV8UC1)
+	defer src.Close()
+	dst := gocv.NewMat()
+	defer dst.Close()
+
+	Thinning(src, &dst, ThinningZhangSuen)
+
+	if src.Empty() || dst.Rows() != src.Rows() {
+		t.Error("invalid Thinning test")
+	}
+}

--- a/cuda/cgo.go
+++ b/cuda/cgo.go
@@ -9,6 +9,6 @@ package cuda
 #cgo !windows pkg-config: opencv4
 #cgo CXXFLAGS:   --std=c++11
 #cgo windows  CPPFLAGS:   -IC:/opencv/build/install/include
-#cgo windows  LDFLAGS:    -LC:/opencv/build/install/x64/mingw/lib -lopencv_core455 -lopencv_face455 -lopencv_videoio455 -lopencv_imgproc455 -lopencv_highgui455 -lopencv_imgcodecs455 -lopencv_objdetect455 -lopencv_features2d455 -lopencv_video455 -lopencv_dnn455 -lopencv_xfeatures2d455 -lopencv_plot455 -lopencv_tracking455 -lopencv_img_hash455 -lopencv_calib3d455 -lopencv_bgsegm455 -lopencv_aruco455 -lopencv_wechat_qrcode455
+#cgo windows  LDFLAGS:    -LC:/opencv/build/install/x64/mingw/lib -lopencv_core455 -lopencv_face455 -lopencv_videoio455 -lopencv_imgproc455 -lopencv_highgui455 -lopencv_imgcodecs455 -lopencv_objdetect455 -lopencv_features2d455 -lopencv_video455 -lopencv_dnn455 -lopencv_xfeatures2d455 -lopencv_plot455 -lopencv_tracking455 -lopencv_img_hash455 -lopencv_calib3d455 -lopencv_bgsegm455 -lopencv_aruco455 -lopencv_wechat_qrcode455 -lopencv_ximgproc455
 */
 import "C"


### PR DESCRIPTION
This PR implements the following filters from the `contrib/ximgproc` module:

- `AnisotropicDiffusion()`
- `edgePreservingFilter()`
- `niBlackThreshold()`
- `PeiLinNormalization()`
- `thinning()` 
