### PR TITLE
Upgrade to openvino 2022.1

### DIFF
--- a/Dockerfile.opencv-openvino
+++ b/Dockerfile.opencv-openvino
@@ -1,0 +1,57 @@
+# to build this docker image:
+#   docker build -f Dockerfile.opencv-openvino -t gocv/opencv:4.6.0-openvino
+FROM openvino/ubuntu20_dev:2022.1.0 AS opencv-openvino-base
+LABEL maintainer="hybridgroup"
+ENV DEBIAN_FRONTEND=noninteractive
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+            git build-essential cmake pkg-config unzip libgtk2.0-dev \
+            wget curl ca-certificates libcurl4-openssl-dev libssl-dev \
+            libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev \
+            libjpeg-dev libpng-dev libtiff-dev libdc1394-22-dev && \
+            rm -rf /var/lib/apt/lists/*
+
+ARG OPENCV_VERSION="4.6.0"
+ENV OPENCV_VERSION $OPENCV_VERSION
+
+RUN curl -Lo opencv.zip https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.zip && \
+    unzip -q opencv.zip && \
+    curl -Lo opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/${OPENCV_VERSION}.zip && \
+    unzip -q opencv_contrib.zip && \
+    rm opencv.zip opencv_contrib.zip && \
+    cd opencv-${OPENCV_VERSION} && \
+    mkdir build && cd build && \
+    cmake -D CMAKE_BUILD_TYPE=RELEASE \
+            -D WITH_IPP=OFF \
+            -D WITH_OPENGL=OFF \
+            -D WITH_QT=OFF \
+            -D CMAKE_INSTALL_PREFIX=/usr/local \
+            -D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib-${OPENCV_VERSION}/modules \
+            -D OPENCV_ENABLE_NONFREE=ON \
+            -D WITH_JASPER=OFF \
+            -D BUILD_DOCS=OFF \
+            -D BUILD_EXAMPLES=OFF \
+            -D BUILD_TESTS=OFF \
+            -D BUILD_PERF_TESTS=OFF \
+            -D BUILD_opencv_java=NO \
+            -D BUILD_opencv_python=NO \
+            -D BUILD_opencv_python2=NO \
+            -D BUILD_opencv_python3=NO \
+            -D WITH_TBB=ON \
+            -D WITH_OPENVINO=1 \
+            -D ENABLE_FAST_MATH=1 \
+            -D OPENCV_GENERATE_PKGCONFIG=ON .. && \
+    make -j $(nproc --all) && \
+    make preinstall && make install && ldconfig && \
+    cd / && rm -rf opencv*
+
+# install golang here
+FROM opencv-openvino-base AS opencv-openvino-golang
+
+ENV GO_RELEASE=1.18.3
+RUN wget https://dl.google.com/go/go${GO_RELEASE}.linux-amd64.tar.gz && \
+    tar xfv go${GO_RELEASE}.linux-amd64.tar.gz -C /usr/local && \
+    rm go${GO_RELEASE}.linux-amd64.tar.gz
+ENV PATH="${PATH}:/usr/local/go/bin"
+USER openvino
+CMD ["go version"]

--- a/openvino/README.md
+++ b/openvino/README.md
@@ -1,13 +1,13 @@
 # Using the Intel® Distribution of OpenVINO™ toolkit
 
-The [Intel® Distribution of OpenVINO™ toolkit](https://software.intel.com/en-us/openvino-toolkit) is a set of tools and libraries for computer vision applications, that uses computer vision and imaging algorithms developed at Intel. It also includes a complete build of OpenCV 4.6.0.
+The [Intel® Distribution of OpenVINO™ toolkit](https://software.intel.com/en-us/openvino-toolkit) is a set of tools and libraries for computer vision applications, that uses computer vision and imaging algorithms developed at Intel. It also includes a complete build of OpenCV 4.5.5.
 
 GoCV supports using the Intel GPU or Intel OpenVINO Inference Engine as a backend for the OpenCV deep neural network (DNN) module. For details, please see:
 https://github.com/hybridgroup/gocv/blob/release/openvino/ie/README.md
 
 ## Installing Intel OpenVINO toolkit
 
-The most recent version of the Intel OpenVINO toolkit is currently 2021.4.2 LTS. You can obtain it from here:
+The most recent version of the Intel OpenVINO toolkit is currently 2022.1 LTS. You can obtain it from here:
 
 https://software.intel.com/en-us/openvino-toolkit
 
@@ -18,7 +18,7 @@ One you have downloaded the compressed file, unzip the contents, and then run th
 Setup the environment for the Intel OpenVINO toolkit, by running the `setupvars.sh` program included with OpenVINO:
 
 ```
-source /opt/intel/openvino_2021/bin/setupvars.sh
+source /opt/intel/openvino_2022/setupvars.sh
 ```
 
 Then set the needed other exports for building/running GoCV code by running the `env.sh` that is in the GoCV `openvino` directory:
@@ -31,10 +31,10 @@ You only need to do these two steps one time per session. Once you have run them
 
 Now you can run the version command example to make sure you are compiling/linking against Intel OpenVINO:
 
-```
-$ go run -tags customenv ./cmd/version/main.go 
+```shell
+$ go run -tags customenv  cmd/version/main.go
 gocv version: 0.31.0
-opencv lib version: 4.6.0-openvino
+opencv lib version: 4.5.5-openvino
 ```
 
 Note the use of `-tags customenv` is needed when using `go run`, `go build`, and `go test` with OpenVINO, so the CGo compiler can pickup the correct settings for the environment, and ignore the usual defaults.

--- a/openvino/README.md
+++ b/openvino/README.md
@@ -1,6 +1,6 @@
 # Using the Intel® Distribution of OpenVINO™ toolkit
 
-The [Intel® Distribution of OpenVINO™ toolkit](https://software.intel.com/en-us/openvino-toolkit) is a set of tools and libraries for computer vision applications, that uses computer vision and imaging algorithms developed at Intel. It also includes a complete build of OpenCV 4.5.5.
+The [Intel® Distribution of OpenVINO™ toolkit](https://software.intel.com/en-us/openvino-toolkit) is a set of tools and libraries for computer vision applications, that uses computer vision and imaging algorithms developed at Intel. It also includes a complete build of OpenCV 4.5.5. Users must build opencv from source with openvino support to use a newer opencv version (eg. 4.6.0).
 
 GoCV supports using the Intel GPU or Intel OpenVINO Inference Engine as a backend for the OpenCV deep neural network (DNN) module. For details, please see:
 https://github.com/hybridgroup/gocv/blob/release/openvino/ie/README.md
@@ -31,8 +31,8 @@ You only need to do these two steps one time per session. Once you have run them
 
 Now you can run the version command example to make sure you are compiling/linking against Intel OpenVINO:
 
-```shell
-$ go run -tags customenv  cmd/version/main.go
+```
+$ go run -tags customenv  ./cmd/version/main.go
 gocv version: 0.31.0
 opencv lib version: 4.5.5-openvino
 ```

--- a/openvino/env.sh
+++ b/openvino/env.sh
@@ -1,4 +1,4 @@
 export CGO_CXXFLAGS="--std=c++11"
-export CGO_CPPFLAGS="-I${INTEL_CVSDK_DIR}/opencv/include -I${INTEL_CVSDK_DIR}/deployment_tools/inference_engine/include"
-export CGO_LDFLAGS="-L${INTEL_CVSDK_DIR}/opencv/lib -L${INTEL_CVSDK_DIR}/deployment_tools/inference_engine/lib/intel64 -lpthread -ldl -linference_engine -lopencv_core -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_calib3d -lopencv_photo"
+export CGO_CPPFLAGS="-I${INTEL_OPENVINO_DIR}/extras/opencv/include -I${INTEL_OPENVINO_DIR}/runtime/include -I${INTEL_OPENVINO_DIR}/runtime/include/ie"
+export CGO_LDFLAGS="-L${INTEL_OPENVINO_DIR}/extras/opencv/lib -L${INTEL_OPENVINO_DIR}/runtime/lib/intel64 -lpthread -ldl -lopenvino -lopencv_core -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_features2d -lopencv_video -lopencv_dnn -lopencv_calib3d -lopencv_photo"
 export PKG_CONFIG_PATH=/usr/lib64/pkgconfig

--- a/openvino/ie/inference_engine.cpp
+++ b/openvino/ie/inference_engine.cpp
@@ -1,11 +1,18 @@
 #include "inference_engine.h"
 
 const char* OpenVinoVersion() {
-    std::ostringstream res;
-    res << std::to_string(InferenceEngine::GetInferenceEngineVersion()->apiVersion.major) 
+    std::ostringstream buf;
+    buf << std::to_string(InferenceEngine::GetInferenceEngineVersion()->apiVersion.major) 
         << "." 
         << std::to_string(InferenceEngine::GetInferenceEngineVersion()->apiVersion.minor)
         << "." 
         << InferenceEngine::GetInferenceEngineVersion()->buildNumber;
-    return res.str().c_str();
+    auto version = buf.str();
+
+    size_t resLen = version.size() + 1;
+    auto res = (char*)malloc(resLen);
+
+    memset(res ,0, resLen);
+    memcpy(res, version.c_str(), resLen);
+    return res;
 }

--- a/openvino/ie/inference_engine.go
+++ b/openvino/ie/inference_engine.go
@@ -7,8 +7,11 @@ package ie
 import (
 	"C"
 )
+import "unsafe"
 
 // Version returns the current Inference Engine library version
 func Version() string {
-	return C.GoString(C.OpenVinoVersion())
+	v := C.OpenVinoVersion()
+	defer C.free(unsafe.Pointer(v))
+	return C.GoString(v)
 }

--- a/openvino/ie/inference_engine_test.go
+++ b/openvino/ie/inference_engine_test.go
@@ -1,12 +1,22 @@
 package ie
 
 import (
+	"strings"
 	"testing"
 )
 
 func TestInferenceEngineVersion(t *testing.T) {
-	if Version() == "" {
+	v := Version()
+	expected := "2022.1"
+	if v == "" || len(v) < len(expected) {
 		t.Error("Invalid IE Version")
 		return
+	}
+
+	// Different platforms can have different strings, only warn if expected
+	// version string does not match.
+	// eg. archlinux: 2.1.custom_makepkg_cdb9bec7210f8c24fde3e416c7ada820faaaa23e
+	if !strings.Contains(v, expected) {
+		t.Log("Unexpected IE Version: ", v)
 	}
 }


### PR DESCRIPTION
* Updated `env.sh` to use the latest openvino release (`2022.1`)
* Fixed issue with `OpenvinoVersion` returning a dangling pointer, resulting in garbage data being printed when executing`go run cmd/openvino/ie/version/main.go`.
* Updated openvino `README.md`
---
OpenVinoVersion output from `opencv-openvino` Docker image:
```
$ go run cmd/openvino/ie/version/main.go 
gocv version: 0.31.0
OpenVINO Inference Engine version: 2.1.2022.1.0-7019-cdb9bec7210-releases/2022/1
```

OpenVinoVersion output on archlinux:
```
$ go run cmd/openvino/ie/version/main.go
gocv version: 0.31.0
OpenVINO Inference Engine version: 2.1.custom_makepkg_cdb9bec7210f8c24fde3e416c7ada820faaaa23e

```