### PR TITLE
add EstimateAffinePartial2DWithParams()

### DIFF
--- a/calib3d.cpp
+++ b/calib3d.cpp
@@ -73,6 +73,10 @@ Mat EstimateAffinePartial2D(Point2fVector from, Point2fVector to) {
     return new cv::Mat(cv::estimateAffinePartial2D(*from, *to));
 }
 
+Mat EstimateAffinePartial2DWithParams(Point2fVector from, Point2fVector to, Mat inliers, int method, double ransacReprojThreshold, size_t maxIters, double confidence, size_t refineIters) {
+    return new cv::Mat(cv::estimateAffinePartial2D(*from, *to, *inliers, method, ransacReprojThreshold, maxIters, confidence, refineIters));
+}
+
 Mat EstimateAffine2D(Point2fVector from, Point2fVector to) {
     return new cv::Mat(cv::estimateAffine2D(*from, *to));
 }

--- a/calib3d.go
+++ b/calib3d.go
@@ -238,6 +238,16 @@ func EstimateAffinePartial2D(from, to Point2fVector) Mat {
 	return newMat(C.EstimateAffinePartial2D(from.p, to.p))
 }
 
+// EstimateAffinePartial2DWithParams computes an optimal limited affine transformation
+// with 4 degrees of freedom between two 2D point sets
+// with additional optional parameters.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d9/d0c/group__calib3d.html#gad767faff73e9cbd8b9d92b955b50062d
+func EstimateAffinePartial2DWithParams(from Point2fVector, to Point2fVector, inliers Mat, method int, ransacReprojThreshold float64, maxIters uint, confidence float64, refineIters uint) Mat {
+	return newMat(C.EstimateAffinePartial2DWithParams(from.p, to.p, inliers.p, C.int(method), C.double(ransacReprojThreshold), C.size_t(maxIters), C.double(confidence), C.size_t(refineIters)))
+}
+
 // EstimateAffine2D Computes an optimal affine transformation between two 2D point sets.
 //
 // For further details, please see:

--- a/calib3d.h
+++ b/calib3d.h
@@ -27,6 +27,7 @@ bool FindChessboardCornersSB(Mat image, Size patternSize, Mat corners, int flags
 bool FindChessboardCornersSBWithMeta(Mat image, Size patternSize, Mat corners, int flags, Mat meta);
 void DrawChessboardCorners(Mat image, Size patternSize, Mat corners, bool patternWasFound);
 Mat EstimateAffinePartial2D(Point2fVector from, Point2fVector to);
+Mat EstimateAffinePartial2DWithParams(Point2fVector from, Point2fVector to, Mat inliers, int method, double ransacReprojThreshold, size_t maxIters, double confidence, size_t refineIters);
 Mat EstimateAffine2D(Point2fVector from, Point2fVector to);
 Mat EstimateAffine2DWithParams(Point2fVector from, Point2fVector to, Mat inliers, int method, double ransacReprojThreshold, size_t maxIters, double confidence, size_t refineIters);
 #ifdef __cplusplus

--- a/calib3d_test.go
+++ b/calib3d_test.go
@@ -557,6 +557,46 @@ func TestEstimateAffinePartial2D(t *testing.T) {
 	}
 }
 
+func TestEstimateAffinePartial2DWithParams(t *testing.T) {
+	src := []Point2f{
+		{0, 0},
+		{10, 5},
+		{10, 10},
+		{5, 10},
+	}
+
+	dst := []Point2f{
+		{0, 0},
+		{10, 0},
+		{10, 10},
+		{0, 10},
+	}
+
+	pvsrc := NewPoint2fVectorFromPoints(src)
+	defer pvsrc.Close()
+
+	pvdst := NewPoint2fVectorFromPoints(dst)
+	defer pvdst.Close()
+
+	inliers := NewMat()
+	defer inliers.Close()
+	method := 8
+	ransacProjThreshold := 3.0
+	maxiters := uint(2000)
+	confidence := 0.99
+	refineIters := uint(10)
+
+	m := EstimateAffinePartial2DWithParams(pvsrc, pvdst, inliers, method, ransacProjThreshold, maxiters, confidence, refineIters)
+	defer m.Close()
+
+	if m.Cols() != 3 {
+		t.Errorf("TestEstimateAffinePartial2D(): unexpected cols = %v, want = %v", m.Cols(), 3)
+	}
+	if m.Rows() != 2 {
+		t.Errorf("TestEstimateAffinePartial2D(): unexpected rows = %v, want = %v", m.Rows(), 2)
+	}
+}
+
 func TestEstimateAffine2D(t *testing.T) {
 	src := []Point2f{
 		{0, 0},


### PR DESCRIPTION
EstimateAffinePartial2DWithParams() is required in my arcface-go repo. I have to borrow some code from gocv to implement it, see https://github.com/jack139/arcface-go. 