### PR TITLE
Add the number of thread setter and getter

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -1145,3 +1145,10 @@ void Points3fVector_Close(Points3fVector ps) {
     delete ps;
 }
 
+void SetNumThreads(int n) {
+    cv::setNumThreads(n);
+}
+
+int GetNumThreads() {
+    return cv::getNumThreads();
+}

--- a/core.go
+++ b/core.go
@@ -2815,3 +2815,13 @@ func (pvs Points3fVector) Append(pv Point3fVector) {
 func (pvs Points3fVector) Close() {
 	C.Points3fVector_Close(pvs.p)
 }
+
+// Set the number of threads for OpenCV.
+func SetNumThreads(n int) {
+	C.SetNumThreads(C.int(n))
+}
+
+// Get the number of threads for OpenCV.
+func GetNumThreads() int {
+	return int(C.GetNumThreads())
+}

--- a/core.h
+++ b/core.h
@@ -512,6 +512,9 @@ Point3fVector Points3fVector_At(Points3fVector ps, int idx);
 void Points3fVector_Append(Points3fVector psv, Point3fVector pv);
 void Points3fVector_Close(Points3fVector ps);
 
+void SetNumThreads(int n);
+int GetNumThreads();
+
 #ifdef __cplusplus
 }
 #endif

--- a/core_test.go
+++ b/core_test.go
@@ -3044,3 +3044,24 @@ func TestElemSize(t *testing.T) {
 		return
 	}
 }
+
+func TestSetThreadNumber(t *testing.T) {
+	N := GetNumThreads()
+
+	SetNumThreads(-1)
+	if GetNumThreads() != N {
+		t.Error("incorrect thread number")
+	}
+
+	SetNumThreads(0)
+	if GetNumThreads() != N {
+		t.Error("incorrect thread number")
+	}
+
+	SetNumThreads(1)
+	if GetNumThreads() != 1 {
+		t.Error("incorrect thread number")
+	}
+
+	SetNumThreads(N)
+}


### PR DESCRIPTION
Suggested in #592.

## What I have done
- `gocv.SetNumThreads` that calls `cv::setNumThreads`
- `gocv.SetNumThreads` that calls `cv::getNumThreads`
- Unit test.

## Test
```go
// test/test.go
package main

import (
    "fmt"
    "gocv.io/x/gocv"
)


func main() {
    fmt.Printf("%d\n", gocv.GetNumThreads())
    gocv.SetNumThreads(0)
    fmt.Printf("%d\n", gocv.GetNumThreads())
    gocv.SetNumThreads(1)
    fmt.Printf("%d\n", gocv.GetNumThreads())
    gocv.SetNumThreads(2)
    fmt.Printf("%d\n", gocv.GetNumThreads())
    gocv.SetNumThreads(-1)
    fmt.Printf("%d\n", gocv.GetNumThreads())
}
```

Result:
```bash
$ go run test/test.go
10
10
1
2
10
```