### PR TITLE
Remove opencv2/aruco.hpp include

### DIFF
--- a/aruco.h
+++ b/aruco.h
@@ -3,7 +3,6 @@
 
 #ifdef __cplusplus
 #include <opencv2/opencv.hpp>
-#include <opencv2/aruco.hpp>
 extern "C" {
 #endif
 


### PR DESCRIPTION
`opencv/aruco.hpp` is still part of `opencv_contrib` in OpenCV 4.7.0. (related to #1045)

We only use core functions and don't have `opencv_contrib` as part of our build process. When attempting to update to gocv 0.32.1/OpenCV 4.7.0 we encountered the error: `aruco.h:6:10: fatal error: opencv2/aruco.hpp: No such file or directory`. Including only `opencv2/opencv.hpp` appears sufficient.

Though we don't use the aruco, `make test` passes with this change.