### PR TITLE
Gosec fixes

### DIFF
--- a/cmd/caffe-classifier/main.go
+++ b/cmd/caffe-classifier/main.go
@@ -29,6 +29,7 @@ import (
 	"image"
 	"image/color"
 	"os"
+	"path/filepath"
 
 	"gocv.io/x/gocv"
 )
@@ -130,11 +131,13 @@ func main() {
 // readDescriptions reads the descriptions from a file
 // and returns a slice of its lines.
 func readDescriptions(path string) ([]string, error) {
-	file, err := os.Open(path)
+	file, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	var lines []string
 	scanner := bufio.NewScanner(file)

--- a/cmd/facedetect-from-url/main.go
+++ b/cmd/facedetect-from-url/main.go
@@ -48,6 +48,7 @@ func main() {
 	}
 
 	// get image from URL
+	// #nosec
 	res, err := http.Get(imageURL)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/mjpeg-streamer/main.go
+++ b/cmd/mjpeg-streamer/main.go
@@ -20,8 +20,7 @@ import (
 	"log"
 	"net/http"
 	"os"
-
-	_ "net/http/pprof"
+	"time"
 
 	"github.com/hybridgroup/mjpeg"
 	"gocv.io/x/gocv"
@@ -62,7 +61,14 @@ func main() {
 
 	// start http server
 	http.Handle("/", stream)
-	log.Fatal(http.ListenAndServe(host, nil))
+
+	server := &http.Server{
+		Addr:         host,
+		ReadTimeout:  60 * time.Second,
+		WriteTimeout: 60 * time.Second,
+	}
+
+	log.Fatal(server.ListenAndServe())
 }
 
 func mjpegCapture() {

--- a/cmd/tf-classifier/main.go
+++ b/cmd/tf-classifier/main.go
@@ -23,6 +23,7 @@ import (
 	"image"
 	"image/color"
 	"os"
+	"path/filepath"
 
 	"gocv.io/x/gocv"
 )
@@ -127,11 +128,13 @@ func main() {
 // readDescriptions reads the descriptions from a file
 // and returns a slice of its lines.
 func readDescriptions(path string) ([]string, error) {
-	file, err := os.Open(path)
+	file, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	var lines []string
 	scanner := bufio.NewScanner(file)


### PR DESCRIPTION
Fixing potential vulnerabilities (medium and above), according to GoSec

- [x] gocv/cmd/mjpeg-streamer/main.go:24] - G108 (CWE-200): Profiling endpoint is automatically exposed on /debug/pprof (Confidence: HIGH, Severity: HIGH)
- [x] gocv/cmd/mjpeg-streamer/main.go:65] - G114 (CWE-676): Use of net/http serve function that has no support for setting timeouts (Confidence: HIGH, Severity: MEDIUM)
- [x] gocv/cmd/tf-classifier/main.go:130] - G304 (CWE-22): Potential file inclusion via variable (Confidence: HIGH, Severity: MEDIUM)
- [x] gocv/cmd/caffe-classifier/main.go:133] - G304 (CWE-22): Potential file inclusion via variable (Confidence: HIGH, Severity: MEDIUM)
- [ ] gocv/cmd/facedetect-from-url/main.go:51] - G107 (CWE-88): Potential HTTP request made with variable url (Confidence: MEDIUM, Severity: MEDIUM) - **Ignored, since the code implies a blind request for the transmitted URL**
- [x] gocv/cmd/tf-classifier/main.go:134] - G307 (CWE-703): Deferring unsafe method "Close" on type "*os.File" (Confidence: HIGH, Severity: MEDIUM)
- [x] gocv/cmd/caffe-classifier/main.go:137] - G307 (CWE-703): Deferring unsafe method "Close" on type "*os.File" (Confidence: HIGH, Severity: MEDIUM)