### PR TITLE
docker: OpenCV base image with Ubuntu 22.04

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -289,3 +289,49 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  opencv-ubuntu-22-04:
+    name: opencv-ubuntu-22-04
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            gocv/opencv:4.7.0-ubuntu-22.04
+            ghcr.io/${{ github.repository_owner }}/opencv:4.7.0-ubuntu-22.04
+          tags: |
+            type=sha,format=long
+            type=raw,value=latest
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Log in to Github Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          file: Dockerfile.opencv-ubuntu-22.04
+          platforms: linux/amd64
+          context: .
+          push: true
+          tags: |
+            gocv/opencv:4.7.0-ubuntu-22.04
+            ghcr.io/${{ github.repository_owner }}/opencv:4.7.0-ubuntu-22.04
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile.opencv-ubuntu-22.04
+++ b/Dockerfile.opencv-ubuntu-22.04
@@ -1,0 +1,58 @@
+# to build this docker image:
+#   docker build -f Dockerfile.opencv-ubuntu-22.04 -t ghcr.io/hybridgroup/opencv:4.7.0-ubuntu-22.04 .
+#   docker build --build-arg OPENCV_VERSION="4.x" --build-arg OPENCV_FILE="https://github.com/opencv/opencv/archive/refs/heads/4.x.zip" --build-arg OPENCV_CONTRIB_FILE="https://github.com/opencv/opencv_contrib/archive/refs/heads/4.x.zip" -f Dockerfile.opencv-ubuntu-20.04 -t ghcr.io/hybridgroup/opencv:4.8.0-dev-ubuntu-20.04 .
+FROM ubuntu:22.04 AS opencv-base
+LABEL maintainer="hybridgroup"
+
+ENV TZ=Europe/Madrid
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+            tzdata git build-essential cmake pkg-config wget unzip libgtk2.0-dev \
+            curl ca-certificates libcurl4-openssl-dev libssl-dev \
+            libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev \
+            libjpeg-turbo8-dev libpng-dev libtiff-dev libdc1394-dev nasm && \
+            rm -rf /var/lib/apt/lists/*
+
+ARG OPENCV_VERSION="4.7.0"
+ENV OPENCV_VERSION $OPENCV_VERSION
+
+ARG OPENCV_FILE="https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.zip"
+ENV OPENCV_FILE $OPENCV_FILE
+
+ARG OPENCV_CONTRIB_FILE="https://github.com/opencv/opencv_contrib/archive/${OPENCV_VERSION}.zip"
+ENV OPENCV_CONTRIB_FILE $OPENCV_CONTRIB_FILE
+
+RUN curl -Lo opencv.zip ${OPENCV_FILE} && \
+            unzip -q opencv.zip && \
+            curl -Lo opencv_contrib.zip ${OPENCV_CONTRIB_FILE} && \
+            unzip -q opencv_contrib.zip && \
+            rm opencv.zip opencv_contrib.zip && \
+            cd opencv-${OPENCV_VERSION} && \
+            mkdir build && cd build && \
+            cmake -D CMAKE_BUILD_TYPE=RELEASE \
+                  -D WITH_IPP=OFF \
+                  -D WITH_OPENGL=OFF \
+                  -D WITH_QT=OFF \
+                  -D CMAKE_INSTALL_PREFIX=/usr/local \
+                  -D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib-${OPENCV_VERSION}/modules \
+                  -D OPENCV_ENABLE_NONFREE=ON \
+                  -D WITH_JASPER=OFF \
+                  -D WITH_TBB=ON \
+                  -D BUILD_JPEG=ON \
+                  -D WITH_SIMD=ON \
+                  -D ENABLE_LIBJPEG_TURBO_SIMD=ON \
+                  -D BUILD_DOCS=OFF \
+                  -D BUILD_EXAMPLES=OFF \
+                  -D BUILD_TESTS=OFF \
+                  -D BUILD_PERF_TESTS=ON \
+                  -D BUILD_opencv_java=NO \
+                  -D BUILD_opencv_python=NO \
+                  -D BUILD_opencv_python2=NO \
+                  -D BUILD_opencv_python3=NO \
+                  -D OPENCV_GENERATE_PKGCONFIG=ON .. && \
+            make -j $(nproc --all) && \
+            make preinstall && make install && ldconfig && \
+            cd / && rm -rf opencv*
+
+CMD ["opencv_version", "-b"]


### PR DESCRIPTION
This PR adds a docker base image with OpenCV 4.7.0 that uses Ubuntu 22.04 as the base image.