### PR TITLE
Fixes parameter ordering for new PCACompute function

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -504,8 +504,8 @@ void Mat_EigenNonSymmetric(Mat src, Mat eigenvalues, Mat eigenvectors) {
     cv::eigenNonSymmetric(*src, *eigenvalues, *eigenvectors);
 }
 
-void Mat_PCACompute(Mat src, Mat mean, Mat eigenvalues, Mat eigenvectors, int maxComponents) {
-    cv::PCACompute(*src, *mean, *eigenvalues, *eigenvectors, maxComponents);
+void Mat_PCACompute(Mat src, Mat mean, Mat eigenvectors, Mat eigenvalues, int maxComponents) {
+    cv::PCACompute(*src, *mean, *eigenvectors, *eigenvalues, maxComponents);
 }
 
 void Mat_Exp(Mat src, Mat dst) {

--- a/core.go
+++ b/core.go
@@ -1229,8 +1229,8 @@ func EigenNonSymmetric(src Mat, eigenvalues *Mat, eigenvectors *Mat) {
 // For further details, please see:
 // https://docs.opencv.org/4.x/d2/de8/group__core__array.html#ga27a565b31d820b05dcbcd47112176b6e
 //
-func PCACompute(src Mat, mean *Mat, eigenvalues *Mat, eigenvectors *Mat, maxComponents int) {
-	C.Mat_PCACompute(src.p, mean.p, eigenvalues.p, eigenvectors.p, C.int(maxComponents))
+func PCACompute(src Mat, mean *Mat, eigenvectors *Mat, eigenvalues *Mat, maxComponents int) {
+	C.Mat_PCACompute(src.p, mean.p, eigenvectors.p, eigenvalues.p, C.int(maxComponents))
 }
 
 // Exp calculates the exponent of every array element.

--- a/core.h
+++ b/core.h
@@ -379,7 +379,7 @@ void Mat_DFT(Mat m, Mat dst, int flags);
 void Mat_Divide(Mat src1, Mat src2, Mat dst);
 bool Mat_Eigen(Mat src, Mat eigenvalues, Mat eigenvectors);
 void Mat_EigenNonSymmetric(Mat src, Mat eigenvalues, Mat eigenvectors);
-void Mat_PCACompute(Mat src, Mat mean, Mat eigenvalues, Mat eigenvectors, int maxComponents);
+void Mat_PCACompute(Mat src, Mat mean, Mat eigenvectors, Mat eigenvalues, int maxComponents);
 void Mat_Exp(Mat src, Mat dst);
 void Mat_ExtractChannel(Mat src, Mat dst, int coi);
 void Mat_FindNonZero(Mat src, Mat idx);

--- a/core_test.go
+++ b/core_test.go
@@ -2077,10 +2077,10 @@ func TestPCACompute(t *testing.T) {
 	src.SetFloatAt(2, 1, 5)
 	src.SetFloatAt(9, 9, 25)
 	mean := NewMat()
-	eigenvalues := NewMat()
 	eigenvectors := NewMat()
+	eigenvalues := NewMat()
 	maxComponents := 2
-	PCACompute(src, &mean, &eigenvalues, &eigenvectors, maxComponents)
+	PCACompute(src, &mean, &eigenvectors, &eigenvalues, maxComponents)
 	if mean.Empty() || eigenvectors.Empty() || eigenvalues.Empty() {
 		t.Error("TestPCACompute should not have empty eigenvectors or eigenvalues.")
 	}


### PR DESCRIPTION
Realized after testing this implementation that I had the parameter names inverted on this. Since they are both output parameters it doesn't impact functinality so the smoke test still worked.

This change corrects the name order so that the doc is correct.