### PR TITLE
Makefile fixes for 64bit architechtures and GoCV/OpenCV version updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,10 +235,26 @@ clean:
 
 # Cleanup old library files.
 sudo_pre_install_clean:
+ifneq (,$(wildcard /usr/local/lib/libopencv*))
 	sudo rm -rf /usr/local/lib/cmake/opencv4/
 	sudo rm -rf /usr/local/lib/libopencv*
 	sudo rm -rf /usr/local/lib/pkgconfig/opencv*
 	sudo rm -rf /usr/local/include/opencv*
+else
+ifneq (,$(wildcard /usr/local/lib64/libopencv*))
+	sudo rm -rf /usr/local/lib64/cmake/opencv4/
+	sudo rm -rf /usr/local/lib64/libopencv*
+	sudo rm -rf /usr/local/lib64/pkgconfig/opencv*
+	sudo rm -rf /usr/local/include/opencv*
+else
+ifneq (,$(wildcard /usr/local/lib/aarch64-linux-gnu/libopencv*))
+	sudo rm -rf /usr/local/lib/aarch64-linux-gnu/cmake/opencv4/
+	sudo rm -rf /usr/local/lib/aarch64-linux-gnu/libopencv*
+	sudo rm -rf /usr/local/lib/aarch64-linux-gnu/pkgconfig/opencv*
+	sudo rm -rf /usr/local/include/opencv*
+endif
+endif
+endif
 
 # Do everything.
 install: deps download sudo_pre_install_clean build sudo_install clean verify

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,11 @@ build_raspi:
 	mkdir build
 	cd build
 	rm -rf *
+ifneq ($(shell uname -m | grep "aarch64"),)
+	cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -D BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} -D OPENCV_EXTRA_MODULES_PATH=$(TMP_DIR)opencv/opencv_contrib-$(OPENCV_VERSION)/modules -D BUILD_DOCS=OFF -D BUILD_EXAMPLES=OFF -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=ON -D BUILD_opencv_java=OFF -D BUILD_opencv_python=NO -D BUILD_opencv_python2=NO -D BUILD_opencv_python3=NO -D ENABLE_NEON=ON -D WITH_JASPER=OFF -D WITH_TBB=ON -D OPENCV_GENERATE_PKGCONFIG=ON ..
+else
 	cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -D BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} -D OPENCV_EXTRA_MODULES_PATH=$(TMP_DIR)opencv/opencv_contrib-$(OPENCV_VERSION)/modules -D BUILD_DOCS=OFF -D BUILD_EXAMPLES=OFF -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=ON -D BUILD_opencv_java=OFF -D BUILD_opencv_python=NO -D BUILD_opencv_python2=NO -D BUILD_opencv_python3=NO -D ENABLE_NEON=ON -D ENABLE_VFPV3=ON -D WITH_JASPER=OFF -D OPENCV_GENERATE_PKGCONFIG=ON ..
+endif
 	$(MAKE) -j $(shell nproc --all --ignore 1)
 	$(MAKE) preinstall
 	cd -

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 .PHONY: test deps download build clean astyle cmds docker
 
 # GoCV version to use.
-GOCV_VERSION?="v0.31.0"
+GOCV_VERSION?="v0.34.0"
 
 # OpenCV version to use.
-OPENCV_VERSION?=4.8.0
+OPENCV_VERSION?=4.8.1
 
 # Go version to use when building Docker image
 GOVERSION?=1.16.2

--- a/Makefile
+++ b/Makefile
@@ -260,13 +260,13 @@ endif
 install: deps download sudo_pre_install_clean build sudo_install clean verify
 
 # Do everything on Raspbian.
-install_raspi: deps download build_raspi sudo_install clean verify
+install_raspi: deps download sudo_pre_install_clean build_raspi sudo_install clean verify
 
 # Do everything on the raspberry pi zero.
-install_raspi_zero: deps download build_raspi_zero sudo_install clean verify
+install_raspi_zero: deps download sudo_pre_install_clean build_raspi_zero sudo_install clean verify
 
 # Do everything on Jetson.
-install_jetson: deps download build_jetson sudo_install clean verify
+install_jetson: deps download sudo_pre_install_clean build_jetson sudo_install clean verify
 
 # Do everything with cuda.
 install_cuda: deps download sudo_pre_install_clean build_cuda sudo_install clean verify verify_cuda


### PR DESCRIPTION
* The `Makefile` was stuck on GoCV v0.31.0 and did not match the OpenCV version 4.8.0 so this has been updated to v0.34.0.

* In OpenCV 4.8.0 there is a major regression which slowed DNN model inference by 200%  https://github.com/opencv/opencv/issues/23941 - this has been fixed in v4.8.1

* Building on 64bit Raspberry Pi fails on cmake flag `-D ENABLE_VFPV3=ON` so a conditional switch has been added for 32/64bit builds in `install_raspi`.  This fixes https://github.com/hybridgroup/gocv/issues/1059

* The `sudo_pre_install_clean` was not cleaning up libraries on 64bit machines (x86 and arm) so clearing of those directories has been implemented.