### PR TITLE
all: correct formatting

### DIFF
--- a/asyncarray.go
+++ b/asyncarray.go
@@ -1,3 +1,4 @@
+//go:build openvino
 // +build openvino
 
 package gocv

--- a/asyncarray_test.go
+++ b/asyncarray_test.go
@@ -1,3 +1,4 @@
+//go:build openvino
 // +build openvino
 
 package gocv

--- a/calib3d.go
+++ b/calib3d.go
@@ -97,7 +97,6 @@ func EstimateNewCameraMatrixForUndistortRectify(k, d Mat, imgSize image.Point, r
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d0c/group__calib3d.html#ga7dfb72c9cf9780a347fbe3d1c47e5d5a
-//
 func InitUndistortRectifyMap(cameraMatrix Mat, distCoeffs Mat, r Mat, newCameraMatrix Mat, size image.Point, m1type int, map1 Mat, map2 Mat) {
 	sz := C.struct_Size{
 		width:  C.int(size.X),
@@ -110,7 +109,6 @@ func InitUndistortRectifyMap(cameraMatrix Mat, distCoeffs Mat, r Mat, newCameraM
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d0c/group__calib3d.html#ga7a6c4e032c97f03ba747966e6ad862b1
-//
 func GetOptimalNewCameraMatrixWithParams(cameraMatrix Mat, distCoeffs Mat, imageSize image.Point, alpha float64, newImgSize image.Point, centerPrincipalPoint bool) (Mat, image.Rectangle) {
 	sz := C.struct_Size{
 		width:  C.int(imageSize.X),
@@ -128,7 +126,6 @@ func GetOptimalNewCameraMatrixWithParams(cameraMatrix Mat, distCoeffs Mat, image
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d0c/group__calib3d.html#ga3207604e4b1a1758aa66acb6ed5aa65d
-//
 func CalibrateCamera(objectPoints Points3fVector, imagePoints Points2fVector, imageSize image.Point,
 	cameraMatrix *Mat, distCoeffs *Mat, rvecs *Mat, tvecs *Mat, calibFlag CalibFlag) float64 {
 	sz := C.struct_Size{
@@ -181,7 +178,6 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d0c/group__calib3d.html#ga93efa9b0aa890de240ca32b11253dd4a
-//
 func FindChessboardCorners(image Mat, patternSize image.Point, corners *Mat, flags CalibCBFlag) bool {
 	sz := C.struct_Size{
 		width:  C.int(patternSize.X),
@@ -194,7 +190,6 @@ func FindChessboardCorners(image Mat, patternSize image.Point, corners *Mat, fla
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d0c/group__calib3d.html#gadc5bcb05cb21cf1e50963df26986d7c9
-//
 func FindChessboardCornersSB(image Mat, patternSize image.Point, corners *Mat, flags CalibCBFlag) bool {
 	sz := C.struct_Size{
 		width:  C.int(patternSize.X),
@@ -207,7 +202,6 @@ func FindChessboardCornersSB(image Mat, patternSize image.Point, corners *Mat, f
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d0c/group__calib3d.html#ga93efa9b0aa890de240ca32b11253dd4a
-//
 func FindChessboardCornersSBWithMeta(image Mat, patternSize image.Point, corners *Mat, flags CalibCBFlag, meta *Mat) bool {
 	sz := C.struct_Size{
 		width:  C.int(patternSize.X),
@@ -220,7 +214,6 @@ func FindChessboardCornersSBWithMeta(image Mat, patternSize image.Point, corners
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d0c/group__calib3d.html#ga6a10b0bb120c4907e5eabbcd22319022
-//
 func DrawChessboardCorners(image *Mat, patternSize image.Point, corners Mat, patternWasFound bool) {
 	sz := C.struct_Size{
 		width:  C.int(patternSize.X),

--- a/cmd/dnn-pose-detection/main.go
+++ b/cmd/dnn-pose-detection/main.go
@@ -228,7 +228,6 @@ func drawPose(frame *gocv.Mat) {
 // PosePairs is a table of the body part connections in the format [model_id][pair_id][from/to]
 // For details please see:
 // https://github.com/CMU-Perceptual-Computing-Lab/openpose/blob/master/doc/output.md
-//
 var PosePairs = [3][20][2]int{
 	{ // COCO body
 		{1, 2}, {1, 5}, {2, 3},

--- a/contrib/bgsegm.go
+++ b/contrib/bgsegm.go
@@ -25,7 +25,6 @@ type BackgroundSubtractorCNT struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/3.4/de/dca/classcv_1_1bgsegm_1_1BackgroundSubtractorCNT.html
-//
 func NewBackgroundSubtractorCNT() BackgroundSubtractorCNT {
 	return BackgroundSubtractorCNT{p: unsafe.Pointer(C.BackgroundSubtractorCNT_Create())}
 }
@@ -42,7 +41,6 @@ func (b *BackgroundSubtractorCNT) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/3.4/de/dca/classcv_1_1bgsegm_1_1BackgroundSubtractorCNT.html
-//
 func (b *BackgroundSubtractorCNT) Apply(src gocv.Mat, dst *gocv.Mat) {
 	C.BackgroundSubtractorCNT_Apply((C.BackgroundSubtractorCNT)(b.p), (C.Mat)(src.Ptr()), (C.Mat)(dst.Ptr()))
 

--- a/contrib/contrib.go
+++ b/contrib/contrib.go
@@ -2,5 +2,4 @@
 //
 // For further details, please see:
 // https://github.com/opencv/opencv_contrib
-//
 package contrib // import "gocv.io/x/gocv/contrib"

--- a/contrib/face.go
+++ b/contrib/face.go
@@ -27,7 +27,6 @@ type LBPHFaceRecognizer struct {
 //
 // For further information, see:
 // https://docs.opencv.org/master/df/d25/classcv_1_1face_1_1LBPHFaceRecognizer.html
-//
 func NewLBPHFaceRecognizer() *LBPHFaceRecognizer {
 	return &LBPHFaceRecognizer{p: C.CreateLBPHFaceRecognizer()}
 }
@@ -35,7 +34,6 @@ func NewLBPHFaceRecognizer() *LBPHFaceRecognizer {
 // Train loaded model with images and their labels
 //
 // see https://docs.opencv.org/master/dd/d65/classcv_1_1face_1_1FaceRecognizer.html#ac8680c2aa9649ad3f55e27761165c0d6
-//
 func (fr *LBPHFaceRecognizer) Train(images []gocv.Mat, labels []int) {
 	cparams := []C.int{}
 	for _, v := range labels {
@@ -61,7 +59,6 @@ func (fr *LBPHFaceRecognizer) Train(images []gocv.Mat, labels []int) {
 //
 // For further information, see:
 // https://docs.opencv.org/master/dd/d65/classcv_1_1face_1_1FaceRecognizer.html#a8a4e73ea878dcd0c235d0487189d25f3
-//
 func (fr *LBPHFaceRecognizer) Update(newImages []gocv.Mat, newLabels []int) {
 	cparams := []C.int{}
 	for _, v := range newLabels {
@@ -88,7 +85,6 @@ func (fr *LBPHFaceRecognizer) Update(newImages []gocv.Mat, newLabels []int) {
 //
 // For further information, see:
 // https://docs.opencv.org/master/dd/d65/classcv_1_1face_1_1FaceRecognizer.html#aa2d2f02faffab1bf01317ae6502fb631
-//
 func (fr *LBPHFaceRecognizer) Predict(sample gocv.Mat) int {
 	label := C.LBPHFaceRecognizer_Predict(fr.p, (C.Mat)(sample.Ptr()))
 
@@ -101,7 +97,6 @@ func (fr *LBPHFaceRecognizer) Predict(sample gocv.Mat) int {
 //
 // For further information, see:
 // https://docs.opencv.org/master/dd/d65/classcv_1_1face_1_1FaceRecognizer.html#ab0d593e53ebd9a0f350c989fcac7f251
-//
 func (fr *LBPHFaceRecognizer) PredictExtendedResponse(sample gocv.Mat) PredictResponse {
 	respp := C.LBPHFaceRecognizer_PredictExtended(fr.p, (C.Mat)(sample.Ptr()))
 	resp := PredictResponse{
@@ -117,7 +112,6 @@ func (fr *LBPHFaceRecognizer) PredictExtendedResponse(sample gocv.Mat) PredictRe
 //
 // For further information, see:
 // https://docs.opencv.org/master/dd/d65/classcv_1_1face_1_1FaceRecognizer.html#a3182081e5f8023e658ad8ab96656dd63
-//
 func (fr *LBPHFaceRecognizer) SetThreshold(threshold float32) {
 	C.LBPHFaceRecognizer_SetThreshold(fr.p, (C.double)(threshold))
 }
@@ -128,7 +122,6 @@ func (fr *LBPHFaceRecognizer) SetThreshold(threshold float32) {
 //
 // For further information, see:
 // https://docs.opencv.org/master/df/d25/classcv_1_1face_1_1LBPHFaceRecognizer.html#ab225f7bf353ce8697a506eda10124a92
-//
 func (fr *LBPHFaceRecognizer) SetNeighbors(neighbors int) {
 	C.LBPHFaceRecognizer_SetNeighbors(fr.p, (C.int)(neighbors))
 }
@@ -137,7 +130,6 @@ func (fr *LBPHFaceRecognizer) SetNeighbors(neighbors int) {
 //
 // For further information, see:
 // https://docs.opencv.org/master/df/d25/classcv_1_1face_1_1LBPHFaceRecognizer.html#a50a3e2ca6e8464166e153c9df84b0a77
-//
 func (fr *LBPHFaceRecognizer) GetNeighbors() int {
 	n := C.LBPHFaceRecognizer_GetNeighbors(fr.p)
 
@@ -149,7 +141,6 @@ func (fr *LBPHFaceRecognizer) GetNeighbors() int {
 //
 // For further information, see:
 // https://docs.opencv.org/master/df/d25/classcv_1_1face_1_1LBPHFaceRecognizer.html#a62d94c75cade902fd3b487b1ef9883fc
-//
 func (fr *LBPHFaceRecognizer) SetRadius(radius int) {
 	C.LBPHFaceRecognizer_SetRadius(fr.p, (C.int)(radius))
 }
@@ -158,7 +149,6 @@ func (fr *LBPHFaceRecognizer) SetRadius(radius int) {
 //
 // For further information, see:
 // https://docs.opencv.org/master/dd/d65/classcv_1_1face_1_1FaceRecognizer.html#a2adf2d555550194244b05c91fefcb4d6
-//
 func (fr *LBPHFaceRecognizer) SaveFile(fname string) {
 	cName := C.CString(fname)
 	defer C.free(unsafe.Pointer(cName))
@@ -169,7 +159,6 @@ func (fr *LBPHFaceRecognizer) SaveFile(fname string) {
 //
 // For further information, see:
 // https://docs.opencv.org/master/dd/d65/classcv_1_1face_1_1FaceRecognizer.html#acc42e5b04595dba71f0777c7179af8c3
-//
 func (fr *LBPHFaceRecognizer) LoadFile(fname string) {
 	cName := C.CString(fname)
 	defer C.free(unsafe.Pointer(cName))

--- a/contrib/img_hash.go
+++ b/contrib/img_hash.go
@@ -15,14 +15,12 @@ type ImgHashBase interface {
 }
 
 // PHash is implementation of the PHash algorithm.
-//
 type PHash struct{}
 
 // Compute computes hash of the input image using PHash.
 //
 // For further information, see:
 // https://docs.opencv.org/master/de/d29/classcv_1_1img__hash_1_1ImgHashBase.html#ae2d9288db370089dfd8aab85d5e0b0f3
-//
 func (hash PHash) Compute(input gocv.Mat, output *gocv.Mat) {
 	C.pHashCompute(C.Mat(input.Ptr()), C.Mat(output.Ptr()))
 }
@@ -31,20 +29,17 @@ func (hash PHash) Compute(input gocv.Mat, output *gocv.Mat) {
 //
 // For further information, see:
 // https://docs.opencv.org/master/de/d29/classcv_1_1img__hash_1_1ImgHashBase.html#a444a3e9ec792cf029385809393f84ad5
-//
 func (hash PHash) Compare(a, b gocv.Mat) float64 {
 	return float64(C.pHashCompare(C.Mat(a.Ptr()), C.Mat(b.Ptr())))
 }
 
 // AverageHash is implementation of the AverageHash algorithm.
-//
 type AverageHash struct{}
 
 // Compute computes hash of the input image using AverageHash.
 //
 // For further information, see:
 // https://docs.opencv.org/master/de/d29/classcv_1_1img__hash_1_1ImgHashBase.html#ae2d9288db370089dfd8aab85d5e0b0f3
-//
 func (hash AverageHash) Compute(input gocv.Mat, output *gocv.Mat) {
 	C.averageHashCompute(C.Mat(input.Ptr()), C.Mat(output.Ptr()))
 }
@@ -53,13 +48,11 @@ func (hash AverageHash) Compute(input gocv.Mat, output *gocv.Mat) {
 //
 // For further information, see:
 // https://docs.opencv.org/master/de/d29/classcv_1_1img__hash_1_1ImgHashBase.html#a444a3e9ec792cf029385809393f84ad5
-//
 func (hash AverageHash) Compare(a, b gocv.Mat) float64 {
 	return float64(C.averageHashCompare(C.Mat(a.Ptr()), C.Mat(b.Ptr())))
 }
 
 // BlockMeanHash is implementation of the BlockMeanHash algorithm.
-//
 type BlockMeanHash struct {
 	Mode BlockMeanHashMode
 }
@@ -76,7 +69,6 @@ const (
 //
 // For further information, see:
 // https://docs.opencv.org/master/de/d29/classcv_1_1img__hash_1_1ImgHashBase.html#ae2d9288db370089dfd8aab85d5e0b0f3
-//
 func (hash BlockMeanHash) Compute(input gocv.Mat, output *gocv.Mat) {
 	C.blockMeanHashCompute(C.Mat(input.Ptr()), C.Mat(output.Ptr()), C.int(hash.Mode))
 }
@@ -85,7 +77,6 @@ func (hash BlockMeanHash) Compute(input gocv.Mat, output *gocv.Mat) {
 //
 // For further information, see:
 // https://docs.opencv.org/master/de/d29/classcv_1_1img__hash_1_1ImgHashBase.html#a444a3e9ec792cf029385809393f84ad5
-//
 func (hash BlockMeanHash) Compare(a, b gocv.Mat) float64 {
 	return float64(C.blockMeanHashCompare(C.Mat(a.Ptr()), C.Mat(b.Ptr()), C.int(hash.Mode)))
 }
@@ -94,14 +85,12 @@ func (hash BlockMeanHash) Compare(a, b gocv.Mat) float64 {
 // call to Compute, and there's no easy way to keep it.
 
 // ColorMomentHash is implementation of the ColorMomentHash algorithm.
-//
 type ColorMomentHash struct{}
 
 // Compute computes hash of the input image using ColorMomentHash.
 //
 // For further information, see:
 // https://docs.opencv.org/master/de/d29/classcv_1_1img__hash_1_1ImgHashBase.html#ae2d9288db370089dfd8aab85d5e0b0f3
-//
 func (hash ColorMomentHash) Compute(input gocv.Mat, output *gocv.Mat) {
 	C.colorMomentHashCompute(C.Mat(input.Ptr()), C.Mat(output.Ptr()))
 }
@@ -110,13 +99,11 @@ func (hash ColorMomentHash) Compute(input gocv.Mat, output *gocv.Mat) {
 //
 // For further information, see:
 // https://docs.opencv.org/master/de/d29/classcv_1_1img__hash_1_1ImgHashBase.html#a444a3e9ec792cf029385809393f84ad5
-//
 func (hash ColorMomentHash) Compare(a, b gocv.Mat) float64 {
 	return float64(C.colorMomentHashCompare(C.Mat(a.Ptr()), C.Mat(b.Ptr())))
 }
 
 // MarrHildrethHash is implementation of the MarrHildrethHash algorithm.
-//
 type MarrHildrethHash struct {
 	Alpha float32
 	Scale float32
@@ -130,7 +117,6 @@ func NewMarrHildrethHash() MarrHildrethHash {
 //
 // For further information, see:
 // https://docs.opencv.org/master/de/d29/classcv_1_1img__hash_1_1ImgHashBase.html#ae2d9288db370089dfd8aab85d5e0b0f3
-//
 func (hash MarrHildrethHash) Compute(input gocv.Mat, output *gocv.Mat) {
 	C.marrHildrethHashCompute(C.Mat(input.Ptr()), C.Mat(output.Ptr()),
 		C.float(hash.Alpha), C.float(hash.Scale))
@@ -140,14 +126,12 @@ func (hash MarrHildrethHash) Compute(input gocv.Mat, output *gocv.Mat) {
 //
 // For further information, see:
 // https://docs.opencv.org/master/de/d29/classcv_1_1img__hash_1_1ImgHashBase.html#a444a3e9ec792cf029385809393f84ad5
-//
 func (hash MarrHildrethHash) Compare(a, b gocv.Mat) float64 {
 	return float64(C.marrHildrethHashCompare(C.Mat(a.Ptr()), C.Mat(b.Ptr()),
 		C.float(hash.Alpha), C.float(hash.Scale)))
 }
 
 // RadialVarianceHash is implementation of the RadialVarianceHash algorithm.
-//
 type RadialVarianceHash struct {
 	Sigma          float64
 	NumOfAngleLine int
@@ -161,7 +145,6 @@ func NewRadialVarianceHash() RadialVarianceHash {
 //
 // For further information, see:
 // https://docs.opencv.org/master/de/d29/classcv_1_1img__hash_1_1ImgHashBase.html#ae2d9288db370089dfd8aab85d5e0b0f3
-//
 func (hash RadialVarianceHash) Compute(input gocv.Mat, output *gocv.Mat) {
 	C.radialVarianceHashCompute(C.Mat(input.Ptr()), C.Mat(output.Ptr()),
 		C.double(hash.Sigma), C.int(hash.NumOfAngleLine))
@@ -171,7 +154,6 @@ func (hash RadialVarianceHash) Compute(input gocv.Mat, output *gocv.Mat) {
 //
 // For further information, see:
 // https://docs.opencv.org/master/de/d29/classcv_1_1img__hash_1_1ImgHashBase.html#a444a3e9ec792cf029385809393f84ad5
-//
 func (hash RadialVarianceHash) Compare(a, b gocv.Mat) float64 {
 	return float64(C.radialVarianceHashCompare(C.Mat(a.Ptr()), C.Mat(b.Ptr()),
 		C.double(hash.Sigma), C.int(hash.NumOfAngleLine)))

--- a/contrib/tracking.go
+++ b/contrib/tracking.go
@@ -15,7 +15,6 @@ import (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/dff/classcv_1_1TrackerKCF.html
-//
 type TrackerKCF struct {
 	p C.TrackerKCF
 }
@@ -47,7 +46,6 @@ func (trk TrackerKCF) Update(img gocv.Mat) (image.Rectangle, bool) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/da2/classcv_1_1TrackerCSRT.html
-//
 type TrackerCSRT struct {
 	p C.TrackerCSRT
 }

--- a/contrib/xfeatures2d.go
+++ b/contrib/xfeatures2d.go
@@ -25,7 +25,6 @@ type SURF struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d5/df7/classcv_1_1xfeatures2d_1_1SURF.html
-//
 func NewSURF() SURF {
 	return SURF{p: unsafe.Pointer(C.SURF_Create())}
 }
@@ -41,7 +40,6 @@ func (d *SURF) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#aa4e9a7082ec61ebc108806704fbd7887
-//
 func (d *SURF) Detect(src gocv.Mat) []gocv.KeyPoint {
 	ret := C.SURF_Detect((C.SURF)(d.p), C.Mat(src.Ptr()))
 
@@ -52,7 +50,6 @@ func (d *SURF) Detect(src gocv.Mat) []gocv.KeyPoint {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#a8be0d1c20b08eb867184b8d74c15a677
-//
 func (d *SURF) DetectAndCompute(src gocv.Mat, mask gocv.Mat) ([]gocv.KeyPoint, gocv.Mat) {
 	desc := gocv.NewMat()
 	ret := C.SURF_DetectAndCompute((C.SURF)(d.p), C.Mat(src.Ptr()), C.Mat(mask.Ptr()),

--- a/contrib/ximgproc.go
+++ b/contrib/ximgproc.go
@@ -15,7 +15,6 @@ import (
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/d2d/group__ximgproc.html#gaffedd976e0a8efb5938107acab185ec2
-//
 func AnisotropicDiffusion(src gocv.Mat, dst *gocv.Mat, alpha float32, k float32, niters int) {
 	C.anisotropicDiffusion(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.float(alpha), C.float(k), C.int(niters))
 }
@@ -24,7 +23,6 @@ func AnisotropicDiffusion(src gocv.Mat, dst *gocv.Mat, alpha float32, k float32,
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/d2d/group__ximgproc.html#ga86fcda65ced0aafa2741088d82e9161c
-//
 func EdgePreservingFilter(src gocv.Mat, dst *gocv.Mat, d int, threshold float32) {
 	C.edgePreservingFilter(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.int(d), C.float(threshold))
 }
@@ -38,12 +36,11 @@ const (
 	BinarizationNICK
 )
 
-// NiblackThreshold performs thresholding on input images using Niblack's technique 
+// NiblackThreshold performs thresholding on input images using Niblack's technique
 // or some of the popular variations it inspired.
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/d2d/group__ximgproc.html#gab042a5032bbb85275f1fd3e04e7c7660
-//
 func NiblackThreshold(src gocv.Mat, dst *gocv.Mat, maxValue float32,
 	typ gocv.ThresholdType, blockSize int, k float32, binarizationMethod BinarizationMethod, r float32) {
 	C.niBlackThreshold(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.float(maxValue), C.int(typ),
@@ -55,7 +52,6 @@ func NiblackThreshold(src gocv.Mat, dst *gocv.Mat, maxValue float32,
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/d2d/group__ximgproc.html#ga50d064b92f63916f4162474eea22d656
-//
 func PeiLinNormalization(src gocv.Mat, dst *gocv.Mat) {
 	C.PeiLinNormalization(C.Mat(src.Ptr()), C.Mat(dst.Ptr()))
 }
@@ -67,7 +63,7 @@ const (
 	ThinningGuoHall
 )
 
-// Thinning applies a binary blob thinning operation, to achieve a skeletization 
+// Thinning applies a binary blob thinning operation, to achieve a skeletization
 // of the input image.
 //
 // The function transforms a binary blob image into a skeletized form using the
@@ -75,7 +71,6 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/d2d/group__ximgproc.html#ga37002c6ca80c978edb6ead5d6b39740c
-//
 func Thinning(src gocv.Mat, dst *gocv.Mat, typ ThinningType) {
 	C.thinning(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.int(typ))
 }

--- a/contrib/xphoto.go
+++ b/contrib/xphoto.go
@@ -126,7 +126,6 @@ func Bm3dDenoisingWithParams(src gocv.Mat, dst *gocv.Mat,
 // For further details, please see:
 // https://docs.opencv.org/master/de/daa/group__xphoto.html
 // https://docs.opencv.org/master/d7/d71/classcv_1_1xphoto_1_1GrayworldWB.html
-//
 func NewGrayworldWB() GrayworldWB {
 	return GrayworldWB{p: unsafe.Pointer(C.GrayworldWB_Create())}
 }
@@ -137,7 +136,6 @@ func NewGrayworldWB() GrayworldWB {
 // https://docs.opencv.org/master/de/daa/group__xphoto.html
 // https://docs.opencv.org/master/d7/d71/classcv_1_1xphoto_1_1GrayworldWB.html
 // https://docs.opencv.org/master/d7/d71/classcv_1_1xphoto_1_1GrayworldWB.html#ac6e17766e394adc15588b8522202cc71
-//
 func (b *GrayworldWB) SetSaturationThreshold(saturationThreshold float32) {
 	C.GrayworldWB_SetSaturationThreshold((C.GrayworldWB)(b.p), C.float(saturationThreshold))
 	return
@@ -149,7 +147,6 @@ func (b *GrayworldWB) SetSaturationThreshold(saturationThreshold float32) {
 // https://docs.opencv.org/master/de/daa/group__xphoto.html
 // https://docs.opencv.org/master/d7/d71/classcv_1_1xphoto_1_1GrayworldWB.html
 // https://docs.opencv.org/master/d7/d71/classcv_1_1xphoto_1_1GrayworldWB.html#ac6e17766e394adc15588b8522202cc71
-//
 func (b *GrayworldWB) GetSaturationThreshold() float32 {
 	return float32(C.GrayworldWB_GetSaturationThreshold((C.GrayworldWB)(b.p)))
 }
@@ -165,7 +162,6 @@ func (b *GrayworldWB) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/d71/classcv_1_1xphoto_1_1GrayworldWB.html#details
-//
 func (b *GrayworldWB) BalanceWhite(src gocv.Mat, dst *gocv.Mat) {
 	C.GrayworldWB_BalanceWhite((C.GrayworldWB)(b.p), C.Mat(src.Ptr()), C.Mat(dst.Ptr()))
 	return
@@ -182,7 +178,6 @@ func (b *GrayworldWB) BalanceWhite(src gocv.Mat, dst *gocv.Mat) {
 // https://docs.opencv.org/master/de/daa/group__xphoto.html
 // https://docs.opencv.org/master/d4/d3b/classcv_1_1xphoto_1_1LearningBasedWB.html
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#gac8fb5636b27eac575f4a4c9c54dd1c7c
-//
 func NewLearningBasedWB() LearningBasedWB {
 	return LearningBasedWB{p: unsafe.Pointer(C.LearningBasedWB_Create())}
 }
@@ -195,7 +190,6 @@ func NewLearningBasedWB() LearningBasedWB {
 // https://docs.opencv.org/master/de/daa/group__xphoto.html
 // https://docs.opencv.org/master/d4/d3b/classcv_1_1xphoto_1_1LearningBasedWB.html
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#gac8fb5636b27eac575f4a4c9c54dd1c7c
-//
 func NewLearningBasedWBWithParams(pathmodel string) LearningBasedWB {
 	cpath := C.CString(pathmodel)
 	defer C.free(unsafe.Pointer(cpath))
@@ -214,7 +208,6 @@ func (b *LearningBasedWB) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d3b/classcv_1_1xphoto_1_1LearningBasedWB.html#aeeaca052262a01d0feed6312ccb9a76e
-//
 func (b *LearningBasedWB) ExtractSimpleFeatures(src gocv.Mat, dst *gocv.Mat) {
 	C.LearningBasedWB_ExtractSimpleFeatures((C.LearningBasedWB)(b.p), C.Mat(src.Ptr()), C.Mat(dst.Ptr()))
 	return
@@ -225,7 +218,6 @@ func (b *LearningBasedWB) ExtractSimpleFeatures(src gocv.Mat, dst *gocv.Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d3b/classcv_1_1xphoto_1_1LearningBasedWB.html#abfe7d3983f8245a7eba0a7f9de40e3e1
-//
 func (b *LearningBasedWB) GetHistBinNum() int {
 	return int(C.LearningBasedWB_GetHistBinNum((C.LearningBasedWB)(b.p)))
 }
@@ -235,7 +227,6 @@ func (b *LearningBasedWB) GetHistBinNum() int {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d3b/classcv_1_1xphoto_1_1LearningBasedWB.html#a764b51265b5a1bd7bd11ce9d14d6f75f
-//
 func (b *LearningBasedWB) GetRangeMaxVal() int {
 	return int(C.LearningBasedWB_GetRangeMaxVal((C.LearningBasedWB)(b.p)))
 }
@@ -245,7 +236,6 @@ func (b *LearningBasedWB) GetRangeMaxVal() int {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d3b/classcv_1_1xphoto_1_1LearningBasedWB.html#ae7eb310249709c2aef41d6399ebd7660
-//
 func (b *LearningBasedWB) GetSaturationThreshold() float32 {
 	return float32(C.LearningBasedWB_GetSaturationThreshold((C.LearningBasedWB)(b.p)))
 }
@@ -255,7 +245,6 @@ func (b *LearningBasedWB) GetSaturationThreshold() float32 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d3b/classcv_1_1xphoto_1_1LearningBasedWB.html#a3381bd425bc4201133c9669071908e7f
-//
 func (b *LearningBasedWB) SetHistBinNum(val int) {
 	C.LearningBasedWB_SetHistBinNum((C.LearningBasedWB)(b.p), C.int(val))
 	return
@@ -266,7 +255,6 @@ func (b *LearningBasedWB) SetHistBinNum(val int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d3b/classcv_1_1xphoto_1_1LearningBasedWB.html#a3d9395274be8053b2f09e46d11a24a65
-//
 func (b *LearningBasedWB) SetRangeMaxVal(val int) {
 	C.LearningBasedWB_SetRangeMaxVal((C.LearningBasedWB)(b.p), C.int(val))
 	return
@@ -277,7 +265,6 @@ func (b *LearningBasedWB) SetRangeMaxVal(val int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d3b/classcv_1_1xphoto_1_1LearningBasedWB.html#a9bff5a507d4dffc58e16d85b1d07f35f
-//
 func (b *LearningBasedWB) SetSaturationThreshold(val float32) {
 	C.LearningBasedWB_SetSaturationThreshold((C.LearningBasedWB)(b.p), C.float(val))
 	return
@@ -287,7 +274,6 @@ func (b *LearningBasedWB) SetSaturationThreshold(val float32) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d7a/classcv_1_1xphoto_1_1WhiteBalancer.html#ae23838a1a54f101b255bca1a97418aa3
-//
 func (b *LearningBasedWB) BalanceWhite(src gocv.Mat, dst *gocv.Mat) {
 	C.LearningBasedWB_BalanceWhite((C.LearningBasedWB)(b.p), C.Mat(src.Ptr()), C.Mat(dst.Ptr()))
 	return
@@ -305,7 +291,6 @@ func (b *LearningBasedWB) BalanceWhite(src gocv.Mat, dst *gocv.Mat) {
 // https://docs.opencv.org/master/de/daa/group__xphoto.html
 // https://docs.opencv.org/master/d1/d8b/classcv_1_1xphoto_1_1SimpleWB.html
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#ga2b48b3b384b5c5ee1b15a2a01c26d5f1
-//
 func NewSimpleWB() SimpleWB {
 	return SimpleWB{p: unsafe.Pointer(C.SimpleWB_Create())}
 }
@@ -322,7 +307,6 @@ func (b *SimpleWB) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/d8b/classcv_1_1xphoto_1_1SimpleWB.html#a45fef780842168cba868212c71ad8318
-//
 func (b *SimpleWB) GetInputMax() float32 {
 	return float32(C.SimpleWB_GetInputMax((C.SimpleWB)(b.p)))
 }
@@ -332,7 +316,6 @@ func (b *SimpleWB) GetInputMax() float32 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/d8b/classcv_1_1xphoto_1_1SimpleWB.html#a69ee7c05e5ca45cac60040371a4a648c
-//
 func (b *SimpleWB) GetInputMin() float32 {
 	return float32(C.SimpleWB_GetInputMin((C.SimpleWB)(b.p)))
 }
@@ -342,7 +325,6 @@ func (b *SimpleWB) GetInputMin() float32 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/d8b/classcv_1_1xphoto_1_1SimpleWB.html#af8b051a0b2d3e8ad0aa323c195d966c1
-//
 func (b *SimpleWB) GetOutputMax() float32 {
 	return float32(C.SimpleWB_GetOutputMax((C.SimpleWB)(b.p)))
 }
@@ -352,7 +334,6 @@ func (b *SimpleWB) GetOutputMax() float32 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/d8b/classcv_1_1xphoto_1_1SimpleWB.html#ada11ef4159bd6354a98d371f5be68b44
-//
 func (b *SimpleWB) GetOutputMin() float32 {
 	return float32(C.SimpleWB_GetOutputMin((C.SimpleWB)(b.p)))
 }
@@ -362,7 +343,6 @@ func (b *SimpleWB) GetOutputMin() float32 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/d8b/classcv_1_1xphoto_1_1SimpleWB.html#a49d63fd73572fc88c944f5ffbcb085a3
-//
 func (b *SimpleWB) GetP() float32 {
 	return float32(C.SimpleWB_GetP((C.SimpleWB)(b.p)))
 }
@@ -372,7 +352,6 @@ func (b *SimpleWB) GetP() float32 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/d8b/classcv_1_1xphoto_1_1SimpleWB.html#a6b2523a8740b353ef50e136d0399bf3a
-//
 func (b *SimpleWB) SetInputMax(val float32) {
 	C.SimpleWB_SetInputMax((C.SimpleWB)(b.p), C.float(val))
 	return
@@ -383,7 +362,6 @@ func (b *SimpleWB) SetInputMax(val float32) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/d8b/classcv_1_1xphoto_1_1SimpleWB.html#a1b08a24a8589aae886fbf96ba27691a0
-//
 func (b *SimpleWB) SetInputMin(val float32) {
 	C.SimpleWB_SetInputMin((C.SimpleWB)(b.p), C.float(val))
 	return
@@ -394,7 +372,6 @@ func (b *SimpleWB) SetInputMin(val float32) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/d8b/classcv_1_1xphoto_1_1SimpleWB.html#a06962b042d9089366bc6347e608481b6
-//
 func (b *SimpleWB) SetOutputMax(val float32) {
 	C.SimpleWB_SetOutputMax((C.SimpleWB)(b.p), C.float(val))
 	return
@@ -405,7 +382,6 @@ func (b *SimpleWB) SetOutputMax(val float32) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/d8b/classcv_1_1xphoto_1_1SimpleWB.html#a60d1e06b122747d416c4f1563167c740
-//
 func (b *SimpleWB) SetOutputMin(val float32) {
 	C.SimpleWB_SetOutputMin((C.SimpleWB)(b.p), C.float(val))
 	return
@@ -416,7 +392,6 @@ func (b *SimpleWB) SetOutputMin(val float32) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/d8b/classcv_1_1xphoto_1_1SimpleWB.html#a31b6bb5452afdb5a444920013417f018
-//
 func (b *SimpleWB) SetP(val float32) {
 	C.SimpleWB_SetP((C.SimpleWB)(b.p), C.float(val))
 	return
@@ -426,7 +401,6 @@ func (b *SimpleWB) SetP(val float32) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d7a/classcv_1_1xphoto_1_1WhiteBalancer.html#ae23838a1a54f101b255bca1a97418aa3
-//
 func (b *SimpleWB) BalanceWhite(src gocv.Mat, dst *gocv.Mat) {
 	C.SimpleWB_BalanceWhite((C.SimpleWB)(b.p), C.Mat(src.Ptr()), C.Mat(dst.Ptr()))
 	return
@@ -444,7 +418,6 @@ func (b *SimpleWB) BalanceWhite(src gocv.Mat, dst *gocv.Mat) {
 // https://docs.opencv.org/master/de/daa/group__xphoto.html
 // https://docs.opencv.org/master/d1/db3/classcv_1_1xphoto_1_1TonemapDurand.html
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#ga51a091aa54e26b3546316ce2c1df190b
-//
 func NewTonemapDurand() TonemapDurand {
 	return TonemapDurand{p: unsafe.Pointer(C.TonemapDurand_Create())}
 }
@@ -457,7 +430,6 @@ func NewTonemapDurand() TonemapDurand {
 // https://docs.opencv.org/master/de/daa/group__xphoto.html
 // https://docs.opencv.org/master/d1/db3/classcv_1_1xphoto_1_1TonemapDurand.html
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#ga51a091aa54e26b3546316ce2c1df190b
-//
 func NewTonemapDurandWithParams(gamma float32, contrast float32, saturation float32,
 	sigma_color float32, sigma_space float32) TonemapDurand {
 	return TonemapDurand{p: unsafe.Pointer(C.TonemapDurand_CreateWithParams(C.float(gamma), C.float(contrast),
@@ -475,7 +447,6 @@ func (b *TonemapDurand) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#ga2df693dd285a7e7fd3b4fc8a8a750cce
-//
 func (b *TonemapDurand) GetContrast() float32 {
 	return float32(C.TonemapDurand_GetContrast((C.TonemapDurand)(b.p)))
 }
@@ -484,7 +455,6 @@ func (b *TonemapDurand) GetContrast() float32 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#gad8ab5850af6fdb3f6bc51d5c9371bbfe
-//
 func (b *TonemapDurand) GetSaturation() float32 {
 	return float32(C.TonemapDurand_GetSaturation((C.TonemapDurand)(b.p)))
 }
@@ -493,7 +463,6 @@ func (b *TonemapDurand) GetSaturation() float32 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#ga31d7588db7e47fb81890cba7ff014edb
-//
 func (b *TonemapDurand) GetSigmaColor() float32 {
 	return float32(C.TonemapDurand_GetSigmaColor((C.TonemapDurand)(b.p)))
 }
@@ -502,7 +471,6 @@ func (b *TonemapDurand) GetSigmaColor() float32 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#ga078b11014d8a41920f50cab57fce9515
-//
 func (b *TonemapDurand) GetSigmaSpace() float32 {
 	return float32(C.TonemapDurand_GetSigmaSpace((C.TonemapDurand)(b.p)))
 }
@@ -511,7 +479,6 @@ func (b *TonemapDurand) GetSigmaSpace() float32 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#ga99eaaa24dc25ba387093e957bfca1cad
-//
 func (b *TonemapDurand) SetContrast(val float32) {
 	C.TonemapDurand_SetContrast((C.TonemapDurand)(b.p), C.float(val))
 	return
@@ -521,7 +488,6 @@ func (b *TonemapDurand) SetContrast(val float32) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#ga9c7de9517f95fd046910fc818e256d55
-//
 func (b *TonemapDurand) SetSaturation(val float32) {
 	C.TonemapDurand_SetSaturation((C.TonemapDurand)(b.p), C.float(val))
 	return
@@ -531,7 +497,6 @@ func (b *TonemapDurand) SetSaturation(val float32) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#ga7dec866735ecbae9e05224958d4585fd
-//
 func (b *TonemapDurand) SetSigmaColor(val float32) {
 	C.TonemapDurand_SetSigmaColor((C.TonemapDurand)(b.p), C.float(val))
 	return
@@ -541,7 +506,6 @@ func (b *TonemapDurand) SetSigmaColor(val float32) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#ga8869068912fae078699ce931bdc17fc4
-//
 func (b *TonemapDurand) SetSigmaSpace(val float32) {
 	C.TonemapDurand_SetSigmaSpace((C.TonemapDurand)(b.p), C.float(val))
 	return
@@ -551,7 +515,6 @@ func (b *TonemapDurand) SetSigmaSpace(val float32) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d5e/classcv_1_1Tonemap.html#a147c2b57ed5a5a0566001f4db2ddc0dd
-//
 func (b *TonemapDurand) GetGamma() float32 {
 	return float32(C.TonemapDurand_GetGamma((C.TonemapDurand)(b.p)))
 }
@@ -560,7 +523,6 @@ func (b *TonemapDurand) GetGamma() float32 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d5e/classcv_1_1Tonemap.html#ac809d2967f942b038b4bf21c97f8b1b7
-//
 func (b *TonemapDurand) SetGamma(val float32) {
 	C.TonemapDurand_SetGamma((C.TonemapDurand)(b.p), C.float(val))
 	return
@@ -570,7 +532,6 @@ func (b *TonemapDurand) SetGamma(val float32) {
 // Tonemaps image with gocv.MatTypeCV32FC3 type image
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d5e/classcv_1_1Tonemap.html#aa705c3b7226f7028a5c117dffab60fe4
-//
 func (b *TonemapDurand) Process(src gocv.Mat, dst *gocv.Mat) {
 	C.TonemapDurand_Process((C.TonemapDurand)(b.p), C.Mat(src.Ptr()), C.Mat(dst.Ptr()))
 	return
@@ -584,7 +545,6 @@ func (b *TonemapDurand) Process(src gocv.Mat, dst *gocv.Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#gab4febba6be53e5fddc480b8cedf51eee
-//
 func Inpaint(src *gocv.Mat, mask *gocv.Mat, dst *gocv.Mat, algorithmType InpaintTypes) {
 	C.Inpaint(C.Mat(src.Ptr()), C.Mat(mask.Ptr()), C.Mat(dst.Ptr()), C.int(algorithmType))
 }
@@ -594,7 +554,6 @@ func Inpaint(src *gocv.Mat, mask *gocv.Mat, dst *gocv.Mat, algorithmType Inpaint
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#gac050a6e876298cb9713cd2c09db9a027
-//
 func OilPaintingWithParams(src gocv.Mat, dst gocv.Mat, size int, dynRatio int, code gocv.ColorConversionCode) {
 	C.OilPaintingWithParams(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.int(size), C.int(dynRatio), C.int(code))
 }
@@ -604,7 +563,6 @@ func OilPaintingWithParams(src gocv.Mat, dst gocv.Mat, size int, dynRatio int, c
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#gac18ef93a7b1e65f703f7dc3b1e8e5235
-//
 func OilPainting(src gocv.Mat, dst *gocv.Mat, size int, dynRatio int) {
 	C.OilPainting(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.int(size), C.int(dynRatio))
 }

--- a/core.go
+++ b/core.go
@@ -179,7 +179,6 @@ var ErrEmptyByteSlice = errors.New("empty byte array")
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d3/d63/classcv_1_1Mat.html
-//
 type Mat struct {
 	p C.Mat
 
@@ -340,7 +339,6 @@ func (m *Mat) Empty() bool {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/d63/classcv_1_1Mat.html#aa90cea495029c7d1ee0a41361ccecdf3
-//
 func (m *Mat) IsContinuous() bool {
 	return bool(C.Mat_IsContinuous(m.p))
 }
@@ -354,7 +352,6 @@ func (m *Mat) Clone() Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/d63/classcv_1_1Mat.html#a33fd5d125b4c302b0c9aa86980791a77
-//
 func (m *Mat) CopyTo(dst *Mat) {
 	C.Mat_CopyTo(m.p, dst.p)
 	return
@@ -364,7 +361,6 @@ func (m *Mat) CopyTo(dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/d63/classcv_1_1Mat.html#a626fe5f96d02525e2604d2ad46dd574f
-//
 func (m *Mat) CopyToWithMask(dst *Mat, mask Mat) {
 	C.Mat_CopyToWithMask(m.p, dst.p, mask.p)
 	return
@@ -374,7 +370,6 @@ func (m *Mat) CopyToWithMask(dst *Mat, mask Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/d63/classcv_1_1Mat.html#adf88c60c5b4980e05bb556080916978b
-//
 func (m *Mat) ConvertTo(dst *Mat, mt MatType) {
 	C.Mat_ConvertTo(m.p, dst.p, C.int(mt))
 	return
@@ -389,7 +384,6 @@ func (m *Mat) ConvertToWithParams(dst *Mat, mt MatType, alpha, beta float32) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/d63/classcv_1_1Mat.html#aa4d317d43fb0cba9c2503f3c61b866c8
-//
 func (m *Mat) Total() int {
 	return int(C.Mat_Total(m.p))
 }
@@ -398,7 +392,6 @@ func (m *Mat) Total() int {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/d63/classcv_1_1Mat.html#aa4d317d43fb0cba9c2503f3c61b866c8
-//
 func (m *Mat) Size() (dims []int) {
 	cdims := C.IntVector{}
 	C.Mat_Size(m.p, &cdims)
@@ -572,7 +565,6 @@ func (m *Mat) Region(rio image.Rectangle) Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/d63/classcv_1_1Mat.html#a4eb96e3251417fa88b78e2abd6cfd7d8
-//
 func (m *Mat) Reshape(cn int, rows int) Mat {
 	return newMat(C.Mat_Reshape(m.p, C.int(cn), C.int(rows)))
 }
@@ -581,7 +573,6 @@ func (m *Mat) Reshape(cn int, rows int) Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga9c25d9ef44a2a48ecc3774b30cb80082
-//
 func (m *Mat) ConvertFp16() Mat {
 	return newMat(C.Mat_ConvertFp16(m.p))
 }
@@ -589,7 +580,6 @@ func (m *Mat) ConvertFp16() Mat {
 // Mean calculates the mean value M of array elements, independently for each channel, and return it as Scalar
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga191389f8a0e58180bb13a727782cd461
-//
 func (m *Mat) Mean() Scalar {
 	s := C.Mat_Mean(m.p)
 	return NewScalar(float64(s.val1), float64(s.val2), float64(s.val3), float64(s.val4))
@@ -598,7 +588,6 @@ func (m *Mat) Mean() Scalar {
 // MeanWithMask calculates the mean value M of array elements,independently for each channel,
 // and returns it as Scalar vector while applying the mask.
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga191389f8a0e58180bb13a727782cd461
-//
 func (m *Mat) MeanWithMask(mask Mat) Scalar {
 	s := C.Mat_MeanWithMask(m.p, mask.p)
 	return NewScalar(float64(s.val1), float64(s.val2), float64(s.val3), float64(s.val4))
@@ -608,7 +597,6 @@ func (m *Mat) MeanWithMask(mask Mat) Scalar {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga186222c3919657890f88df5a1f64a7d7
-//
 func (m *Mat) Sqrt() Mat {
 	return newMat(C.Mat_Sqrt(m.p))
 }
@@ -617,7 +605,6 @@ func (m *Mat) Sqrt() Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga716e10a2dd9e228e4d3c95818f106722
-//
 func (m *Mat) Sum() Scalar {
 	s := C.Mat_Sum(m.p)
 	return NewScalar(float64(s.val1), float64(s.val2), float64(s.val3), float64(s.val4))
@@ -627,7 +614,6 @@ func (m *Mat) Sum() Scalar {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga62286befb7cde3568ff8c7d14d5079da
-//
 func (m *Mat) PatchNaNs() {
 	C.Mat_PatchNaNs(m.p)
 }
@@ -893,7 +879,6 @@ func (m *Mat) T() Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga6fef31bc8c4071cbc114a758a2b79c14
-//
 func AbsDiff(src1, src2 Mat, dst *Mat) {
 	C.Mat_AbsDiff(src1.p, src2.p, dst.p)
 }
@@ -902,7 +887,6 @@ func AbsDiff(src1, src2 Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga10ac1bfb180e2cfda1701d06c24fdbd6
-//
 func Add(src1, src2 Mat, dst *Mat) {
 	C.Mat_Add(src1.p, src2.p, dst.p)
 }
@@ -911,7 +895,6 @@ func Add(src1, src2 Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gafafb2513349db3bcff51f54ee5592a19
-//
 func AddWeighted(src1 Mat, alpha float64, src2 Mat, beta float64, gamma float64, dst *Mat) {
 	C.Mat_AddWeighted(src1.p, C.double(alpha),
 		src2.p, C.double(beta), C.double(gamma), dst.p)
@@ -923,7 +906,6 @@ func AddWeighted(src1 Mat, alpha float64, src2 Mat, beta float64, gamma float64,
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga60b4d04b251ba5eb1392c34425497e14
-//
 func BitwiseAnd(src1 Mat, src2 Mat, dst *Mat) {
 	C.Mat_BitwiseAnd(src1.p, src2.p, dst.p)
 }
@@ -934,7 +916,6 @@ func BitwiseAnd(src1 Mat, src2 Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga60b4d04b251ba5eb1392c34425497e14
-//
 func BitwiseAndWithMask(src1 Mat, src2 Mat, dst *Mat, mask Mat) {
 	C.Mat_BitwiseAndWithMask(src1.p, src2.p, dst.p, mask.p)
 }
@@ -943,7 +924,6 @@ func BitwiseAndWithMask(src1 Mat, src2 Mat, dst *Mat, mask Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga0002cf8b418479f4cb49a75442baee2f
-//
 func BitwiseNot(src1 Mat, dst *Mat) {
 	C.Mat_BitwiseNot(src1.p, dst.p)
 }
@@ -952,7 +932,6 @@ func BitwiseNot(src1 Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga0002cf8b418479f4cb49a75442baee2f
-//
 func BitwiseNotWithMask(src1 Mat, dst *Mat, mask Mat) {
 	C.Mat_BitwiseNotWithMask(src1.p, dst.p, mask.p)
 }
@@ -962,7 +941,6 @@ func BitwiseNotWithMask(src1 Mat, dst *Mat, mask Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gab85523db362a4e26ff0c703793a719b4
-//
 func BitwiseOr(src1 Mat, src2 Mat, dst *Mat) {
 	C.Mat_BitwiseOr(src1.p, src2.p, dst.p)
 }
@@ -972,7 +950,6 @@ func BitwiseOr(src1 Mat, src2 Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gab85523db362a4e26ff0c703793a719b4
-//
 func BitwiseOrWithMask(src1 Mat, src2 Mat, dst *Mat, mask Mat) {
 	C.Mat_BitwiseOrWithMask(src1.p, src2.p, dst.p, mask.p)
 }
@@ -982,7 +959,6 @@ func BitwiseOrWithMask(src1 Mat, src2 Mat, dst *Mat, mask Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga84b2d8188ce506593dcc3f8cd00e8e2c
-//
 func BitwiseXor(src1 Mat, src2 Mat, dst *Mat) {
 	C.Mat_BitwiseXor(src1.p, src2.p, dst.p)
 }
@@ -992,7 +968,6 @@ func BitwiseXor(src1 Mat, src2 Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga84b2d8188ce506593dcc3f8cd00e8e2c
-//
 func BitwiseXorWithMask(src1 Mat, src2 Mat, dst *Mat, mask Mat) {
 	C.Mat_BitwiseXorWithMask(src1.p, src2.p, dst.p, mask.p)
 }
@@ -1001,7 +976,6 @@ func BitwiseXorWithMask(src1 Mat, src2 Mat, dst *Mat, mask Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga4ba778a1c57f83233b1d851c83f5a622
-//
 func BatchDistance(src1 Mat, src2 Mat, dist Mat, dtype MatType, nidx Mat, normType NormType, K int, mask Mat, update int, crosscheck bool) {
 	C.Mat_BatchDistance(src1.p, src2.p, dist.p, C.int(dtype), nidx.p, C.int(normType), C.int(K), mask.p, C.int(update), C.bool(crosscheck))
 }
@@ -1010,7 +984,6 @@ func BatchDistance(src1 Mat, src2 Mat, dist Mat, dtype MatType, nidx Mat, normTy
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga247f571aa6244827d3d798f13892da58
-//
 func BorderInterpolate(p int, len int, borderType CovarFlags) int {
 	ret := C.Mat_BorderInterpolate(C.int(p), C.int(len), C.int(borderType))
 	return int(ret)
@@ -1020,7 +993,6 @@ func BorderInterpolate(p int, len int, borderType CovarFlags) int {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/de1/group__core.html#ga719ebd4a73f30f4fab258ab7616d0f0f
-//
 type CovarFlags int
 
 const (
@@ -1047,7 +1019,6 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga017122d912af19d7d0d2cccc2d63819f
-//
 func CalcCovarMatrix(samples Mat, covar *Mat, mean *Mat, flags CovarFlags, ctype MatType) {
 	C.Mat_CalcCovarMatrix(samples.p, covar.p, mean.p, C.int(flags), C.int(ctype))
 }
@@ -1056,7 +1027,6 @@ func CalcCovarMatrix(samples Mat, covar *Mat, mean *Mat, flags CovarFlags, ctype
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gac5f92f48ec32cacf5275969c33ee837d
-//
 func CartToPolar(x Mat, y Mat, magnitude *Mat, angle *Mat, angleInDegrees bool) {
 	C.Mat_CartToPolar(x.p, y.p, magnitude.p, angle.p, C.bool(angleInDegrees))
 }
@@ -1065,7 +1035,6 @@ func CartToPolar(x Mat, y Mat, magnitude *Mat, angle *Mat, angleInDegrees bool) 
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga2bd19d89cae59361416736f87e3c7a64
-//
 func CheckRange(src Mat) bool {
 	return bool(C.Mat_CheckRange(src.p))
 }
@@ -1075,7 +1044,6 @@ func CheckRange(src Mat) bool {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga303cfb72acf8cbb36d884650c09a3a97
-//
 func Compare(src1 Mat, src2 Mat, dst *Mat, ct CompareType) {
 	C.Mat_Compare(src1.p, src2.p, dst.p, C.int(ct))
 }
@@ -1084,7 +1052,6 @@ func Compare(src1 Mat, src2 Mat, dst *Mat, ct CompareType) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gaa4b89393263bb4d604e0fe5986723914
-//
 func CountNonZero(src Mat) int {
 	return int(C.Mat_CountNonZero(src.p))
 }
@@ -1093,7 +1060,6 @@ func CountNonZero(src Mat) int {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gaa9d88dcd0e54b6d1af38d41f2a3e3d25
-//
 func CompleteSymm(m Mat, lowerToUpper bool) {
 	C.Mat_CompleteSymm(m.p, C.bool(lowerToUpper))
 }
@@ -1102,7 +1068,6 @@ func CompleteSymm(m Mat, lowerToUpper bool) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga3460e9c9f37b563ab9dd550c4d8c4e7d
-//
 func ConvertScaleAbs(src Mat, dst *Mat, alpha float64, beta float64) {
 	C.Mat_ConvertScaleAbs(src.p, dst.p, C.double(alpha), C.double(beta))
 }
@@ -1111,7 +1076,6 @@ func ConvertScaleAbs(src Mat, dst *Mat, alpha float64, beta float64) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga2ac1049c2c3dd25c2b41bffe17658a36
-//
 func CopyMakeBorder(src Mat, dst *Mat, top int, bottom int, left int, right int, bt BorderType, value color.RGBA) {
 
 	cValue := C.struct_Scalar{
@@ -1128,7 +1092,6 @@ func CopyMakeBorder(src Mat, dst *Mat, top int, bottom int, left int, right int,
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gaf4dde112b483b38175621befedda1f1c
-//
 type DftFlags int
 
 const (
@@ -1166,7 +1129,6 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga85aad4d668c01fbd64825f589e3696d4
-//
 func DCT(src Mat, dst *Mat, flags DftFlags) {
 	C.Mat_DCT(src.p, dst.p, C.int(flags))
 }
@@ -1175,7 +1137,6 @@ func DCT(src Mat, dst *Mat, flags DftFlags) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gaf802bd9ca3e07b8b6170645ef0611d0c
-//
 func Determinant(src Mat) float64 {
 	return float64(C.Mat_Determinant(src.p))
 }
@@ -1185,7 +1146,6 @@ func Determinant(src Mat) float64 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gadd6cf9baf2b8b704a11b5f04aaf4f39d
-//
 func DFT(src Mat, dst *Mat, flags DftFlags) {
 	C.Mat_DFT(src.p, dst.p, C.int(flags))
 }
@@ -1195,7 +1155,6 @@ func DFT(src Mat, dst *Mat, flags DftFlags) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga6db555d30115642fedae0cda05604874
-//
 func Divide(src1 Mat, src2 Mat, dst *Mat) {
 	C.Mat_Divide(src1.p, src2.p, dst.p)
 }
@@ -1204,7 +1163,6 @@ func Divide(src1 Mat, src2 Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga9fa0d58657f60eaa6c71f6fbb40456e3
-//
 func Eigen(src Mat, eigenvalues *Mat, eigenvectors *Mat) bool {
 	ret := C.Mat_Eigen(src.p, eigenvalues.p, eigenvectors.p)
 	return bool(ret)
@@ -1214,7 +1172,6 @@ func Eigen(src Mat, eigenvalues *Mat, eigenvectors *Mat) bool {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gaf51987e03cac8d171fbd2b327cf966f6
-//
 func EigenNonSymmetric(src Mat, eigenvalues *Mat, eigenvectors *Mat) {
 	C.Mat_EigenNonSymmetric(src.p, eigenvalues.p, eigenvectors.p)
 }
@@ -1228,7 +1185,6 @@ func EigenNonSymmetric(src Mat, eigenvalues *Mat, eigenvectors *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d2/de8/group__core__array.html#ga27a565b31d820b05dcbcd47112176b6e
-//
 func PCACompute(src Mat, mean *Mat, eigenvectors *Mat, eigenvalues *Mat, maxComponents int) {
 	C.Mat_PCACompute(src.p, mean.p, eigenvectors.p, eigenvalues.p, C.int(maxComponents))
 }
@@ -1237,7 +1193,6 @@ func PCACompute(src Mat, mean *Mat, eigenvectors *Mat, eigenvalues *Mat, maxComp
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga3e10108e2162c338f1b848af619f39e5
-//
 func Exp(src Mat, dst *Mat) {
 	C.Mat_Exp(src.p, dst.p)
 }
@@ -1246,7 +1201,6 @@ func Exp(src Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gacc6158574aa1f0281878c955bcf35642
-//
 func ExtractChannel(src Mat, dst *Mat, coi int) {
 	C.Mat_ExtractChannel(src.p, dst.p, C.int(coi))
 }
@@ -1255,7 +1209,6 @@ func ExtractChannel(src Mat, dst *Mat, coi int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gaed7df59a3539b4cc0fe5c9c8d7586190
-//
 func FindNonZero(src Mat, idx *Mat) {
 	C.Mat_FindNonZero(src.p, idx.p)
 }
@@ -1264,7 +1217,6 @@ func FindNonZero(src Mat, idx *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gaca7be533e3dac7feb70fc60635adf441
-//
 func Flip(src Mat, dst *Mat, flipCode int) {
 	C.Mat_Flip(src.p, dst.p, C.int(flipCode))
 }
@@ -1273,7 +1225,6 @@ func Flip(src Mat, dst *Mat, flipCode int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gacb6e64071dffe36434e1e7ee79e7cb35
-//
 func Gemm(src1, src2 Mat, alpha float64, src3 Mat, beta float64, dst *Mat, flags int) {
 	C.Mat_Gemm(src1.p, src2.p, C.double(alpha), src3.p, C.double(beta), dst.p, C.int(flags))
 }
@@ -1283,7 +1234,6 @@ func Gemm(src1, src2 Mat, alpha float64, src3 Mat, beta float64, dst *Mat, flags
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga6577a2e59968936ae02eb2edde5de299
-//
 func GetOptimalDFTSize(vecsize int) int {
 	return int(C.Mat_GetOptimalDFTSize(C.int(vecsize)))
 }
@@ -1292,7 +1242,6 @@ func GetOptimalDFTSize(vecsize int) int {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gaab5ceee39e0580f879df645a872c6bf7
-//
 func Hconcat(src1, src2 Mat, dst *Mat) {
 	C.Mat_Hconcat(src1.p, src2.p, dst.p)
 }
@@ -1301,13 +1250,11 @@ func Hconcat(src1, src2 Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gaab5ceee39e0580f879df645a872c6bf7
-//
 func Vconcat(src1, src2 Mat, dst *Mat) {
 	C.Mat_Vconcat(src1.p, src2.p, dst.p)
 }
 
 // RotateFlag for image rotation
-//
 //
 // For further details please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga6f45d55c0b1cc9d97f5353a7c8a7aac2
@@ -1334,7 +1281,6 @@ func Rotate(src Mat, dst *Mat, code RotateFlag) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga77b168d84e564c50228b69730a227ef2
-//
 func IDCT(src Mat, dst *Mat, flags int) {
 	C.Mat_Idct(src.p, dst.p, C.int(flags))
 }
@@ -1343,7 +1289,6 @@ func IDCT(src Mat, dst *Mat, flags int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gaa708aa2d2e57a508f968eb0f69aa5ff1
-//
 func IDFT(src Mat, dst *Mat, flags, nonzeroRows int) {
 	C.Mat_Idft(src.p, dst.p, C.int(flags), C.int(nonzeroRows))
 }
@@ -1352,7 +1297,6 @@ func IDFT(src Mat, dst *Mat, flags, nonzeroRows int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga48af0ab51e36436c5d04340e036ce981
-//
 func InRange(src, lb, ub Mat, dst *Mat) {
 	C.Mat_InRange(src.p, lb.p, ub.p, dst.p)
 }
@@ -1361,7 +1305,6 @@ func InRange(src, lb, ub Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga48af0ab51e36436c5d04340e036ce981
-//
 func InRangeWithScalar(src Mat, lb, ub Scalar, dst *Mat) {
 	lbVal := C.struct_Scalar{
 		val1: C.double(lb.Val1),
@@ -1385,7 +1328,6 @@ func InRangeWithScalar(src Mat, lb, ub Scalar, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga1d4bd886d35b00ec0b764cb4ce6eb515
-//
 func InsertChannel(src Mat, dst *Mat, coi int) {
 	C.Mat_InsertChannel(src.p, dst.p, C.int(coi))
 }
@@ -1394,7 +1336,6 @@ func InsertChannel(src Mat, dst *Mat, coi int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gad278044679d4ecf20f7622cc151aaaa2
-//
 func Invert(src Mat, dst *Mat, flags SolveDecompositionFlags) float64 {
 	ret := C.Mat_Invert(src.p, dst.p, C.int(flags))
 	return float64(ret)
@@ -1420,7 +1361,6 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d5/d38/group__core__cluster.html#ga9a34dc06c6ec9460e90860f15bcd2f88
-//
 func KMeans(data Mat, k int, bestLabels *Mat, criteria TermCriteria, attempts int, flags KMeansFlags, centers *Mat) float64 {
 	ret := C.KMeans(data.p, C.int(k), bestLabels.p, criteria.p, C.int(attempts), C.int(flags), centers.p)
 	return float64(ret)
@@ -1430,7 +1370,6 @@ func KMeans(data Mat, k int, bestLabels *Mat, criteria TermCriteria, attempts in
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d5/d38/group__core__cluster.html#ga9a34dc06c6ec9460e90860f15bcd2f88
-//
 func KMeansPoints(points PointVector, k int, bestLabels *Mat, criteria TermCriteria, attempts int, flags KMeansFlags, centers *Mat) float64 {
 	ret := C.KMeansPoints(points.p, C.int(k), bestLabels.p, criteria.p, C.int(attempts), C.int(flags), centers.p)
 	return float64(ret)
@@ -1440,7 +1379,6 @@ func KMeansPoints(points PointVector, k int, bestLabels *Mat, criteria TermCrite
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga937ecdce4679a77168730830a955bea7
-//
 func Log(src Mat, dst *Mat) {
 	C.Mat_Log(src.p, dst.p)
 }
@@ -1449,7 +1387,6 @@ func Log(src Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga6d3b097586bca4409873d64a90fe64c3
-//
 func Magnitude(x, y Mat, magnitude *Mat) {
 	C.Mat_Magnitude(x.p, y.p, magnitude.p)
 }
@@ -1458,7 +1395,6 @@ func Magnitude(x, y Mat, magnitude *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gacc40fa15eac0fb83f8ca70b7cc0b588d
-//
 func Max(src1, src2 Mat, dst *Mat) {
 	C.Mat_Max(src1.p, src2.p, dst.p)
 }
@@ -1467,7 +1403,6 @@ func Max(src1, src2 Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga846c858f4004d59493d7c6a4354b301d
-//
 func MeanStdDev(src Mat, dst *Mat, dstStdDev *Mat) {
 	C.Mat_MeanStdDev(src.p, dst.p, dstStdDev.p)
 }
@@ -1476,7 +1411,6 @@ func MeanStdDev(src Mat, dst *Mat, dstStdDev *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga7d7b4d6c6ee504b30a20b1680029c7b4
-//
 func Merge(mv []Mat, dst *Mat) {
 	cMatArray := make([]C.Mat, len(mv))
 	for i, r := range mv {
@@ -1494,7 +1428,6 @@ func Merge(mv []Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga9af368f182ee76d0463d0d8d5330b764
-//
 func Min(src1, src2 Mat, dst *Mat) {
 	C.Mat_Min(src1.p, src2.p, dst.p)
 }
@@ -1503,7 +1436,6 @@ func Min(src1, src2 Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga7622c466c628a75d9ed008b42250a73f
-//
 func MinMaxIdx(input Mat) (minVal, maxVal float32, minIdx, maxIdx int) {
 	var cMinVal C.double
 	var cMaxVal C.double
@@ -1519,7 +1451,6 @@ func MinMaxIdx(input Mat) (minVal, maxVal float32, minIdx, maxIdx int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/trunk/d2/de8/group__core__array.html#gab473bf2eb6d14ff97e89b355dac20707
-//
 func MinMaxLoc(input Mat) (minVal, maxVal float32, minLoc, maxLoc image.Point) {
 	var cMinVal C.double
 	var cMaxVal C.double
@@ -1538,7 +1469,6 @@ func MinMaxLoc(input Mat) (minVal, maxVal float32, minLoc, maxLoc image.Point) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga51d768c270a1cdd3497255017c4504be
-//
 func MixChannels(src []Mat, dst []Mat, fromTo []int) {
 	cSrcArray := make([]C.Mat, len(src))
 	for i, r := range src {
@@ -1575,11 +1505,10 @@ func MixChannels(src []Mat, dst []Mat, fromTo []int) {
 	}
 }
 
-//Mulspectrums performs the per-element multiplication of two Fourier spectrums.
+// Mulspectrums performs the per-element multiplication of two Fourier spectrums.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga3ab38646463c59bf0ce962a9d51db64f
-//
 func MulSpectrums(a Mat, b Mat, dst *Mat, flags DftFlags) {
 	C.Mat_MulSpectrums(a.p, b.p, dst.p, C.int(flags))
 }
@@ -1589,7 +1518,6 @@ func MulSpectrums(a Mat, b Mat, dst *Mat, flags DftFlags) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga979d898a58d7f61c53003e162e7ad89f
-//
 func Multiply(src1 Mat, src2 Mat, dst *Mat) {
 	C.Mat_Multiply(src1.p, src2.p, dst.p)
 }
@@ -1599,7 +1527,6 @@ func Multiply(src1 Mat, src2 Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga979d898a58d7f61c53003e162e7ad89f
-//
 func MultiplyWithParams(src1 Mat, src2 Mat, dst *Mat, scale float64, dtype MatType) {
 	C.Mat_MultiplyWithParams(src1.p, src2.p, dst.p, C.double(scale), C.int(dtype))
 }
@@ -1608,7 +1535,6 @@ func MultiplyWithParams(src1 Mat, src2 Mat, dst *Mat, scale float64, dtype MatTy
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gad12cefbcb5291cf958a85b4b67b6149f
-//
 type NormType int
 
 const (
@@ -1644,7 +1570,6 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga87eef7ee3970f86906d69a92cbf064bd
-//
 func Normalize(src Mat, dst *Mat, alpha float64, beta float64, typ NormType) {
 	C.Mat_Normalize(src.p, dst.p, C.double(alpha), C.double(beta), C.int(typ))
 }
@@ -1653,7 +1578,6 @@ func Normalize(src Mat, dst *Mat, alpha float64, beta float64, typ NormType) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga7c331fb8dd951707e184ef4e3f21dd33
-//
 func Norm(src1 Mat, normType NormType) float64 {
 	return float64(C.Norm(src1.p, C.int(normType)))
 }
@@ -1662,7 +1586,6 @@ func Norm(src1 Mat, normType NormType) float64 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga7c331fb8dd951707e184ef4e3f21dd33
-//
 func NormWithMats(src1 Mat, src2 Mat, normType NormType) float64 {
 	return float64(C.NormWithMats(src1.p, src2.p, C.int(normType)))
 }
@@ -1671,7 +1594,6 @@ func NormWithMats(src1 Mat, src2 Mat, normType NormType) float64 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gad327659ac03e5fd6894b90025e6900a7
-//
 func PerspectiveTransform(src Mat, dst *Mat, tm Mat) {
 	C.Mat_PerspectiveTransform(src.p, dst.p, tm.p)
 }
@@ -1680,7 +1602,6 @@ func PerspectiveTransform(src Mat, dst *Mat, tm Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d5d/classcv_1_1TermCriteria.html#a56fecdc291ccaba8aad27d67ccf72c57
-//
 type TermCriteriaType int
 
 const (
@@ -1723,7 +1644,6 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga12b43690dbd31fed96f213eefead2373
-//
 func Solve(src1 Mat, src2 Mat, dst *Mat, flags SolveDecompositionFlags) bool {
 	return bool(C.Mat_Solve(src1.p, src2.p, dst.p, C.int(flags)))
 }
@@ -1732,7 +1652,6 @@ func Solve(src1 Mat, src2 Mat, dst *Mat, flags SolveDecompositionFlags) bool {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga1c3b0b925b085b6e96931ee309e6a1da
-//
 func SolveCubic(coeffs Mat, roots *Mat) int {
 	return int(C.Mat_SolveCubic(coeffs.p, roots.p))
 }
@@ -1741,7 +1660,6 @@ func SolveCubic(coeffs Mat, roots *Mat) int {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gac2f5e953016fabcdf793d762f4ec5dce
-//
 func SolvePoly(coeffs Mat, roots *Mat, maxIters int) float64 {
 	return float64(C.Mat_SolvePoly(coeffs.p, roots.p, C.int(maxIters)))
 }
@@ -1766,7 +1684,6 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga4b78072a303f29d9031d56e5638da78e
-//
 func Reduce(src Mat, dst *Mat, dim int, rType ReduceTypes, dType MatType) {
 	C.Mat_Reduce(src.p, dst.p, C.int(dim), C.int(rType), C.int(dType))
 }
@@ -1775,7 +1692,6 @@ func Reduce(src Mat, dst *Mat, dim int, rType ReduceTypes, dType MatType) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gaa87ea34d99bcc5bf9695048355163da0
-//
 func ReduceArgMax(src Mat, dst *Mat, axis int, lastIndex bool) {
 	C.Mat_ReduceArgMax(src.p, dst.p, C.int(axis), C.bool(lastIndex))
 }
@@ -1784,7 +1700,6 @@ func ReduceArgMax(src Mat, dst *Mat, axis int, lastIndex bool) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gaeecd548276bfb91b938989e66b722088
-//
 func ReduceArgMin(src Mat, dst *Mat, axis int, lastIndex bool) {
 	C.Mat_ReduceArgMin(src.p, dst.p, C.int(axis), C.bool(lastIndex))
 }
@@ -1793,7 +1708,6 @@ func ReduceArgMin(src Mat, dst *Mat, axis int, lastIndex bool) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga496c3860f3ac44c40b48811333cfda2d
-//
 func Repeat(src Mat, nY int, nX int, dst *Mat) {
 	C.Mat_Repeat(src.p, C.int(nY), C.int(nX), dst.p)
 }
@@ -1802,15 +1716,14 @@ func Repeat(src Mat, nY int, nX int, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga9e0845db4135f55dcf20227402f00d98
-//
 func ScaleAdd(src1 Mat, alpha float64, src2 Mat, dst *Mat) {
 	C.Mat_ScaleAdd(src1.p, C.double(alpha), src2.p, dst.p)
 }
 
 // SetIdentity initializes a scaled identity matrix.
 // For further details, please see:
-//  https://docs.opencv.org/master/d2/de8/group__core__array.html#ga388d7575224a4a277ceb98ccaa327c99
 //
+//	https://docs.opencv.org/master/d2/de8/group__core__array.html#ga388d7575224a4a277ceb98ccaa327c99
 func SetIdentity(src Mat, scalar float64) {
 	C.Mat_SetIdentity(src.p, C.double(scalar))
 }
@@ -1835,7 +1748,6 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga45dd56da289494ce874be2324856898f
-//
 func Sort(src Mat, dst *Mat, flags SortFlags) {
 	C.Mat_Sort(src.p, dst.p, C.int(flags))
 }
@@ -1845,7 +1757,6 @@ func Sort(src Mat, dst *Mat, flags SortFlags) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gadf35157cbf97f3cb85a545380e383506
-//
 func SortIdx(src Mat, dst *Mat, flags SortFlags) {
 	C.Mat_SortIdx(src.p, dst.p, C.int(flags))
 }
@@ -1855,7 +1766,6 @@ func SortIdx(src Mat, dst *Mat, flags SortFlags) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga0547c7fed86152d7e9d0096029c8518a
-//
 func Split(src Mat) (mv []Mat) {
 	cMats := C.struct_Mats{}
 	C.Mat_Split(src.p, &(cMats))
@@ -1872,7 +1782,6 @@ func Split(src Mat) (mv []Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gaa0f00d98b4b5edeaeb7b8333b2de353b
-//
 func Subtract(src1 Mat, src2 Mat, dst *Mat) {
 	C.Mat_Subtract(src1.p, src2.p, dst.p)
 }
@@ -1881,7 +1790,6 @@ func Subtract(src1 Mat, src2 Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga3419ac19c7dcd2be4bd552a23e147dd8
-//
 func Trace(src Mat) Scalar {
 	s := C.Mat_Trace(src.p)
 	return NewScalar(float64(s.val1), float64(s.val2), float64(s.val3), float64(s.val4))
@@ -1891,7 +1799,6 @@ func Trace(src Mat) Scalar {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga393164aa54bb9169ce0a8cc44e08ff22
-//
 func Transform(src Mat, dst *Mat, tm Mat) {
 	C.Mat_Transform(src.p, dst.p, tm.p)
 }
@@ -1900,7 +1807,6 @@ func Transform(src Mat, dst *Mat, tm Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga46630ed6c0ea6254a35f447289bd7404
-//
 func Transpose(src Mat, dst *Mat) {
 	C.Mat_Transpose(src.p, dst.p)
 }
@@ -1909,7 +1815,6 @@ func Transpose(src Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gaf0d056b5bd1dc92500d6f6cf6bac41ef
-//
 func Pow(src Mat, power float64, dst *Mat) {
 	C.Mat_Pow(src.p, C.double(power), dst.p)
 }
@@ -1918,7 +1823,6 @@ func Pow(src Mat, power float64, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga581ff9d44201de2dd1b40a50db93d665
-//
 func PolarToCart(magnitude Mat, degree Mat, x *Mat, y *Mat, angleInDegrees bool) {
 	C.Mat_PolarToCart(magnitude.p, degree.p, x.p, y.p, C.bool(angleInDegrees))
 }
@@ -1927,7 +1831,6 @@ func PolarToCart(magnitude Mat, degree Mat, x *Mat, y *Mat, angleInDegrees bool)
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga9db9ca9b4d81c3bde5677b8f64dc0137
-//
 func Phase(x, y Mat, angle *Mat, angleInDegrees bool) {
 	C.Mat_Phase(x.p, y.p, angle.p, C.bool(angleInDegrees))
 }
@@ -1936,7 +1839,6 @@ func Phase(x, y Mat, angle *Mat, angleInDegrees bool) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d5d/classcv_1_1TermCriteria.html
-//
 type TermCriteria struct {
 	p C.TermCriteria
 }
@@ -1950,7 +1852,6 @@ func NewTermCriteria(typ TermCriteriaType, maxCount int, epsilon float64) TermCr
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d1/da0/classcv_1_1Scalar__.html
-//
 type Scalar struct {
 	Val1 float64
 	Val2 float64
@@ -1968,7 +1869,6 @@ func NewScalar(v1 float64, v2 float64, v3 float64, v4 float64) Scalar {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/d29/classcv_1_1KeyPoint.html
-//
 type KeyPoint struct {
 	X, Y                  float64
 	Size, Angle, Response float64
@@ -1979,7 +1879,6 @@ type KeyPoint struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/de0/classcv_1_1DMatch.html#a546ddb9a87898f06e510e015a6de596e
-//
 type DMatch struct {
 	QueryIdx int
 	TrainIdx int
@@ -2330,7 +2229,6 @@ func (pfv Point2fVector) Close() {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/de0/group__core__utils.html#gae73f58000611a1af25dd36d496bf4487
-//
 func GetTickCount() float64 {
 	return float64(C.GetCVTickCount())
 }
@@ -2339,7 +2237,6 @@ func GetTickCount() float64 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/de0/group__core__utils.html#ga705441a9ef01f47acdc55d87fbe5090c
-//
 func GetTickFrequency() float64 {
 	return float64(C.GetTickFrequency())
 }
@@ -2436,7 +2333,6 @@ func toCStrings(strs []string) C.struct_CStrings {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/d63/classcv_1_1Mat.html#aa6542193430356ad631a9beabc624107
-//
 func (m *Mat) RowRange(start, end int) Mat {
 	return newMat(C.Mat_rowRange(m.p, C.int(start), C.int(end)))
 }
@@ -2445,7 +2341,6 @@ func (m *Mat) RowRange(start, end int) Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/d63/classcv_1_1Mat.html#aadc8f9210fe4dec50513746c246fa8d9
-//
 func (m *Mat) ColRange(start, end int) Mat {
 	return newMat(C.Mat_colRange(m.p, C.int(start), C.int(end)))
 }
@@ -2457,7 +2352,6 @@ func (m *Mat) ColRange(start, end int) Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/dd6/classcv_1_1RNG.html
-//
 type RNG struct {
 	p C.RNG
 }
@@ -2475,7 +2369,6 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga75843061d150ad6564b5447e38e57722
-//
 func TheRNG() RNG {
 	return RNG{
 		p: C.TheRNG(),
@@ -2486,7 +2379,6 @@ func TheRNG() RNG {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga757e657c037410d9e19e819569e7de0f
-//
 func SetRNGSeed(seed int) {
 	C.SetRNGSeed(C.int(seed))
 }
@@ -2495,7 +2387,6 @@ func SetRNGSeed(seed int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/dd6/classcv_1_1RNG.html#ad26f2b09d9868cf108e84c9814aa682d
-//
 func (r *RNG) Fill(mat *Mat, distType RNGDistType, a, b float64, saturateRange bool) {
 	C.RNG_Fill(r.p, mat.p, C.int(distType), C.double(a), C.double(b), C.bool(saturateRange))
 }
@@ -2505,7 +2396,6 @@ func (r *RNG) Fill(mat *Mat, distType RNGDistType, a, b float64, saturateRange b
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/dd6/classcv_1_1RNG.html#a8df8ce4dc7d15916cee743e5a884639d
-//
 func (r *RNG) Gaussian(sigma float64) float64 {
 	return float64(C.RNG_Gaussian(r.p, C.double(sigma)))
 }
@@ -2515,7 +2405,6 @@ func (r *RNG) Gaussian(sigma float64) float64 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/dd6/classcv_1_1RNG.html#a8df8ce4dc7d15916cee743e5a884639d
-//
 func (r *RNG) Next() uint {
 	return uint(C.RNG_Next(r.p))
 }
@@ -2524,7 +2413,6 @@ func (r *RNG) Next() uint {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#gaeff1f61e972d133a04ce3a5f81cf6808
-//
 func RandN(mat *Mat, mean, stddev Scalar) {
 	meanVal := C.struct_Scalar{
 		val1: C.double(mean.Val1),
@@ -2546,7 +2434,6 @@ func RandN(mat *Mat, mean, stddev Scalar) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga6a789c8a5cb56c6dd62506179808f763
-//
 func RandShuffle(mat *Mat) {
 	C.RandShuffle(mat.p)
 }
@@ -2555,7 +2442,6 @@ func RandShuffle(mat *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga6a789c8a5cb56c6dd62506179808f763
-//
 func RandShuffleWithParams(mat *Mat, iterFactor float64, rng RNG) {
 	C.RandShuffleWithParams(mat.p, C.double(iterFactor), rng.p)
 }
@@ -2565,7 +2451,6 @@ func RandShuffleWithParams(mat *Mat, iterFactor float64, rng RNG) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga1ba1026dca0807b27057ba6a49d258c0
-//
 func RandU(mat *Mat, low, high Scalar) {
 	lowVal := C.struct_Scalar{
 		val1: C.double(low.Val1),

--- a/cuda/arithm.go
+++ b/cuda/arithm.go
@@ -14,7 +14,6 @@ import "gocv.io/x/gocv"
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga54a72bd772494ab34d05406fd76df2b6
-//
 func Abs(src GpuMat, dst *GpuMat) {
 	C.GpuAbs(src.p, dst.p, nil)
 }
@@ -24,7 +23,6 @@ func Abs(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga54a72bd772494ab34d05406fd76df2b6
-//
 func AbsWithStream(src GpuMat, dst *GpuMat, stream Stream) {
 	C.GpuAbs(src.p, dst.p, stream.p)
 }
@@ -34,7 +32,6 @@ func AbsWithStream(src GpuMat, dst *GpuMat, stream Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gac062b283cf46ee90f74a773d3382ab54
-//
 func AbsDiff(src1, src2 GpuMat, dst *GpuMat) {
 	C.GpuAbsDiff(src1.p, src2.p, dst.p, nil)
 }
@@ -44,7 +41,6 @@ func AbsDiff(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gac062b283cf46ee90f74a773d3382ab54
-//
 func AbsDiffWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 	C.GpuAbsDiff(src1.p, src2.p, dst.p, s.p)
 }
@@ -53,7 +49,6 @@ func AbsDiffWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga5d9794bde97ed23d1c1485249074a8b1
-//
 func Add(src1, src2 GpuMat, dst *GpuMat) {
 	C.GpuAdd(src1.p, src2.p, dst.p, nil)
 }
@@ -63,7 +58,6 @@ func Add(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga5d9794bde97ed23d1c1485249074a8b1
-//
 func AddWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 	C.GpuAdd(src1.p, src2.p, dst.p, s.p)
 }
@@ -73,7 +67,6 @@ func AddWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga78d7c1a013877abd4237fbfc4e13bd76
-//
 func BitwiseAnd(src1, src2 GpuMat, dst *GpuMat) {
 	C.GpuBitwiseAnd(src1.p, src2.p, dst.p, nil)
 }
@@ -83,7 +76,6 @@ func BitwiseAnd(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga78d7c1a013877abd4237fbfc4e13bd76
-//
 func BitwiseAndWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 	C.GpuBitwiseAnd(src1.p, src2.p, dst.p, s.p)
 }
@@ -92,7 +84,6 @@ func BitwiseAndWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gae58159a2259ae1acc76b531c171cf06a
-//
 func BitwiseNot(src GpuMat, dst *GpuMat) {
 	C.GpuBitwiseNot(src.p, dst.p, nil)
 }
@@ -102,7 +93,6 @@ func BitwiseNot(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gae58159a2259ae1acc76b531c171cf06a
-//
 func BitwiseNotWithStream(src GpuMat, dst *GpuMat, s Stream) {
 	C.GpuBitwiseNot(src.p, dst.p, s.p)
 }
@@ -112,7 +102,6 @@ func BitwiseNotWithStream(src GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gafd098ee3e51c68daa793999c1da3dfb7
-//
 func BitwiseOr(src1, src2 GpuMat, dst *GpuMat) {
 	C.GpuBitwiseOr(src1.p, src2.p, dst.p, nil)
 }
@@ -122,7 +111,6 @@ func BitwiseOr(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gafd098ee3e51c68daa793999c1da3dfb7
-//
 func BitwiseOrWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 	C.GpuBitwiseXor(src1.p, src2.p, dst.p, s.p)
 }
@@ -132,7 +120,6 @@ func BitwiseOrWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga3d95d4faafb099aacf18e8b915a4ad8d
-//
 func BitwiseXor(src1, src2 GpuMat, dst *GpuMat) {
 	C.GpuBitwiseXor(src1.p, src2.p, dst.p, nil)
 }
@@ -142,7 +129,6 @@ func BitwiseXor(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga3d95d4faafb099aacf18e8b915a4ad8d
-//
 func BitwiseXorWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 	C.GpuBitwiseXor(src1.p, src2.p, dst.p, s.p)
 }
@@ -151,7 +137,6 @@ func BitwiseXorWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga124315aa226260841e25cc0b9ea99dc3
-//
 func Divide(src1, src2 GpuMat, dst *GpuMat) {
 	C.GpuDivide(src1.p, src2.p, dst.p, nil)
 }
@@ -161,7 +146,6 @@ func Divide(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga124315aa226260841e25cc0b9ea99dc3
-//
 func DivideWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 	C.GpuDivide(src1.p, src2.p, dst.p, s.p)
 }
@@ -170,7 +154,6 @@ func DivideWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gac6e51541d3bb0a7a396128e4d5919b61
-//
 func Exp(src GpuMat, dst *GpuMat) {
 	C.GpuExp(src.p, dst.p, nil)
 }
@@ -180,7 +163,6 @@ func Exp(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gac6e51541d3bb0a7a396128e4d5919b61
-//
 func ExpWithStream(src GpuMat, dst *GpuMat, s Stream) {
 	C.GpuExp(src.p, dst.p, s.p)
 }
@@ -189,7 +171,6 @@ func ExpWithStream(src GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gac6e51541d3bb0a7a396128e4d5919b61
-//
 func Log(src GpuMat, dst *GpuMat) {
 	C.GpuLog(src.p, dst.p, nil)
 }
@@ -199,7 +180,6 @@ func Log(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gac6e51541d3bb0a7a396128e4d5919b61
-//
 func LogWithStream(src GpuMat, dst *GpuMat, s Stream) {
 	C.GpuLog(src.p, dst.p, s.p)
 }
@@ -208,7 +188,6 @@ func LogWithStream(src GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gadb5dd3d870f10c0866035755b929b1e7
-//
 func Max(src1, src2 GpuMat, dst *GpuMat) {
 	C.GpuMax(src1.p, src2.p, dst.p, nil)
 }
@@ -218,7 +197,6 @@ func Max(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gadb5dd3d870f10c0866035755b929b1e7
-//
 func MaxWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 	C.GpuMax(src1.p, src2.p, dst.p, s.p)
 }
@@ -227,7 +205,6 @@ func MaxWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga74f0b05a65b3d949c237abb5e6c60867
-//
 func Min(src1, src2 GpuMat, dst *GpuMat) {
 	C.GpuMin(src1.p, src2.p, dst.p, nil)
 }
@@ -237,7 +214,6 @@ func Min(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga74f0b05a65b3d949c237abb5e6c60867
-//
 func MinWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 	C.GpuMin(src1.p, src2.p, dst.p, s.p)
 }
@@ -246,7 +222,6 @@ func MinWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga124315aa226260841e25cc0b9ea99dc3
-//
 func Multiply(src1, src2 GpuMat, dst *GpuMat) {
 	C.GpuMultiply(src1.p, src2.p, dst.p, nil)
 }
@@ -255,7 +230,6 @@ func Multiply(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga8aae233da90ce0ffe309ab8004342acb
-//
 func Sqr(src GpuMat, dst *GpuMat) {
 	C.GpuSqr(src.p, dst.p, nil)
 }
@@ -265,7 +239,6 @@ func Sqr(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga8aae233da90ce0ffe309ab8004342acb
-//
 func SqrWithStream(src GpuMat, dst *GpuMat, s Stream) {
 	C.GpuSqr(src.p, dst.p, s.p)
 }
@@ -274,7 +247,6 @@ func SqrWithStream(src GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga09303680cb1a5521a922b6d392028d8c
-//
 func Sqrt(src GpuMat, dst *GpuMat) {
 	C.GpuSqrt(src.p, dst.p, nil)
 }
@@ -284,7 +256,6 @@ func Sqrt(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga09303680cb1a5521a922b6d392028d8c
-//
 func SqrtWithStream(src GpuMat, dst *GpuMat, s Stream) {
 	C.GpuSqrt(src.p, dst.p, s.p)
 }
@@ -293,7 +264,6 @@ func SqrtWithStream(src GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga6eab60fc250059e2fda79c5636bd067f
-//
 func Subtract(src1, src2 GpuMat, dst *GpuMat) {
 	C.GpuSubtract(src1.p, src2.p, dst.p, nil)
 }
@@ -303,7 +273,6 @@ func Subtract(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga6eab60fc250059e2fda79c5636bd067f
-//
 func SubtractWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 	C.GpuSubtract(src1.p, src2.p, dst.p, s.p)
 }
@@ -312,7 +281,6 @@ func SubtractWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga40f1c94ae9a9456df3cad48e3cb008e1
-//
 func Threshold(src GpuMat, dst *GpuMat, thresh, maxval float64, typ gocv.ThresholdType) {
 	C.GpuThreshold(src.p, dst.p, C.double(thresh), C.double(maxval), C.int(typ), nil)
 }
@@ -322,7 +290,6 @@ func Threshold(src GpuMat, dst *GpuMat, thresh, maxval float64, typ gocv.Thresho
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga40f1c94ae9a9456df3cad48e3cb008e1
-//
 func ThresholdWithStream(src GpuMat, dst *GpuMat, thresh, maxval float64, typ gocv.ThresholdType, s Stream) {
 	C.GpuThreshold(src.p, dst.p, C.double(thresh), C.double(maxval), C.int(typ), s.p)
 }
@@ -331,7 +298,6 @@ func ThresholdWithStream(src GpuMat, dst *GpuMat, thresh, maxval float64, typ go
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/d09/group__cudaarithm__core.html#ga4d0a3f2b46e8f0f1ec2b5ac178dcd871
-//
 func Flip(src GpuMat, dst *GpuMat, flipCode int) {
 	C.GpuFlip(src.p, dst.p, C.int(flipCode), nil)
 }
@@ -341,7 +307,6 @@ func Flip(src GpuMat, dst *GpuMat, flipCode int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/d09/group__cudaarithm__core.html#ga4d0a3f2b46e8f0f1ec2b5ac178dcd871
-//
 func FlipWithStream(src GpuMat, dst *GpuMat, flipCode int, stream Stream) {
 	C.GpuFlip(src.p, dst.p, C.int(flipCode), stream.p)
 }

--- a/cuda/bgsegm.go
+++ b/cuda/bgsegm.go
@@ -25,7 +25,6 @@ type BackgroundSubtractorMOG struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d3d/cudabgsegm_8hpp.html
-//
 func NewBackgroundSubtractorMOG2() BackgroundSubtractorMOG2 {
 	return BackgroundSubtractorMOG2{p: unsafe.Pointer(C.CudaBackgroundSubtractorMOG2_Create())}
 }
@@ -41,7 +40,6 @@ func (b *BackgroundSubtractorMOG2) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/df/d23/classcv_1_1cuda_1_1BackgroundSubtractorMOG2.html#a92408f07bf1268c1b778cb186b3113b0
-//
 func (b *BackgroundSubtractorMOG2) Apply(src GpuMat, dst *GpuMat) {
 	C.CudaBackgroundSubtractorMOG2_Apply((C.CudaBackgroundSubtractorMOG2)(b.p), src.p, dst.p, nil)
 	return
@@ -52,7 +50,6 @@ func (b *BackgroundSubtractorMOG2) Apply(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/df/d23/classcv_1_1cuda_1_1BackgroundSubtractorMOG2.html#a92408f07bf1268c1b778cb186b3113b0
-//
 func (b *BackgroundSubtractorMOG2) ApplyWithStream(src GpuMat, dst *GpuMat, s Stream) {
 	C.CudaBackgroundSubtractorMOG2_Apply((C.CudaBackgroundSubtractorMOG2)(b.p), src.p, dst.p, s.p)
 	return
@@ -64,7 +61,6 @@ func (b *BackgroundSubtractorMOG2) ApplyWithStream(src GpuMat, dst *GpuMat, s St
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d3d/cudabgsegm_8hpp.html
-//
 func NewBackgroundSubtractorMOG() BackgroundSubtractorMOG {
 	return BackgroundSubtractorMOG{p: unsafe.Pointer(C.CudaBackgroundSubtractorMOG_Create())}
 }
@@ -80,7 +76,6 @@ func (b *BackgroundSubtractorMOG) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/dfe/classcv_1_1cuda_1_1BackgroundSubtractorMOG.html#a8f52d2f7abd1c77c84243efc53972cbf
-//
 func (b *BackgroundSubtractorMOG) Apply(src GpuMat, dst *GpuMat) {
 	C.CudaBackgroundSubtractorMOG_Apply((C.CudaBackgroundSubtractorMOG)(b.p), src.p, dst.p, nil)
 	return
@@ -91,7 +86,6 @@ func (b *BackgroundSubtractorMOG) Apply(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/dfe/classcv_1_1cuda_1_1BackgroundSubtractorMOG.html#a8f52d2f7abd1c77c84243efc53972cbf
-//
 func (b *BackgroundSubtractorMOG) ApplyWithStream(src GpuMat, dst *GpuMat, s Stream) {
 	C.CudaBackgroundSubtractorMOG_Apply((C.CudaBackgroundSubtractorMOG)(b.p), src.p, dst.p, s.p)
 	return

--- a/cuda/cuda.go
+++ b/cuda/cuda.go
@@ -25,7 +25,6 @@ type GpuMat struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d60/classcv_1_1cuda_1_1GpuMat.html#a00ef5bfe18d14623dcf578a35e40a46b
-//
 func (g *GpuMat) Upload(data gocv.Mat) {
 	C.GpuMat_Upload(g.p, C.Mat(data.Ptr()), nil)
 }
@@ -34,7 +33,6 @@ func (g *GpuMat) Upload(data gocv.Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d60/classcv_1_1cuda_1_1GpuMat.html#a00ef5bfe18d14623dcf578a35e40a46b
-//
 func (g *GpuMat) UploadWithStream(data gocv.Mat, s Stream) {
 	C.GpuMat_Upload(g.p, C.Mat(data.Ptr()), s.p)
 }
@@ -106,7 +104,6 @@ func GetCudaEnabledDeviceCount() int {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d40/group__cudacore__init.html#ga6ded4ed8e4fc483a9863d31f34ec9c0e
-//
 func GetDevice() int {
 	return int(C.GetCudaDevice())
 }
@@ -115,7 +112,6 @@ func GetDevice() int {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d40/group__cudacore__init.html#gaefa34186b185de47851836dba537828b
-//
 func SetDevice(device int) {
 	C.SetCudaDevice(C.int(device))
 }
@@ -127,7 +123,6 @@ func SetDevice(device int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d40/group__cudacore__init.html#ga6153b6f461101374e655a54fc77e725e
-//
 func ResetDevice() {
 	C.ResetCudaDevice()
 }
@@ -136,7 +131,6 @@ func ResetDevice() {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d60/classcv_1_1cuda_1_1GpuMat.html#a3a1b076e54d8a8503014e27a5440d98a
-//
 func (m *GpuMat) ConvertTo(dst *GpuMat, mt gocv.MatType) {
 	C.GpuMat_ConvertTo(m.p, dst.p, C.int(mt), nil)
 	return
@@ -146,7 +140,6 @@ func (m *GpuMat) ConvertTo(dst *GpuMat, mt gocv.MatType) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d60/classcv_1_1cuda_1_1GpuMat.html#a3a1b076e54d8a8503014e27a5440d98a
-//
 func (m *GpuMat) ConvertToWithStream(dst *GpuMat, mt gocv.MatType, s Stream) {
 	C.GpuMat_ConvertTo(m.p, dst.p, C.int(mt), s.p)
 	return
@@ -156,7 +149,6 @@ func (m *GpuMat) ConvertToWithStream(dst *GpuMat, mt gocv.MatType, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d60/classcv_1_1cuda_1_1GpuMat.html#a948c562ee340c0678a44884bde1f5a3e
-//
 func (m *GpuMat) CopyTo(dst *GpuMat) {
 	C.GpuMat_CopyTo(m.p, dst.p, nil)
 	return
@@ -166,7 +158,6 @@ func (m *GpuMat) CopyTo(dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d60/classcv_1_1cuda_1_1GpuMat.html#a948c562ee340c0678a44884bde1f5a3e
-//
 func (m *GpuMat) CopyToWithStream(dst *GpuMat, s Stream) {
 	C.GpuMat_CopyTo(m.p, dst.p, s.p)
 	return
@@ -197,7 +188,6 @@ func (m *GpuMat) Type() gocv.MatType {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d60/classcv_1_1cuda_1_1GpuMat.html#a408e22ed824d1ddf59f58bda895017a8
-//
 func (m *GpuMat) Reshape(cn int, rows int) GpuMat {
 	return newGpuMat(C.GpuMat_Reshape(m.p, C.int(cn), C.int(rows)))
 }
@@ -226,7 +216,6 @@ func (s *Stream) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/df3/classcv_1_1cuda_1_1Stream.html#a9fab618395d42fa31987506e42fab1b4
-//
 func (s *Stream) QueryIfComplete() bool {
 	return bool(C.Stream_QueryIfComplete(s.p))
 }
@@ -235,7 +224,6 @@ func (s *Stream) QueryIfComplete() bool {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/df3/classcv_1_1cuda_1_1Stream.html#a0e1d939503e8faad741ab584b720bca6
-//
 func (s *Stream) WaitForCompletion() {
 	C.Stream_WaitForCompletion(s.p)
 }

--- a/cuda/filters.go
+++ b/cuda/filters.go
@@ -18,7 +18,6 @@ import (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d66/group__cudafilters.html#gaa4df286369114cfd4b144ae211f6a6c8
-//
 type GaussianFilter struct {
 	p unsafe.Pointer
 }
@@ -44,7 +43,6 @@ func (gf *GaussianFilter) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d2b/classcv_1_1cuda_1_1Filter.html#a20b58d13871027473b4c39cc698cf80f
-//
 func (gf *GaussianFilter) Apply(img GpuMat, dst *GpuMat) {
 	C.GaussianFilter_Apply(C.GaussianFilter(gf.p), img.p, dst.p, nil)
 	return
@@ -55,7 +53,6 @@ func (gf *GaussianFilter) Apply(img GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d2b/classcv_1_1cuda_1_1Filter.html#a20b58d13871027473b4c39cc698cf80f
-//
 func (gf *GaussianFilter) ApplyWithStream(img GpuMat, dst *GpuMat, s Stream) {
 	C.GaussianFilter_Apply(C.GaussianFilter(gf.p), img.p, dst.p, s.p)
 	return
@@ -65,7 +62,6 @@ func (gf *GaussianFilter) ApplyWithStream(img GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d66/group__cudafilters.html#gabf85fe61958bb21e93211a6fcc7c5c3b
-//
 type SobelFilter struct {
 	p unsafe.Pointer
 }
@@ -91,7 +87,6 @@ func (sf *SobelFilter) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d2b/classcv_1_1cuda_1_1Filter.html#a20b58d13871027473b4c39cc698cf80f
-//
 func (sf *SobelFilter) Apply(img GpuMat, dst *GpuMat) {
 	C.SobelFilter_Apply(C.SobelFilter(sf.p), img.p, dst.p, nil)
 	return
@@ -102,7 +97,6 @@ func (sf *SobelFilter) Apply(img GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d2b/classcv_1_1cuda_1_1Filter.html#a20b58d13871027473b4c39cc698cf80f
-//
 func (sf *SobelFilter) ApplyWithStream(img GpuMat, dst *GpuMat, s Stream) {
 	C.SobelFilter_Apply(C.SobelFilter(sf.p), img.p, dst.p, s.p)
 	return

--- a/cuda/objdetect.go
+++ b/cuda/objdetect.go
@@ -30,7 +30,6 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d80/classcv_1_1cuda_1_1CascadeClassifier.html
-//
 type CascadeClassifier struct {
 	p unsafe.Pointer
 }
@@ -47,7 +46,6 @@ func NewCascadeClassifier(name string) CascadeClassifier {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d80/classcv_1_1cuda_1_1CascadeClassifier.html#a182656b878046eb3f0e9c0f0ee327f08
-//
 func (c *CascadeClassifier) DetectMultiScale(img GpuMat) []image.Rectangle {
 	ret := C.CascadeClassifier_GPU_DetectMultiScale(C.CascadeClassifier_GPU(c.p), img.p)
 	defer C.GpuRects_Close(ret)
@@ -59,7 +57,6 @@ func (c *CascadeClassifier) DetectMultiScale(img GpuMat) []image.Rectangle {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d5/d33/structcv_1_1HOG.html#a723b95b709cfd3f95cf9e616de988fc8
-//
 type HOG struct {
 	p unsafe.Pointer
 }
@@ -97,7 +94,6 @@ func CreateHOGWithParams(winSize, blockSize, blockStride, cellSize image.Point, 
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#ab4287267081959ec77c01269dbfcd373
-//
 func (h *HOG) Compute(img GpuMat) GpuMat {
 	return newGpuMat(C.HOG_Compute(C.HOG(h.p), img.p))
 }
@@ -107,7 +103,6 @@ func (h *HOG) Compute(img GpuMat) GpuMat {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d5/d33/structcv_1_1HOG.html#a660e5cd036fd5ddf0f5767b352acd948
-//
 func (h *HOG) DetectMultiScale(img GpuMat) []image.Rectangle {
 	ret := C.HOG_DetectMultiScale(C.HOG(h.p), img.p)
 	defer C.GpuRects_Close(ret)
@@ -119,7 +114,6 @@ func (h *HOG) DetectMultiScale(img GpuMat) []image.Rectangle {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#a016f9ffced8b2f4b20bdd06a775017d1
-//
 func (h *HOG) GetDefaultPeopleDetector() C.Mat {
 	return C.Mat(C.HOG_GetPeopleDetector(C.HOG(h.p)))
 }
@@ -128,7 +122,6 @@ func (h *HOG) GetDefaultPeopleDetector() C.Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#a5d12db2277b7c3c849d75258eec8d1d4
-//
 func (h *HOG) SetSVMDetector(det C.Mat) error {
 	C.HOG_SetSVMDetector(C.HOG(h.p), det)
 	return nil
@@ -138,7 +131,6 @@ func (h *HOG) SetSVMDetector(det C.Mat) error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#adad29ed960a953aa13dc59c410683620
-//
 func (h *HOG) GetDescriptorFormat() DescriptorStorageFormat {
 	return DescriptorStorageFormat(C.HOG_GetDescriptorFormat(C.HOG(h.p)))
 }
@@ -147,7 +139,6 @@ func (h *HOG) GetDescriptorFormat() DescriptorStorageFormat {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#a016f9ffced8b2f4b20bdd06a775017d1
-//
 func (h *HOG) GetBlockHistogramSize() int {
 	return int(C.HOG_GetBlockHistogramSize(C.HOG(h.p)))
 }
@@ -156,7 +147,6 @@ func (h *HOG) GetBlockHistogramSize() int {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#adb8c714cba1a025b8869d5a0e152f824
-//
 func (h *HOG) GetDescriptorSize() int {
 	return int(C.HOG_GetDescriptorSize(C.HOG(h.p)))
 }
@@ -165,7 +155,6 @@ func (h *HOG) GetDescriptorSize() int {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#a7032eed27cf7a004b727a6e522c2404e
-//
 func (h *HOG) GetGammaCorrection() bool {
 	return bool(C.HOG_GetGammaCorrection(C.HOG(h.p)))
 }
@@ -174,7 +163,6 @@ func (h *HOG) GetGammaCorrection() bool {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#a7032eed27cf7a004b727a6e522c2404e
-//
 func (h *HOG) GetGroupThreshold() int {
 	return int(C.HOG_GetGroupThreshold(C.HOG(h.p)))
 }
@@ -183,7 +171,6 @@ func (h *HOG) GetGroupThreshold() int {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#ae0de149980ea47fbd39b7766df565b27
-//
 func (h *HOG) GetHitThreshold() float64 {
 	return float64(C.HOG_GetHitThreshold(C.HOG(h.p)))
 }
@@ -192,7 +179,6 @@ func (h *HOG) GetHitThreshold() float64 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#a6853c9a66889fed996678f7972df9660
-//
 func (h *HOG) GetL2HysThreshold() float64 {
 	return float64(C.HOG_GetL2HysThreshold(C.HOG(h.p)))
 }
@@ -201,7 +187,6 @@ func (h *HOG) GetL2HysThreshold() float64 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#a15238eb6f52a1ddeedd015773c46efd8
-//
 func (h *HOG) GetNumLevels() int {
 	return int(C.HOG_GetNumLevels(C.HOG(h.p)))
 }
@@ -210,7 +195,6 @@ func (h *HOG) GetNumLevels() int {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#a89c59564625bb2c691af8c2cf49aab9e
-//
 func (h *HOG) GetScaleFactor() float64 {
 	return float64(C.HOG_GetScaleFactor(C.HOG(h.p)))
 }
@@ -219,7 +203,6 @@ func (h *HOG) GetScaleFactor() float64 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#a22d03fa05b251b4f19cfa1fab36e754e
-//
 func (h *HOG) GetWinSigma() float64 {
 	return float64(C.HOG_GetWinSigma(C.HOG(h.p)))
 }
@@ -228,7 +211,6 @@ func (h *HOG) GetWinSigma() float64 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#a6c63504790b51963ca33496a0b039b48
-//
 func (h *HOG) GetWinStride() image.Point {
 	sz := C.HOG_GetWinStride(C.HOG(h.p))
 	return image.Pt(int(sz.width), int(sz.height))
@@ -238,7 +220,6 @@ func (h *HOG) GetWinStride() image.Point {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#a6e3e1075a567268f2dfb2151b1c99cb6
-//
 func (h *HOG) SetDescriptorFormat(descrFormat DescriptorStorageFormat) {
 	C.HOG_SetDescriptorFormat(C.HOG(h.p), C.int(descrFormat))
 }
@@ -247,7 +228,6 @@ func (h *HOG) SetDescriptorFormat(descrFormat DescriptorStorageFormat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#a0eb2f1ecf59ccc599bffac3a0a55562f
-//
 func (h *HOG) SetGammaCorrection(gammaCorrection bool) {
 	C.HOG_SetGammaCorrection(C.HOG(h.p), C.bool(gammaCorrection))
 }
@@ -256,7 +236,6 @@ func (h *HOG) SetGammaCorrection(gammaCorrection bool) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#adad9af4e4ed0e0a045a70cd44520eefd
-//
 func (h *HOG) SetGroupThreshold(groupThreshold int) {
 	C.HOG_SetGroupThreshold(C.HOG(h.p), C.int(groupThreshold))
 }
@@ -265,7 +244,6 @@ func (h *HOG) SetGroupThreshold(groupThreshold int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#a8b623393c11d18b89fa373269b97aea4
-//
 func (h *HOG) SetHitThreshold(hitThreshold float64) {
 	C.HOG_SetHitThreshold(C.HOG(h.p), C.double(hitThreshold))
 }
@@ -274,7 +252,6 @@ func (h *HOG) SetHitThreshold(hitThreshold float64) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#a30e5c88864fff774f403313993947d62
-//
 func (h *HOG) SetL2HysThreshold(thresholdL2hys float64) {
 	C.HOG_SetL2HysThreshold(C.HOG(h.p), C.double(thresholdL2hys))
 }
@@ -283,7 +260,6 @@ func (h *HOG) SetL2HysThreshold(thresholdL2hys float64) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#a7602088f3e792de196f8f7efcd9bd448
-//
 func (h *HOG) SetNumLevels(nlevels int) {
 	C.HOG_SetNumLevels(C.HOG(h.p), C.int(nlevels))
 }
@@ -292,7 +268,6 @@ func (h *HOG) SetNumLevels(nlevels int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#a21dc5e3dc6272030694d52e83352b337
-//
 func (h *HOG) SetScaleFactor(scale0 float64) {
 	C.HOG_SetScaleFactor(C.HOG(h.p), C.double(scale0))
 }
@@ -301,7 +276,6 @@ func (h *HOG) SetScaleFactor(scale0 float64) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#ab291779ff8ac649174b102f64c5f9012
-//
 func (h *HOG) SetWinSigma(winSigma float64) {
 	C.HOG_SetWinSigma(C.HOG(h.p), C.double(winSigma))
 }
@@ -310,7 +284,6 @@ func (h *HOG) SetWinSigma(winSigma float64) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/da6/classcv_1_1cuda_1_1HOG.html#a5e74646651209ae13f1b3dd18179773f
-//
 func (h *HOG) SetWinStride(sz image.Point) {
 	pSize := C.struct_Size{
 		width:  C.int(sz.X),

--- a/cuda/optflow.go
+++ b/cuda/optflow.go
@@ -18,7 +18,6 @@ type SparsePyrLKOpticalFlow struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/d05/classcv_1_1cuda_1_1SparsePyrLKOpticalFlow.html#a6bcd2d457532d7db76c3e7f11b60063b
-//
 func NewSparsePyrLKOpticalFlow() SparsePyrLKOpticalFlow {
 	return SparsePyrLKOpticalFlow{p: unsafe.Pointer(C.CudaSparsePyrLKOpticalFlow_Create())}
 }

--- a/cuda/warping.go
+++ b/cuda/warping.go
@@ -243,7 +243,7 @@ func WarpAffine(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point, flags Interpo
 // WarpAffineWithStream applies an affine transformation to an image
 // using a Stream for concurrency.
 //
-// For more parameters please check WarpAffineWithParams
+// # For more parameters please check WarpAffineWithParams
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga9e8dd9e73b96bdc8e27d85c0e83f1130

--- a/dnn.go
+++ b/dnn.go
@@ -15,7 +15,6 @@ import (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d30/classcv_1_1dnn_1_1Net.html
-//
 type Net struct {
 	// C.Net
 	p unsafe.Pointer
@@ -140,7 +139,6 @@ func (net *Net) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d30/classcv_1_1dnn_1_1Net.html#a6a5778787d5b8770deab5eda6968e66c
-//
 func (net *Net) Empty() bool {
 	return bool(C.Net_Empty((C.Net)(net.p)))
 }
@@ -149,7 +147,6 @@ func (net *Net) Empty() bool {
 //
 // For further details, please see:
 // https://docs.opencv.org/trunk/db/d30/classcv_1_1dnn_1_1Net.html#a672a08ae76444d75d05d7bfea3e4a328
-//
 func (net *Net) SetInput(blob Mat, name string) {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
@@ -161,7 +158,6 @@ func (net *Net) SetInput(blob Mat, name string) {
 //
 // For further details, please see:
 // https://docs.opencv.org/trunk/db/d30/classcv_1_1dnn_1_1Net.html#a98ed94cb6ef7063d3697259566da310b
-//
 func (net *Net) Forward(outputName string) Mat {
 	cName := C.CString(outputName)
 	defer C.free(unsafe.Pointer(cName))
@@ -173,7 +169,6 @@ func (net *Net) Forward(outputName string) Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/3.4.1/db/d30/classcv_1_1dnn_1_1Net.html#adb34d7650e555264c7da3b47d967311b
-//
 func (net *Net) ForwardLayers(outBlobNames []string) (blobs []Mat) {
 	cMats := C.struct_Mats{}
 	C.Net_ForwardLayers((C.Net)(net.p), &(cMats), toCStrings(outBlobNames))
@@ -189,7 +184,6 @@ func (net *Net) ForwardLayers(outBlobNames []string) (blobs []Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/3.4/db/d30/classcv_1_1dnn_1_1Net.html#a7f767df11386d39374db49cd8df8f59e
-//
 func (net *Net) SetPreferableBackend(backend NetBackendType) error {
 	C.Net_SetPreferableBackend((C.Net)(net.p), C.int(backend))
 	return nil
@@ -199,7 +193,6 @@ func (net *Net) SetPreferableBackend(backend NetBackendType) error {
 //
 // For further details, please see:
 // https://docs.opencv.org/3.4/db/d30/classcv_1_1dnn_1_1Net.html#a9dddbefbc7f3defbe3eeb5dc3d3483f4
-//
 func (net *Net) SetPreferableTarget(target NetTargetType) error {
 	C.Net_SetPreferableTarget((C.Net)(net.p), C.int(target))
 	return nil
@@ -209,7 +202,6 @@ func (net *Net) SetPreferableTarget(target NetTargetType) error {
 //
 // For further details, please see:
 // https://docs.opencv.org/3.4/d6/d0f/group__dnn.html#ga3b34fe7a29494a6a4295c169a7d32422
-//
 func ReadNet(model string, config string) Net {
 	cModel := C.CString(model)
 	defer C.free(unsafe.Pointer(cModel))
@@ -223,7 +215,6 @@ func ReadNet(model string, config string) Net {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/d0f/group__dnn.html#ga138439da76f26266fdefec9723f6c5cd
-//
 func ReadNetBytes(framework string, model []byte, config []byte) (Net, error) {
 	cFramework := C.CString(framework)
 	defer C.free(unsafe.Pointer(cFramework))
@@ -242,7 +233,6 @@ func ReadNetBytes(framework string, model []byte, config []byte) (Net, error) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/d0f/group__dnn.html#ga29d0ea5e52b1d1a6c2681e3f7d68473a
-//
 func ReadNetFromCaffe(prototxt string, caffeModel string) Net {
 	cprototxt := C.CString(prototxt)
 	defer C.free(unsafe.Pointer(cprototxt))
@@ -256,7 +246,6 @@ func ReadNetFromCaffe(prototxt string, caffeModel string) Net {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/d0f/group__dnn.html#ga946b342af1355185a7107640f868b64a
-//
 func ReadNetFromCaffeBytes(prototxt []byte, caffeModel []byte) (Net, error) {
 	bPrototxt, err := toByteArray(prototxt)
 	if err != nil {
@@ -273,7 +262,6 @@ func ReadNetFromCaffeBytes(prototxt []byte, caffeModel []byte) (Net, error) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/d0f/group__dnn.html#gad820b280978d06773234ba6841e77e8d
-//
 func ReadNetFromTensorflow(model string) Net {
 	cmodel := C.CString(model)
 	defer C.free(unsafe.Pointer(cmodel))
@@ -284,7 +272,6 @@ func ReadNetFromTensorflow(model string) Net {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/d0f/group__dnn.html#gacdba30a7c20db2788efbf5bb16a7884d
-//
 func ReadNetFromTensorflowBytes(model []byte) (Net, error) {
 	bModel, err := toByteArray(model)
 	if err != nil {
@@ -294,11 +281,11 @@ func ReadNetFromTensorflowBytes(model []byte) (Net, error) {
 }
 
 // ReadNetFromTorch reads a network model stored in Torch framework's format (t7).
-//   check net.Empty() for read failure
+//
+//	check net.Empty() for read failure
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/d0f/group__dnn.html#gaaaed8c8530e9e92fe6647700c13d961e
-//
 func ReadNetFromTorch(model string) Net {
 	cmodel := C.CString(model)
 	defer C.free(unsafe.Pointer(cmodel))
@@ -306,11 +293,11 @@ func ReadNetFromTorch(model string) Net {
 }
 
 // ReadNetFromONNX reads a network model stored in ONNX framework's format.
-//   check net.Empty() for read failure
+//
+//	check net.Empty() for read failure
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/d0f/group__dnn.html#ga7faea56041d10c71dbbd6746ca854197
-//
 func ReadNetFromONNX(model string) Net {
 	cmodel := C.CString(model)
 	defer C.free(unsafe.Pointer(cmodel))
@@ -321,7 +308,6 @@ func ReadNetFromONNX(model string) Net {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/d0f/group__dnn.html#ga9198ecaac7c32ddf0aa7a1bcbd359567
-//
 func ReadNetFromONNXBytes(model []byte) (Net, error) {
 	bModel, err := toByteArray(model)
 	if err != nil {
@@ -336,7 +322,6 @@ func ReadNetFromONNXBytes(model []byte) (Net, error) {
 //
 // For further details, please see:
 // https://docs.opencv.org/trunk/d6/d0f/group__dnn.html#ga152367f253c81b53fe6862b299f5c5cd
-//
 func BlobFromImage(img Mat, scaleFactor float64, size image.Point, mean Scalar,
 	swapRB bool, crop bool) Mat {
 
@@ -361,7 +346,6 @@ func BlobFromImage(img Mat, scaleFactor float64, size image.Point, mean Scalar,
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/d0f/group__dnn.html#ga2b89ed84432e4395f5a1412c2926293c
-//
 func BlobFromImages(imgs []Mat, blob *Mat, scaleFactor float64, size image.Point, mean Scalar,
 	swapRB bool, crop bool, ddepth MatType) {
 
@@ -395,7 +379,6 @@ func BlobFromImages(imgs []Mat, blob *Mat, scaleFactor float64, size image.Point
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/d0f/group__dnn.html#ga4051b5fa2ed5f54b76c059a8625df9f5
-//
 func ImagesFromBlob(blob Mat, imgs []Mat) {
 	cMats := C.struct_Mats{}
 	C.Net_ImagesFromBlob(blob.p, &(cMats))
@@ -407,14 +390,13 @@ func ImagesFromBlob(blob Mat, imgs []Mat) {
 
 // GetBlobChannel extracts a single (2d)channel from a 4 dimensional blob structure
 // (this might e.g. contain the results of a SSD or YOLO detection,
-//  a bones structure from pose detection, or a color plane from Colorization)
 //
+//	a bones structure from pose detection, or a color plane from Colorization)
 func GetBlobChannel(blob Mat, imgidx int, chnidx int) Mat {
 	return newMat(C.Net_GetBlobChannel(blob.p, C.int(imgidx), C.int(chnidx)))
 }
 
 // GetBlobSize retrieves the 4 dimensional size information in (N,C,H,W) order
-//
 func GetBlobSize(blob Mat) Scalar {
 	s := C.Net_GetBlobSize(blob.p)
 	return NewScalar(float64(s.val1), float64(s.val2), float64(s.val3), float64(s.val4))
@@ -430,7 +412,6 @@ type Layer struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d30/classcv_1_1dnn_1_1Net.html#a70aec7f768f38c32b1ee25f3a56526df
-//
 func (net *Net) GetLayer(layer int) Layer {
 	return Layer{p: unsafe.Pointer(C.Net_GetLayer((C.Net)(net.p), C.int(layer)))}
 }
@@ -439,7 +420,6 @@ func (net *Net) GetLayer(layer int) Layer {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d30/classcv_1_1dnn_1_1Net.html#a06ce946f675f75d1c020c5ddbc78aedc
-//
 func (net *Net) GetPerfProfile() float64 {
 	return float64(C.Net_GetPerfProfile((C.Net)(net.p)))
 }
@@ -448,7 +428,6 @@ func (net *Net) GetPerfProfile() float64 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d30/classcv_1_1dnn_1_1Net.html#ae62a73984f62c49fd3e8e689405b056a
-//
 func (net *Net) GetUnconnectedOutLayers() (ids []int) {
 	cids := C.IntVector{}
 	C.Net_GetUnconnectedOutLayers((C.Net)(net.p), &cids)
@@ -471,7 +450,6 @@ func (net *Net) GetUnconnectedOutLayers() (ids []int) {
 //
 // For furtherdetails, please see:
 // https://docs.opencv.org/master/db/d30/classcv_1_1dnn_1_1Net.html#ae8be9806024a0d1d41aba687cce99e6b
-//
 func (net *Net) GetLayerNames() (names []string) {
 	cstrs := C.CStrings{}
 	defer C.CStrings_Close(cstrs)
@@ -500,7 +478,6 @@ func (l *Layer) GetType() string {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/d6c/classcv_1_1dnn_1_1Layer.html#a60ffc8238f3fa26cd3f49daa7ac0884b
-//
 func (l *Layer) InputNameToIndex(name string) int {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
@@ -511,7 +488,6 @@ func (l *Layer) InputNameToIndex(name string) int {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/d6c/classcv_1_1dnn_1_1Layer.html#a60ffc8238f3fa26cd3f49daa7ac0884b
-//
 func (l *Layer) OutputNameToIndex(name string) int {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
@@ -560,8 +536,7 @@ func NMSBoxes(bboxes []image.Rectangle, scores []float32, scoreThreshold float32
 
 	ptr := *(*[]C.int)(unsafe.Pointer(h))
 
-
-	indices = make([]int,indicesVector.length)
+	indices = make([]int, indicesVector.length)
 	for i := 0; i < int(indicesVector.length); i++ {
 		indices[i] = int(ptr[i])
 	}
@@ -610,7 +585,7 @@ func NMSBoxesWithParams(bboxes []image.Rectangle, scores []float32, scoreThresho
 
 	ptr := *(*[]C.int)(unsafe.Pointer(h))
 
-	indices = make([]int,indicesVector.length)
+	indices = make([]int, indicesVector.length)
 	for i := 0; i < int(indicesVector.length); i++ {
 		indices[i] = int(ptr[i])
 	}

--- a/dnn_async_openvino.go
+++ b/dnn_async_openvino.go
@@ -1,3 +1,4 @@
+//go:build openvino
 // +build openvino
 
 package gocv
@@ -17,7 +18,6 @@ import "C"
 //
 // For further details, please see:
 // https://docs.opencv.org/trunk/db/d30/classcv_1_1dnn_1_1Net.html#a814890154ea9e10b132fec00b6f6ba30
-//
 func (net *Net) ForwardAsync(outputName string) AsyncArray {
 	cName := C.CString(outputName)
 	defer C.free(unsafe.Pointer(cName))

--- a/features2d.go
+++ b/features2d.go
@@ -21,7 +21,6 @@ type AKAZE struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d30/classcv_1_1AKAZE.html
-//
 func NewAKAZE() AKAZE {
 	return AKAZE{p: unsafe.Pointer(C.AKAZE_Create())}
 }
@@ -37,7 +36,6 @@ func (a *AKAZE) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#aa4e9a7082ec61ebc108806704fbd7887
-//
 func (a *AKAZE) Detect(src Mat) []KeyPoint {
 	ret := C.AKAZE_Detect((C.AKAZE)(a.p), src.p)
 	defer C.KeyPoints_Close(ret)
@@ -49,7 +47,6 @@ func (a *AKAZE) Detect(src Mat) []KeyPoint {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#a8be0d1c20b08eb867184b8d74c15a677
-//
 func (a *AKAZE) DetectAndCompute(src Mat, mask Mat) ([]KeyPoint, Mat) {
 	desc := NewMat()
 	ret := C.AKAZE_DetectAndCompute((C.AKAZE)(a.p), src.p, mask.p, desc.p)
@@ -68,7 +65,6 @@ type AgastFeatureDetector struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/d19/classcv_1_1AgastFeatureDetector.html
-//
 func NewAgastFeatureDetector() AgastFeatureDetector {
 	return AgastFeatureDetector{p: unsafe.Pointer(C.AgastFeatureDetector_Create())}
 }
@@ -84,7 +80,6 @@ func (a *AgastFeatureDetector) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#aa4e9a7082ec61ebc108806704fbd7887
-//
 func (a *AgastFeatureDetector) Detect(src Mat) []KeyPoint {
 	ret := C.AgastFeatureDetector_Detect((C.AgastFeatureDetector)(a.p), src.p)
 	defer C.KeyPoints_Close(ret)
@@ -102,7 +97,6 @@ type BRISK struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d30/classcv_1_1AKAZE.html
-//
 func NewBRISK() BRISK {
 	return BRISK{p: unsafe.Pointer(C.BRISK_Create())}
 }
@@ -118,7 +112,6 @@ func (b *BRISK) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#aa4e9a7082ec61ebc108806704fbd7887
-//
 func (b *BRISK) Detect(src Mat) []KeyPoint {
 	ret := C.BRISK_Detect((C.BRISK)(b.p), src.p)
 	defer C.KeyPoints_Close(ret)
@@ -130,7 +123,6 @@ func (b *BRISK) Detect(src Mat) []KeyPoint {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#a8be0d1c20b08eb867184b8d74c15a677
-//
 func (b *BRISK) DetectAndCompute(src Mat, mask Mat) ([]KeyPoint, Mat) {
 	desc := NewMat()
 	ret := C.BRISK_DetectAndCompute((C.BRISK)(b.p), src.p, mask.p, desc.p)
@@ -164,7 +156,6 @@ type FastFeatureDetector struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/df/d74/classcv_1_1FastFeatureDetector.html
-//
 func NewFastFeatureDetector() FastFeatureDetector {
 	return FastFeatureDetector{p: unsafe.Pointer(C.FastFeatureDetector_Create())}
 }
@@ -173,7 +164,6 @@ func NewFastFeatureDetector() FastFeatureDetector {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/df/d74/classcv_1_1FastFeatureDetector.html#ab986f2ff8f8778aab1707e2642bc7f8e
-//
 func NewFastFeatureDetectorWithParams(threshold int, nonmaxSuppression bool, typ FastFeatureDetectorType) FastFeatureDetector {
 	return FastFeatureDetector{p: unsafe.Pointer(C.FastFeatureDetector_CreateWithParams(C.int(threshold), C.bool(nonmaxSuppression), C.int(typ)))}
 }
@@ -189,7 +179,6 @@ func (f *FastFeatureDetector) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#aa4e9a7082ec61ebc108806704fbd7887
-//
 func (f *FastFeatureDetector) Detect(src Mat) []KeyPoint {
 	ret := C.FastFeatureDetector_Detect((C.FastFeatureDetector)(f.p), src.p)
 	defer C.KeyPoints_Close(ret)
@@ -207,7 +196,6 @@ type GFTTDetector struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/df/d21/classcv_1_1GFTTDetector.html
-//
 func NewGFTTDetector() GFTTDetector {
 	return GFTTDetector{p: unsafe.Pointer(C.GFTTDetector_Create())}
 }
@@ -223,7 +211,6 @@ func (a *GFTTDetector) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#aa4e9a7082ec61ebc108806704fbd7887
-//
 func (a *GFTTDetector) Detect(src Mat) []KeyPoint {
 	ret := C.GFTTDetector_Detect((C.GFTTDetector)(a.p), src.p)
 	defer C.KeyPoints_Close(ret)
@@ -241,7 +228,6 @@ type KAZE struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/d61/classcv_1_1KAZE.html
-//
 func NewKAZE() KAZE {
 	return KAZE{p: unsafe.Pointer(C.KAZE_Create())}
 }
@@ -257,7 +243,6 @@ func (a *KAZE) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#aa4e9a7082ec61ebc108806704fbd7887
-//
 func (a *KAZE) Detect(src Mat) []KeyPoint {
 	ret := C.KAZE_Detect((C.KAZE)(a.p), src.p)
 	defer C.KeyPoints_Close(ret)
@@ -269,7 +254,6 @@ func (a *KAZE) Detect(src Mat) []KeyPoint {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#a8be0d1c20b08eb867184b8d74c15a677
-//
 func (a *KAZE) DetectAndCompute(src Mat, mask Mat) ([]KeyPoint, Mat) {
 	desc := NewMat()
 	ret := C.KAZE_DetectAndCompute((C.KAZE)(a.p), src.p, mask.p, desc.p)
@@ -288,7 +272,6 @@ type MSER struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/d28/classcv_1_1MSER.html
-//
 func NewMSER() MSER {
 	return MSER{p: unsafe.Pointer(C.MSER_Create())}
 }
@@ -304,7 +287,6 @@ func (a *MSER) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#aa4e9a7082ec61ebc108806704fbd7887
-//
 func (a *MSER) Detect(src Mat) []KeyPoint {
 	ret := C.MSER_Detect((C.MSER)(a.p), src.p)
 	defer C.KeyPoints_Close(ret)
@@ -322,7 +304,6 @@ type ORB struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d95/classcv_1_1ORB.html
-//
 func NewORB() ORB {
 	return ORB{p: unsafe.Pointer(C.ORB_Create())}
 }
@@ -331,7 +312,6 @@ func NewORB() ORB {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d95/classcv_1_1ORB.html#aeff0cbe668659b7ca14bb85ff1c4073b
-//
 func NewORBWithParams(nFeatures int, scaleFactor float32, nLevels int, edgeThreshold int, firstLevel int, WTAK int, scoreType ORBScoreType, patchSize int, fastThreshold int) ORB {
 	return ORB{p: unsafe.Pointer(C.ORB_CreateWithParams(
 		C.int(nFeatures),
@@ -364,7 +344,6 @@ func (o *ORB) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#aa4e9a7082ec61ebc108806704fbd7887
-//
 func (o *ORB) Detect(src Mat) []KeyPoint {
 	ret := C.ORB_Detect((C.ORB)(o.p), src.p)
 	defer C.KeyPoints_Close(ret)
@@ -376,7 +355,6 @@ func (o *ORB) Detect(src Mat) []KeyPoint {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#a8be0d1c20b08eb867184b8d74c15a677
-//
 func (o *ORB) DetectAndCompute(src Mat, mask Mat) ([]KeyPoint, Mat) {
 	desc := NewMat()
 	ret := C.ORB_DetectAndCompute((C.ORB)(o.p), src.p, mask.p, desc.p)
@@ -400,7 +378,6 @@ type SimpleBlobDetectorParams struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d7a/classcv_1_1SimpleBlobDetector.html
-//
 func NewSimpleBlobDetector() SimpleBlobDetector {
 	return SimpleBlobDetector{p: unsafe.Pointer(C.SimpleBlobDetector_Create())}
 }
@@ -409,7 +386,6 @@ func NewSimpleBlobDetector() SimpleBlobDetector {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d7a/classcv_1_1SimpleBlobDetector.html
-//
 func NewSimpleBlobDetectorWithParams(params SimpleBlobDetectorParams) SimpleBlobDetector {
 	return SimpleBlobDetector{p: unsafe.Pointer(C.SimpleBlobDetector_Create_WithParams(params.p))}
 }
@@ -620,7 +596,6 @@ func (p *SimpleBlobDetectorParams) GetThresholdStep() float64 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#aa4e9a7082ec61ebc108806704fbd7887
-//
 func (b *SimpleBlobDetector) Detect(src Mat) []KeyPoint {
 	ret := C.SimpleBlobDetector_Detect((C.SimpleBlobDetector)(b.p), src.p)
 	defer C.KeyPoints_Close(ret)
@@ -657,7 +632,6 @@ type BFMatcher struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/da1/classcv_1_1BFMatcher.html#abe0bb11749b30d97f60d6ade665617bd
-//
 func NewBFMatcher() BFMatcher {
 	return BFMatcher{p: unsafe.Pointer(C.BFMatcher_Create())}
 }
@@ -667,7 +641,6 @@ func NewBFMatcher() BFMatcher {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/da1/classcv_1_1BFMatcher.html#abe0bb11749b30d97f60d6ade665617bd
-//
 func NewBFMatcherWithParams(normType NormType, crossCheck bool) BFMatcher {
 	return BFMatcher{p: unsafe.Pointer(C.BFMatcher_CreateWithParams(C.int(normType), C.bool(crossCheck)))}
 }
@@ -683,7 +656,6 @@ func (b *BFMatcher) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/db/d39/classcv_1_1DescriptorMatcher.html#a0f046f47b68ec7074391e1e85c750cba
-//
 func (b *BFMatcher) Match(query, train Mat) []DMatch {
 	ret := C.BFMatcher_Match((C.BFMatcher)(b.p), query.p, train.p)
 	defer C.DMatches_Close(ret)
@@ -695,7 +667,6 @@ func (b *BFMatcher) Match(query, train Mat) []DMatch {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d39/classcv_1_1DescriptorMatcher.html#aa880f9353cdf185ccf3013e08210483a
-//
 func (b *BFMatcher) KnnMatch(query, train Mat, k int) [][]DMatch {
 	ret := C.BFMatcher_KnnMatch((C.BFMatcher)(b.p), query.p, train.p, C.int(k))
 	defer C.MultiDMatches_Close(ret)
@@ -713,7 +684,6 @@ type FlannBasedMatcher struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dc/de2/classcv_1_1FlannBasedMatcher.html#ab9114a6471e364ad221f89068ca21382
-//
 func NewFlannBasedMatcher() FlannBasedMatcher {
 	return FlannBasedMatcher{p: unsafe.Pointer(C.FlannBasedMatcher_Create())}
 }
@@ -729,7 +699,6 @@ func (f *FlannBasedMatcher) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d39/classcv_1_1DescriptorMatcher.html#aa880f9353cdf185ccf3013e08210483a
-//
 func (f *FlannBasedMatcher) KnnMatch(query, train Mat, k int) [][]DMatch {
 	ret := C.FlannBasedMatcher_KnnMatch((C.FlannBasedMatcher)(f.p), query.p, train.p, C.int(k))
 	defer C.MultiDMatches_Close(ret)
@@ -832,7 +801,6 @@ type SIFT struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d5/d3c/classcv_1_1xfeatures2d_1_1SIFT.html
-//
 func NewSIFT() SIFT {
 	return SIFT{p: unsafe.Pointer(C.SIFT_Create())}
 }
@@ -848,7 +816,6 @@ func (d *SIFT) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#aa4e9a7082ec61ebc108806704fbd7887
-//
 func (d *SIFT) Detect(src Mat) []KeyPoint {
 	ret := C.SIFT_Detect((C.SIFT)(d.p), C.Mat(src.Ptr()))
 	defer C.KeyPoints_Close(ret)
@@ -860,7 +827,6 @@ func (d *SIFT) Detect(src Mat) []KeyPoint {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#a8be0d1c20b08eb867184b8d74c15a677
-//
 func (d *SIFT) DetectAndCompute(src Mat, mask Mat) ([]KeyPoint, Mat) {
 	desc := NewMat()
 	ret := C.SIFT_DetectAndCompute((C.SIFT)(d.p), C.Mat(src.Ptr()), C.Mat(mask.Ptr()),

--- a/gocv.go
+++ b/gocv.go
@@ -7,5 +7,4 @@
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d1/dfb/intro.html
-//
 package gocv // import "gocv.io/x/gocv"

--- a/highgui.go
+++ b/highgui.go
@@ -19,7 +19,6 @@ import (
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d7/dfc/group__highgui.html
-//
 type Window struct {
 	name string
 	open bool
@@ -29,7 +28,6 @@ type Window struct {
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d7/dfc/group__highgui.html#ga5afdf8410934fd099df85c75b2e0888b
-//
 func NewWindow(name string) *Window {
 	runtime.LockOSThread()
 
@@ -45,7 +43,6 @@ func NewWindow(name string) *Window {
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d7/dfc/group__highgui.html#ga851ccdd6961022d1d5b4c4f255dbab34
-//
 func (w *Window) Close() error {
 	cName := C.CString(w.name)
 	defer C.free(unsafe.Pointer(cName))
@@ -109,7 +106,6 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dfc/group__highgui.html#gaaf9504b8f9cf19024d9d44a14e461656
-//
 func (w *Window) GetWindowProperty(flag WindowPropertyFlag) float64 {
 	cName := C.CString(w.name)
 	defer C.free(unsafe.Pointer(cName))
@@ -121,7 +117,6 @@ func (w *Window) GetWindowProperty(flag WindowPropertyFlag) float64 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dfc/group__highgui.html#ga66e4a6db4d4e06148bcdfe0d70a5df27
-//
 func (w *Window) SetWindowProperty(flag WindowPropertyFlag, value WindowFlag) {
 	cName := C.CString(w.name)
 	defer C.free(unsafe.Pointer(cName))
@@ -133,7 +128,6 @@ func (w *Window) SetWindowProperty(flag WindowPropertyFlag, value WindowFlag) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dfc/group__highgui.html#ga56f8849295fd10d0c319724ddb773d96
-//
 func (w *Window) SetWindowTitle(title string) {
 	cName := C.CString(w.name)
 	defer C.free(unsafe.Pointer(cName))
@@ -150,7 +144,6 @@ func (w *Window) SetWindowTitle(title string) {
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d7/dfc/group__highgui.html#ga453d42fe4cb60e5723281a89973ee563
-//
 func (w *Window) IMShow(img Mat) {
 	cName := C.CString(w.name)
 	defer C.free(unsafe.Pointer(cName))
@@ -165,7 +158,6 @@ func (w *Window) IMShow(img Mat) {
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d7/dfc/group__highgui.html#ga5628525ad33f52eab17feebcfba38bd7
-//
 func (w *Window) WaitKey(delay int) int {
 	return int(C.Window_WaitKey(C.int(delay)))
 }
@@ -174,7 +166,6 @@ func (w *Window) WaitKey(delay int) int {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dfc/group__highgui.html#ga8d86b207f7211250dbe6e28f76307ffb
-//
 func (w *Window) MoveWindow(x, y int) {
 	cName := C.CString(w.name)
 	defer C.free(unsafe.Pointer(cName))
@@ -186,7 +177,6 @@ func (w *Window) MoveWindow(x, y int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dfc/group__highgui.html#ga9e80e080f7ef33f897e415358aee7f7e
-//
 func (w *Window) ResizeWindow(width, height int) {
 	cName := C.CString(w.name)
 	defer C.free(unsafe.Pointer(cName))
@@ -203,7 +193,6 @@ func (w *Window) ResizeWindow(width, height int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dfc/group__highgui.html#ga8daf4730d3adf7035b6de9be4c469af5
-//
 func (w *Window) SelectROI(img Mat) image.Rectangle {
 	cName := C.CString(w.name)
 	defer C.free(unsafe.Pointer(cName))
@@ -222,7 +211,6 @@ func (w *Window) SelectROI(img Mat) image.Rectangle {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dfc/group__highgui.html#ga0f11fad74a6432b8055fb21621a0f893
-//
 func (w *Window) SelectROIs(img Mat) []image.Rectangle {
 	cName := C.CString(w.name)
 	defer C.free(unsafe.Pointer(cName))
@@ -256,7 +244,6 @@ func SelectROIs(name string, img Mat) []image.Rectangle {
 
 // WaitKey that is not attached to a specific Window.
 // Only use when no Window exists in your application, e.g. command line app.
-//
 func WaitKey(delay int) int {
 	return int(C.Window_WaitKey(C.int(delay)))
 }
@@ -271,7 +258,6 @@ type Trackbar struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dfc/group__highgui.html#gaf78d2155d30b728fc413803745b67a9b
-//
 func (w *Window) CreateTrackbar(name string, max int) *Trackbar {
 	cName := C.CString(w.name)
 	defer C.free(unsafe.Pointer(cName))
@@ -288,7 +274,6 @@ func (w *Window) CreateTrackbar(name string, max int) *Trackbar {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dfc/group__highgui.html#gaf78d2155d30b728fc413803745b67a9b
-//
 func (w *Window) CreateTrackbarWithValue(name string, value *int, max int) *Trackbar {
 	cName := C.CString(w.name)
 	defer C.free(unsafe.Pointer(cName))
@@ -304,7 +289,6 @@ func (w *Window) CreateTrackbarWithValue(name string, value *int, max int) *Trac
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dfc/group__highgui.html#ga122632e9e91b9ec06943472c55d9cda8
-//
 func (t *Trackbar) GetPos() int {
 	cName := C.CString(t.parent.name)
 	defer C.free(unsafe.Pointer(cName))
@@ -319,7 +303,6 @@ func (t *Trackbar) GetPos() int {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dfc/group__highgui.html#ga67d73c4c9430f13481fd58410d01bd8d
-//
 func (t *Trackbar) SetPos(pos int) {
 	cName := C.CString(t.parent.name)
 	defer C.free(unsafe.Pointer(cName))
@@ -334,7 +317,6 @@ func (t *Trackbar) SetPos(pos int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dfc/group__highgui.html#gabe26ffe8d2b60cc678895595a581b7aa
-//
 func (t *Trackbar) SetMin(pos int) {
 	cName := C.CString(t.parent.name)
 	defer C.free(unsafe.Pointer(cName))
@@ -349,7 +331,6 @@ func (t *Trackbar) SetMin(pos int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dfc/group__highgui.html#ga7e5437ccba37f1154b65210902fc4480
-//
 func (t *Trackbar) SetMax(pos int) {
 	cName := C.CString(t.parent.name)
 	defer C.free(unsafe.Pointer(cName))

--- a/highgui_test.go
+++ b/highgui_test.go
@@ -1,5 +1,6 @@
 // Do not run these tests on mac OS X. They fail with errors suggesting the GUI
 // should only be touched from the main thread.
+//go:build !darwin
 // +build !darwin
 
 package gocv

--- a/imgproc_colorcodes.go
+++ b/imgproc_colorcodes.go
@@ -4,7 +4,6 @@ package gocv
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d7/d1b/group__imgproc__misc.html#ga4e0972be5de079fed4e3a10e24ef5ef0
-//
 type ColorConversionCode int
 
 const (

--- a/mat_noprofile.go
+++ b/mat_noprofile.go
@@ -1,3 +1,4 @@
+//go:build !matprofile
 // +build !matprofile
 
 package gocv

--- a/mat_profile.go
+++ b/mat_profile.go
@@ -1,3 +1,4 @@
+//go:build matprofile
 // +build matprofile
 
 package gocv
@@ -25,7 +26,7 @@ import (
 //
 // and you can display the current entries with:
 //
-// 	var b bytes.Buffer
+//	var b bytes.Buffer
 //	gocv.MatProfile.WriteTo(&b, 1)
 //	fmt.Print(b.String())
 //

--- a/matprofile_test.go
+++ b/matprofile_test.go
@@ -1,3 +1,4 @@
+//go:build matprofile
 // +build matprofile
 
 package gocv

--- a/objdetect.go
+++ b/objdetect.go
@@ -14,7 +14,6 @@ import (
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d1/de5/classcv_1_1CascadeClassifier.html
-//
 type CascadeClassifier struct {
 	p C.CascadeClassifier
 }
@@ -35,7 +34,6 @@ func (c *CascadeClassifier) Close() error {
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d1/de5/classcv_1_1CascadeClassifier.html#a1a5884c8cc749422f9eb77c2471958bc
-//
 func (c *CascadeClassifier) Load(name string) bool {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
@@ -47,7 +45,6 @@ func (c *CascadeClassifier) Load(name string) bool {
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d1/de5/classcv_1_1CascadeClassifier.html#aaf8181cb63968136476ec4204ffca498
-//
 func (c *CascadeClassifier) DetectMultiScale(img Mat) []image.Rectangle {
 	ret := C.CascadeClassifier_DetectMultiScale(c.p, img.p)
 	defer C.Rects_Close(ret)
@@ -60,7 +57,6 @@ func (c *CascadeClassifier) DetectMultiScale(img Mat) []image.Rectangle {
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d1/de5/classcv_1_1CascadeClassifier.html#aaf8181cb63968136476ec4204ffca498
-//
 func (c *CascadeClassifier) DetectMultiScaleWithParams(img Mat, scale float64,
 	minNeighbors, flags int, minSize, maxSize image.Point) []image.Rectangle {
 
@@ -85,7 +81,6 @@ func (c *CascadeClassifier) DetectMultiScaleWithParams(img Mat, scale float64,
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d5/d33/structcv_1_1HOGDescriptor.html#a723b95b709cfd3f95cf9e616de988fc8
-//
 type HOGDescriptor struct {
 	p C.HOGDescriptor
 }
@@ -107,7 +102,6 @@ func (h *HOGDescriptor) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d5/d33/structcv_1_1HOGDescriptor.html#a660e5cd036fd5ddf0f5767b352acd948
-//
 func (h *HOGDescriptor) DetectMultiScale(img Mat) []image.Rectangle {
 	ret := C.HOGDescriptor_DetectMultiScale(h.p, img.p)
 	defer C.Rects_Close(ret)
@@ -120,7 +114,6 @@ func (h *HOGDescriptor) DetectMultiScale(img Mat) []image.Rectangle {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d5/d33/structcv_1_1HOGDescriptor.html#a660e5cd036fd5ddf0f5767b352acd948
-//
 func (h *HOGDescriptor) DetectMultiScaleWithParams(img Mat, hitThresh float64,
 	winStride, padding image.Point, scale, finalThreshold float64, useMeanshiftGrouping bool) []image.Rectangle {
 	wSz := C.struct_Size{
@@ -144,7 +137,6 @@ func (h *HOGDescriptor) DetectMultiScaleWithParams(img Mat, hitThresh float64,
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d5/d33/structcv_1_1HOGDescriptor.html#a660e5cd036fd5ddf0f5767b352acd948
-//
 func HOGDefaultPeopleDetector() Mat {
 	return newMat(C.HOG_GetDefaultPeopleDetector())
 }
@@ -153,7 +145,6 @@ func HOGDefaultPeopleDetector() Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d5/d33/structcv_1_1HOGDescriptor.html#a09e354ad701f56f9c550dc0385dc36f1
-//
 func (h *HOGDescriptor) SetSVMDetector(det Mat) error {
 	C.HOGDescriptor_SetSVMDetector(h.p, det.p)
 	return nil
@@ -163,7 +154,6 @@ func (h *HOGDescriptor) SetSVMDetector(det Mat) error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d5/d54/group__objdetect.html#ga3dba897ade8aa8227edda66508e16ab9
-//
 func GroupRectangles(rects []image.Rectangle, groupThreshold int, eps float64) []image.Rectangle {
 	cRectArray := make([]C.struct_Rect, len(rects))
 	for i, r := range rects {
@@ -189,7 +179,6 @@ func GroupRectangles(rects []image.Rectangle, groupThreshold int, eps float64) [
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/dc3/classcv_1_1QRCodeDetector.html
-//
 type QRCodeDetector struct {
 	p C.QRCodeDetector
 }
@@ -214,7 +203,6 @@ func (a *QRCodeDetector) Close() error {
 // Returns true as long as some QR code was detected even in case where the decoding failed
 // For further details, please see:
 // https://docs.opencv.org/master/de/dc3/classcv_1_1QRCodeDetector.html#a7290bd6a5d59b14a37979c3a14fbf394
-//
 func (a *QRCodeDetector) DetectAndDecode(input Mat, points *Mat, straight_qrcode *Mat) string {
 	goResult := C.GoString(C.QRCodeDetector_DetectAndDecode(a.p, input.p, points.p, straight_qrcode.p))
 	return string(goResult)
@@ -224,7 +212,6 @@ func (a *QRCodeDetector) DetectAndDecode(input Mat, points *Mat, straight_qrcode
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/dc3/classcv_1_1QRCodeDetector.html#a64373f7d877d27473f64fe04bb57d22b
-//
 func (a *QRCodeDetector) Detect(input Mat, points *Mat) bool {
 	result := C.QRCodeDetector_Detect(a.p, input.p, points.p)
 	return bool(result)
@@ -234,7 +221,6 @@ func (a *QRCodeDetector) Detect(input Mat, points *Mat) bool {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/dc3/classcv_1_1QRCodeDetector.html#a4172c2eb4825c844fb1b0ae67202d329
-//
 func (a *QRCodeDetector) Decode(input Mat, points Mat, straight_qrcode *Mat) string {
 	goResult := C.GoString(C.QRCodeDetector_DetectAndDecode(a.p, input.p, points.p, straight_qrcode.p))
 	return string(goResult)
@@ -258,7 +244,7 @@ func (a *QRCodeDetector) DetectMulti(input Mat, points *Mat) bool {
 // Returns true as long as some QR code was detected even in case where the decoding failed
 // For usage please see TestQRCodeDetector
 // For further details, please see:
-//https://docs.opencv.org/master/de/dc3/classcv_1_1QRCodeDetector.html#a188b63ffa17922b2c65d8a0ab7b70775
+// https://docs.opencv.org/master/de/dc3/classcv_1_1QRCodeDetector.html#a188b63ffa17922b2c65d8a0ab7b70775
 func (a *QRCodeDetector) DetectAndDecodeMulti(input Mat, decoded *[]string, points *Mat, qrCodes *[]Mat) bool {
 	cDecoded := C.CStrings{}
 	defer C.CStrings_Close(cDecoded)

--- a/openvino/ie/ie.go
+++ b/openvino/ie/ie.go
@@ -3,5 +3,4 @@
 //
 // For further details, please see:
 // https://software.intel.com/en-us/openvino-toolkit
-//
 package ie // import "gocv.io/x/gocv/openvino/ie"

--- a/openvino/openvino.go
+++ b/openvino/openvino.go
@@ -2,5 +2,4 @@
 //
 // For further details, please see:
 // https://software.intel.com/en-us/openvino-toolkit
-//
 package openvino // import "gocv.io/x/gocv/openvino"

--- a/photo.go
+++ b/photo.go
@@ -11,7 +11,7 @@ import (
 	"unsafe"
 )
 
-//SeamlessCloneFlags seamlessClone algorithm flags
+// SeamlessCloneFlags seamlessClone algorithm flags
 type SeamlessCloneFlags int
 
 // MergeMertens is a wrapper around the cv::MergeMertens.
@@ -39,7 +39,6 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/df/da0/group__photo__clone.html#ga6684f35dc669ff6196a7c340dc73b98e
-//
 func ColorChange(src, mask Mat, dst *Mat, red_mul, green_mul, blue_mul float32) {
 	C.ColorChange(src.p, mask.p, dst.p, C.float(red_mul), C.float(green_mul), C.float(blue_mul))
 }
@@ -48,7 +47,6 @@ func ColorChange(src, mask Mat, dst *Mat, red_mul, green_mul, blue_mul float32) 
 //
 // For further details, please see:
 // https://docs.opencv.org/master/df/da0/group__photo__clone.html#ga2bf426e4c93a6b1f21705513dfeca49d
-//
 func SeamlessClone(src, dst, mask Mat, p image.Point, blend *Mat, flags SeamlessCloneFlags) {
 	cp := C.struct_Point{
 		x: C.int(p.X),
@@ -62,7 +60,6 @@ func SeamlessClone(src, dst, mask Mat, p image.Point, blend *Mat, flags Seamless
 //
 // For further details, please see:
 // https://docs.opencv.org/master/df/da0/group__photo__clone.html#gac5025767cf2febd8029d474278e886c7
-//
 func IlluminationChange(src, mask Mat, dst *Mat, alpha, beta float32) {
 	C.IlluminationChange(src.p, mask.p, dst.p, C.float(alpha), C.float(beta))
 }
@@ -71,7 +68,6 @@ func IlluminationChange(src, mask Mat, dst *Mat, alpha, beta float32) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/df/da0/group__photo__clone.html#gad55df6aa53797365fa7cc23959a54004
-//
 func TextureFlattening(src, mask Mat, dst *Mat, lowThreshold, highThreshold float32, kernelSize int) {
 	C.TextureFlattening(src.p, mask.p, dst.p, C.float(lowThreshold), C.float(highThreshold), C.int(kernelSize))
 }
@@ -80,7 +76,6 @@ func TextureFlattening(src, mask Mat, dst *Mat, lowThreshold, highThreshold floa
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/d79/group__photo__denoise.html#gaa501e71f52fb2dc17ff8ca5e7d2d3619
-//
 func FastNlMeansDenoisingColoredMulti(src []Mat, dst *Mat, imgToDenoiseIndex int, temporalWindowSize int) {
 	cMatArray := make([]C.Mat, len(src))
 	for i, r := range src {
@@ -97,7 +92,6 @@ func FastNlMeansDenoisingColoredMulti(src []Mat, dst *Mat, imgToDenoiseIndex int
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/d79/group__photo__denoise.html#gaa501e71f52fb2dc17ff8ca5e7d2d3619
-//
 func FastNlMeansDenoisingColoredMultiWithParams(src []Mat, dst *Mat, imgToDenoiseIndex int, temporalWindowSize int, h float32, hColor float32, templateWindowSize int, searchWindowSize int) {
 	cMatArray := make([]C.Mat, len(src))
 	for i, r := range src {
@@ -118,7 +112,6 @@ func FastNlMeansDenoisingColoredMultiWithParams(src []Mat, dst *Mat, imgToDenois
 // https://docs.opencv.org/master/d6/df5/group__photo__hdr.html
 // https://docs.opencv.org/master/d7/dd6/classcv_1_1MergeMertens.html
 // https://docs.opencv.org/master/d6/df5/group__photo__hdr.html#ga79d59aa3cb3a7c664e59a4b5acc1ccb6
-//
 func NewMergeMertens() MergeMertens {
 	return MergeMertens{p: unsafe.Pointer(C.MergeMertens_Create())}
 }
@@ -131,7 +124,6 @@ func NewMergeMertens() MergeMertens {
 // https://docs.opencv.org/master/d6/df5/group__photo__hdr.html
 // https://docs.opencv.org/master/d7/dd6/classcv_1_1MergeMertens.html
 // https://docs.opencv.org/master/d6/df5/group__photo__hdr.html#ga79d59aa3cb3a7c664e59a4b5acc1ccb6
-//
 func NewMergeMertensWithParams(contrast_weight float32, saturation_weight float32, exposure_weight float32) MergeMertens {
 	return MergeMertens{p: unsafe.Pointer(C.MergeMertens_CreateWithParams(C.float(contrast_weight), C.float(saturation_weight), C.float(exposure_weight)))}
 }
@@ -147,7 +139,6 @@ func (b *MergeMertens) Close() error {
 // Return a image MAT : 8bits 3 channel image ( RGB 8 bits )
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dd6/classcv_1_1MergeMertens.html#a2d2254b2aab722c16954de13a663644d
-//
 func (b *MergeMertens) Process(src []Mat, dst *Mat) {
 	cMatArray := make([]C.Mat, len(src))
 	for i, r := range src {
@@ -172,7 +163,6 @@ func (b *MergeMertens) Process(src []Mat, dst *Mat) {
 // https://docs.opencv.org/master/d6/df5/group__photo__hdr.html
 // https://docs.opencv.org/master/d7/db6/classcv_1_1AlignMTB.html
 // https://docs.opencv.org/master/d6/df5/group__photo__hdr.html#ga2f1fafc885a5d79dbfb3542e08db0244
-//
 func NewAlignMTB() AlignMTB {
 	return AlignMTB{p: unsafe.Pointer(C.AlignMTB_Create())}
 }
@@ -186,7 +176,6 @@ func NewAlignMTB() AlignMTB {
 // https://docs.opencv.org/master/d6/df5/group__photo__hdr.html
 // https://docs.opencv.org/master/d7/db6/classcv_1_1AlignMTB.html
 // https://docs.opencv.org/master/d6/df5/group__photo__hdr.html#ga2f1fafc885a5d79dbfb3542e08db0244
-//
 func NewAlignMTBWithParams(max_bits int, exclude_range int, cut bool) AlignMTB {
 	return AlignMTB{p: unsafe.Pointer(C.AlignMTB_CreateWithParams(C.int(max_bits), C.int(exclude_range), C.bool(cut)))}
 }
@@ -202,7 +191,6 @@ func (b *AlignMTB) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/db6/classcv_1_1AlignMTB.html#a37b3417d844f362d781f34155cbcb201
-//
 func (b *AlignMTB) Process(src []Mat, dst *[]Mat) {
 
 	cSrcArray := make([]C.Mat, len(src))
@@ -232,7 +220,6 @@ func (b *AlignMTB) Process(src []Mat, dst *[]Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d1/d79/group__photo__denoise.html#ga4c6b0031f56ea3f98f768881279ffe93
-//
 func FastNlMeansDenoising(src Mat, dst *Mat) {
 	C.FastNlMeansDenoising(src.p, dst.p)
 }
@@ -242,7 +229,6 @@ func FastNlMeansDenoising(src Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d1/d79/group__photo__denoise.html#ga4c6b0031f56ea3f98f768881279ffe93
-//
 func FastNlMeansDenoisingWithParams(src Mat, dst *Mat, h float32, templateWindowSize int, searchWindowSize int) {
 	C.FastNlMeansDenoisingWithParams(src.p, dst.p, C.float(h), C.int(templateWindowSize), C.int(searchWindowSize))
 }
@@ -251,7 +237,6 @@ func FastNlMeansDenoisingWithParams(src Mat, dst *Mat, h float32, templateWindow
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d1/d79/group__photo__denoise.html#ga21abc1c8b0e15f78cd3eff672cb6c476
-//
 func FastNlMeansDenoisingColored(src Mat, dst *Mat) {
 	C.FastNlMeansDenoisingColored(src.p, dst.p)
 }
@@ -260,7 +245,6 @@ func FastNlMeansDenoisingColored(src Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d1/d79/group__photo__denoise.html#ga21abc1c8b0e15f78cd3eff672cb6c476
-//
 func FastNlMeansDenoisingColoredWithParams(src Mat, dst *Mat, h float32, hColor float32, templateWindowSize int, searchWindowSize int) {
 	C.FastNlMeansDenoisingColoredWithParams(src.p, dst.p, C.float(h), C.float(hColor), C.int(templateWindowSize), C.int(searchWindowSize))
 }
@@ -269,7 +253,6 @@ func FastNlMeansDenoisingColoredWithParams(src Mat, dst *Mat, h float32, hColor 
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/dac/group__photo__render.html#gae5930dd822c713b36f8529b21ddebd0c
-//
 func DetailEnhance(src Mat, dst *Mat, sigma_s, sigma_r float32) {
 	C.DetailEnhance(src.p, dst.p, C.float(sigma_s), C.float(sigma_r))
 }
@@ -289,7 +272,6 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/dac/group__photo__render.html#gafaee2977597029bc8e35da6e67bd31f7
-//
 func EdgePreservingFilter(src Mat, dst *Mat, filter EdgeFilter, sigma_s, sigma_r float32) {
 	C.EdgePreservingFilter(src.p, dst.p, C.int(filter), C.float(sigma_s), C.float(sigma_r))
 }
@@ -298,7 +280,6 @@ func EdgePreservingFilter(src Mat, dst *Mat, filter EdgeFilter, sigma_s, sigma_r
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/dac/group__photo__render.html#gae5930dd822c713b36f8529b21ddebd0c
-//
 func PencilSketch(src Mat, dst1, dst2 *Mat, sigma_s, sigma_r, shade_factor float32) {
 	C.PencilSketch(src.p, dst1.p, dst2.p, C.float(sigma_s), C.float(sigma_r), C.float(shade_factor))
 }
@@ -310,7 +291,6 @@ func PencilSketch(src Mat, dst1, dst2 *Mat, sigma_s, sigma_r, shade_factor float
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/dac/group__photo__render.html#gacb0f7324017df153d7b5d095aed53206
-//
 func Stylization(src Mat, dst *Mat, sigma_s, sigma_r float32) {
 	C.Stylization(src.p, dst.p, C.float(sigma_s), C.float(sigma_r))
 }
@@ -333,7 +313,6 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d7/d8b/group__photo__inpaint.html#gaedd30dfa0214fec4c88138b51d678085
-//
 func Inpaint(src Mat, mask Mat, dst *Mat, inpaintRadius float32, algorithmType InpaintMethods) {
 	C.PhotoInpaint(C.Mat(src.Ptr()), C.Mat(mask.Ptr()), C.Mat(dst.Ptr()), C.float(inpaintRadius), C.int(algorithmType))
 }

--- a/photo_test.go
+++ b/photo_test.go
@@ -241,7 +241,7 @@ func TestPencilSketch(t *testing.T) {
 	if dst2.Empty() || dst2.Rows() != src.Rows() || dst2.Cols() != src.Cols() {
 		t.Error("Invlalid PencilSketch test")
 	}
-} 
+}
 
 func TestInpaint(t *testing.T) {
 	src := IMRead("images/inpaint-src.jpg", IMReadColor)

--- a/video.go
+++ b/video.go
@@ -10,11 +10,13 @@ import (
 	"unsafe"
 )
 
-/**
-  cv::OPTFLOW_USE_INITIAL_FLOW = 4,
-  cv::OPTFLOW_LK_GET_MIN_EIGENVALS = 8,
-  cv::OPTFLOW_FARNEBACK_GAUSSIAN = 256
-  For further details, please see: https://docs.opencv.org/master/dc/d6b/group__video__track.html#gga2c6cc144c9eee043575d5b311ac8af08a9d4430ac75199af0cf6fcdefba30eafe
+/*
+*
+
+	cv::OPTFLOW_USE_INITIAL_FLOW = 4,
+	cv::OPTFLOW_LK_GET_MIN_EIGENVALS = 8,
+	cv::OPTFLOW_FARNEBACK_GAUSSIAN = 256
+	For further details, please see: https://docs.opencv.org/master/dc/d6b/group__video__track.html#gga2c6cc144c9eee043575d5b311ac8af08a9d4430ac75199af0cf6fcdefba30eafe
 */
 const (
 	OptflowUseInitialFlow    = 4
@@ -22,12 +24,14 @@ const (
 	OptflowFarnebackGaussian = 256
 )
 
-/**
-  cv::MOTION_TRANSLATION = 0,
-  cv::MOTION_EUCLIDEAN = 1,
-  cv::MOTION_AFFINE = 2,
-  cv::MOTION_HOMOGRAPHY = 3
-  For further details, please see: https://docs.opencv.org/4.x/dc/d6b/group__video__track.html#ggaaedb1f94e6b143cef163622c531afd88a01106d6d20122b782ff25eaeffe9a5be
+/*
+*
+
+	cv::MOTION_TRANSLATION = 0,
+	cv::MOTION_EUCLIDEAN = 1,
+	cv::MOTION_AFFINE = 2,
+	cv::MOTION_HOMOGRAPHY = 3
+	For further details, please see: https://docs.opencv.org/4.x/dc/d6b/group__video__track.html#ggaaedb1f94e6b143cef163622c531afd88a01106d6d20122b782ff25eaeffe9a5be
 */
 const (
 	MotionTranslation = 0
@@ -49,7 +53,6 @@ type BackgroundSubtractorMOG2 struct {
 // For further details, please see:
 // https://docs.opencv.org/master/de/de1/group__video__motion.html#ga2beb2dee7a073809ccec60f145b6b29c
 // https://docs.opencv.org/master/d7/d7b/classcv_1_1BackgroundSubtractorMOG2.html
-//
 func NewBackgroundSubtractorMOG2() BackgroundSubtractorMOG2 {
 	return BackgroundSubtractorMOG2{p: unsafe.Pointer(C.BackgroundSubtractorMOG2_Create())}
 }
@@ -61,7 +64,6 @@ func NewBackgroundSubtractorMOG2() BackgroundSubtractorMOG2 {
 // For further details, please see:
 // https://docs.opencv.org/master/de/de1/group__video__motion.html#ga2beb2dee7a073809ccec60f145b6b29c
 // https://docs.opencv.org/master/d7/d7b/classcv_1_1BackgroundSubtractorMOG2.html
-//
 func NewBackgroundSubtractorMOG2WithParams(history int, varThreshold float64, detectShadows bool) BackgroundSubtractorMOG2 {
 	return BackgroundSubtractorMOG2{p: unsafe.Pointer(C.BackgroundSubtractorMOG2_CreateWithParams(C.int(history), C.double(varThreshold), C.bool(detectShadows)))}
 }
@@ -77,7 +79,6 @@ func (b *BackgroundSubtractorMOG2) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/df6/classcv_1_1BackgroundSubtractor.html#aa735e76f7069b3fa9c3f32395f9ccd21
-//
 func (b *BackgroundSubtractorMOG2) Apply(src Mat, dst *Mat) {
 	C.BackgroundSubtractorMOG2_Apply((C.BackgroundSubtractorMOG2)(b.p), src.p, dst.p)
 	return
@@ -96,7 +97,6 @@ type BackgroundSubtractorKNN struct {
 // For further details, please see:
 // https://docs.opencv.org/master/de/de1/group__video__motion.html#gac9be925771f805b6fdb614ec2292006d
 // https://docs.opencv.org/master/db/d88/classcv_1_1BackgroundSubtractorKNN.html
-//
 func NewBackgroundSubtractorKNN() BackgroundSubtractorKNN {
 	return BackgroundSubtractorKNN{p: unsafe.Pointer(C.BackgroundSubtractorKNN_Create())}
 }
@@ -108,7 +108,6 @@ func NewBackgroundSubtractorKNN() BackgroundSubtractorKNN {
 // For further details, please see:
 // https://docs.opencv.org/master/de/de1/group__video__motion.html#gac9be925771f805b6fdb614ec2292006d
 // https://docs.opencv.org/master/db/d88/classcv_1_1BackgroundSubtractorKNN.html
-//
 func NewBackgroundSubtractorKNNWithParams(history int, dist2Threshold float64, detectShadows bool) BackgroundSubtractorKNN {
 	return BackgroundSubtractorKNN{p: unsafe.Pointer(C.BackgroundSubtractorKNN_CreateWithParams(C.int(history), C.double(dist2Threshold), C.bool(detectShadows)))}
 }
@@ -124,7 +123,6 @@ func (k *BackgroundSubtractorKNN) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/df6/classcv_1_1BackgroundSubtractor.html#aa735e76f7069b3fa9c3f32395f9ccd21
-//
 func (k *BackgroundSubtractorKNN) Apply(src Mat, dst *Mat) {
 	C.BackgroundSubtractorKNN_Apply((C.BackgroundSubtractorKNN)(k.p), src.p, dst.p)
 	return
@@ -135,7 +133,6 @@ func (k *BackgroundSubtractorKNN) Apply(src Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d6b/group__video__track.html#ga5d10ebbd59fe09c5f650289ec0ece5af
-//
 func CalcOpticalFlowFarneback(prevImg Mat, nextImg Mat, flow *Mat, pyrScale float64, levels int, winsize int,
 	iterations int, polyN int, polySigma float64, flags int) {
 	C.CalcOpticalFlowFarneback(prevImg.p, nextImg.p, flow.p, C.double(pyrScale), C.int(levels), C.int(winsize),
@@ -148,7 +145,6 @@ func CalcOpticalFlowFarneback(prevImg Mat, nextImg Mat, flow *Mat, pyrScale floa
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d6b/group__video__track.html#ga473e4b886d0bcc6b65831eb88ed93323
-//
 func CalcOpticalFlowPyrLK(prevImg Mat, nextImg Mat, prevPts Mat, nextPts Mat, status *Mat, err *Mat) {
 	C.CalcOpticalFlowPyrLK(prevImg.p, nextImg.p, prevPts.p, nextPts.p, status.p, err.p)
 	return
@@ -159,7 +155,6 @@ func CalcOpticalFlowPyrLK(prevImg Mat, nextImg Mat, prevPts Mat, nextPts Mat, st
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d6b/group__video__track.html#ga473e4b886d0bcc6b65831eb88ed93323
-//
 func CalcOpticalFlowPyrLKWithParams(prevImg Mat, nextImg Mat, prevPts Mat, nextPts Mat, status *Mat, err *Mat,
 	winSize image.Point, maxLevel int, criteria TermCriteria, flags int, minEigThreshold float64) {
 	winSz := C.struct_Size{
@@ -174,7 +169,6 @@ func CalcOpticalFlowPyrLKWithParams(prevImg Mat, nextImg Mat, prevPts Mat, nextP
 //
 // For futther details, please see:
 // https://docs.opencv.org/4.x/dc/d6b/group__video__track.html#ga1aa357007eaec11e9ed03500ecbcbe47
-//
 func FindTransformECC(templateImage Mat, inputImage Mat, warpMatrix *Mat, motionType int, criteria TermCriteria, inputMask Mat, gaussFiltSize int) float64 {
 	return float64(C.FindTransformECC(templateImage.p, inputImage.p, warpMatrix.p, C.int(motionType), criteria.p, inputMask.p, C.int(gaussFiltSize)))
 }
@@ -182,7 +176,6 @@ func FindTransformECC(templateImage Mat, inputImage Mat, warpMatrix *Mat, motion
 // Tracker is the base interface for object tracking.
 //
 // see: https://docs.opencv.org/master/d0/d0a/classcv_1_1Tracker.html
-//
 type Tracker interface {
 	// Close closes, as Trackers need to be Closed manually.
 	//
@@ -230,7 +223,6 @@ func trackerUpdate(trk C.Tracker, img Mat) (image.Rectangle, bool) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d26/classcv_1_1TrackerMIL.html
-//
 type TrackerMIL struct {
 	p C.TrackerMIL
 }
@@ -263,7 +255,6 @@ func (trk TrackerMIL) Update(img Mat) (image.Rectangle, bool) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html
-//
 type KalmanFilter struct {
 	p C.KalmanFilter
 }
@@ -272,7 +263,6 @@ type KalmanFilter struct {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#ac0799f0611baee9e7e558f016e4a7b40
-//
 func NewKalmanFilter(dynamParams int, measureParams int) KalmanFilter {
 	return KalmanFilter{p: C.KalmanFilter_New(C.int(dynamParams), C.int(measureParams))}
 }
@@ -281,7 +271,6 @@ func NewKalmanFilter(dynamParams int, measureParams int) KalmanFilter {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#abac82ecfa530611a163255bc7d91c088
-//
 func NewKalmanFilterWithParams(dynamParams int, measureParams int, controlParams int, matType MatType) KalmanFilter {
 	return KalmanFilter{p: C.KalmanFilter_NewWithParams(C.int(dynamParams), C.int(measureParams), C.int(controlParams), C.int(matType))}
 }
@@ -290,7 +279,6 @@ func NewKalmanFilterWithParams(dynamParams int, measureParams int, controlParams
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#a4f136c39c016d3530c7c5801dd1ddb3b
-//
 func (kf *KalmanFilter) Init(dynamParams int, measureParams int) {
 	C.KalmanFilter_Init(kf.p, C.int(dynamParams), C.int(measureParams))
 }
@@ -299,7 +287,6 @@ func (kf *KalmanFilter) Init(dynamParams int, measureParams int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#aa710d2255566bec8d6ce608d103d4fa7
-//
 func (kf *KalmanFilter) Predict() Mat {
 	return newMat(C.KalmanFilter_Predict(kf.p))
 }
@@ -308,7 +295,6 @@ func (kf *KalmanFilter) Predict() Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#aa710d2255566bec8d6ce608d103d4fa7
-//
 func (kf *KalmanFilter) PredictWithParams(control Mat) Mat {
 	return newMat(C.KalmanFilter_PredictWithParams(kf.p, control.p))
 }
@@ -317,7 +303,6 @@ func (kf *KalmanFilter) PredictWithParams(control Mat) Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#a60eb7feb569222ad0657ef1875884b5e
-//
 func (kf *KalmanFilter) Correct(measurement Mat) Mat {
 	return newMat(C.KalmanFilter_Correct(kf.p, measurement.p))
 }
@@ -334,7 +319,6 @@ func (kf *KalmanFilter) Close() {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#a60eb7feb569222ad0657ef1875884b5e
-//
 func (kf *KalmanFilter) GetStatePre() Mat {
 	return newMat(C.KalmanFilter_GetStatePre(kf.p))
 }
@@ -345,7 +329,6 @@ func (kf *KalmanFilter) GetStatePre() Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#add8fb5ac9c04b4600b679698dcb0447d
-//
 func (kf *KalmanFilter) GetStatePost() Mat {
 	return newMat(C.KalmanFilter_GetStatePost(kf.p))
 }
@@ -356,7 +339,6 @@ func (kf *KalmanFilter) GetStatePost() Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#a0657173e411acbf40d2d3c6b46e03b19
-//
 func (kf *KalmanFilter) GetTransitionMatrix() Mat {
 	return newMat(C.KalmanFilter_GetTransitionMatrix(kf.p))
 }
@@ -367,7 +349,6 @@ func (kf *KalmanFilter) GetTransitionMatrix() Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#a6486e7287114810636fb33953280ed52
-//
 func (kf *KalmanFilter) GetControlMatrix() Mat {
 	return newMat(C.KalmanFilter_GetControlMatrix(kf.p))
 }
@@ -378,7 +359,6 @@ func (kf *KalmanFilter) GetControlMatrix() Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#a0f60b78726d8eccf74a1f2479c2d1f97
-//
 func (kf *KalmanFilter) GetMeasurementMatrix() Mat {
 	return newMat(C.KalmanFilter_GetMeasurementMatrix(kf.p))
 }
@@ -389,7 +369,6 @@ func (kf *KalmanFilter) GetMeasurementMatrix() Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#af19be9c0630d0f658bdbaea409a35cda
-//
 func (kf *KalmanFilter) GetProcessNoiseCov() Mat {
 	return newMat(C.KalmanFilter_GetProcessNoiseCov(kf.p))
 }
@@ -400,7 +379,6 @@ func (kf *KalmanFilter) GetProcessNoiseCov() Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#a828d051035ba807966ad65edf288a08e
-//
 func (kf *KalmanFilter) GetMeasurementNoiseCov() Mat {
 	return newMat(C.KalmanFilter_GetMeasurementNoiseCov(kf.p))
 }
@@ -411,7 +389,6 @@ func (kf *KalmanFilter) GetMeasurementNoiseCov() Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#ae1bd3a86f10753d723e7174d570d9ac1
-//
 func (kf *KalmanFilter) GetErrorCovPre() Mat {
 	return newMat(C.KalmanFilter_GetErrorCovPre(kf.p))
 }
@@ -422,7 +399,6 @@ func (kf *KalmanFilter) GetErrorCovPre() Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#a077d73eb075b00779dc009a9057c27c3
-//
 func (kf *KalmanFilter) GetGain() Mat {
 	return newMat(C.KalmanFilter_GetGain(kf.p))
 }
@@ -432,8 +408,7 @@ func (kf *KalmanFilter) GetGain() Mat {
 // posteriori error estimate covariance matrix (P(k)): P(k)=(I-K(k)*H)*P'(k)
 //
 // For further details, please see:
-//https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#a446d8e9a0105b0aa35cd66119c529803
-//
+// https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#a446d8e9a0105b0aa35cd66119c529803
 func (kf *KalmanFilter) GetErrorCovPost() Mat {
 	return newMat(C.KalmanFilter_GetErrorCovPost(kf.p))
 }
@@ -442,7 +417,6 @@ func (kf *KalmanFilter) GetErrorCovPost() Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#aa3d064a9194c2815dbe19c056b6dc763
-//
 func (kf *KalmanFilter) GetTemp1() Mat {
 	return newMat(C.KalmanFilter_GetTemp1(kf.p))
 }
@@ -451,7 +425,6 @@ func (kf *KalmanFilter) GetTemp1() Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#a14866bd506668eb0ed57b3974b3a1ee7
-//
 func (kf *KalmanFilter) GetTemp2() Mat {
 	return newMat(C.KalmanFilter_GetTemp2(kf.p))
 }
@@ -460,7 +433,6 @@ func (kf *KalmanFilter) GetTemp2() Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#afdbe36066a7d7f560aa02abe6be114d8
-//
 func (kf *KalmanFilter) GetTemp3() Mat {
 	return newMat(C.KalmanFilter_GetTemp3(kf.p))
 }
@@ -469,7 +441,6 @@ func (kf *KalmanFilter) GetTemp3() Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#a84342f2d9dec1e6389025ad229401809
-//
 func (kf *KalmanFilter) GetTemp4() Mat {
 	return newMat(C.KalmanFilter_GetTemp4(kf.p))
 }
@@ -478,7 +449,6 @@ func (kf *KalmanFilter) GetTemp4() Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#a846c2a6222c6e5d8b1385dfbccc83ae0
-//
 func (kf *KalmanFilter) GetTemp5() Mat {
 	return newMat(C.KalmanFilter_GetTemp5(kf.p))
 }

--- a/videoio.go
+++ b/videoio.go
@@ -286,7 +286,6 @@ const (
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d8/dfe/classcv_1_1VideoCapture.html
-//
 type VideoCapture struct {
 	p C.VideoCapture
 }
@@ -406,7 +405,6 @@ func (v *VideoCapture) ToCodec(codec string) float64 {
 //
 // For further details, please see:
 // http://docs.opencv.org/master/dd/d9e/classcv_1_1VideoWriter.html
-//
 type VideoWriter struct {
 	mu *sync.RWMutex
 	p  C.VideoWriter
@@ -418,7 +416,6 @@ type VideoWriter struct {
 //
 // For further details, please see:
 // http://docs.opencv.org/master/dd/d9e/classcv_1_1VideoWriter.html#a0901c353cd5ea05bba455317dab81130
-//
 func VideoWriterFile(name string, codec string, fps float64, width int, height int, isColor bool) (vw *VideoWriter, err error) {
 
 	if fps == 0 || width == 0 || height == 0 {
@@ -452,7 +449,6 @@ func (vw *VideoWriter) Close() error {
 //
 // For further details, please see:
 // http://docs.opencv.org/master/dd/d9e/classcv_1_1VideoWriter.html#a9a40803e5f671968ac9efa877c984d75
-//
 func (vw *VideoWriter) IsOpened() bool {
 	isOpend := C.VideoWriter_IsOpened(vw.p)
 	return isOpend != 0
@@ -462,7 +458,6 @@ func (vw *VideoWriter) IsOpened() bool {
 //
 // For further details, please see:
 // http://docs.opencv.org/master/dd/d9e/classcv_1_1VideoWriter.html#a3115b679d612a6a0b5864a0c88ed4b39
-//
 func (vw *VideoWriter) Write(img Mat) error {
 	vw.mu.Lock()
 	defer vw.mu.Unlock()


### PR DESCRIPTION
This PR runs `go fmt` against all Go files and corrects the formatting.