### PR TITLE
Add separate "Compute" bindings for detection algorithms 

### DIFF
--- a/contrib/xfeatures2d.cpp
+++ b/contrib/xfeatures2d.cpp
@@ -30,6 +30,30 @@ struct KeyPoints SURF_Detect(SURF d, Mat src) {
     return ret;
 }
 
+struct KeyPoints SURF_Compute(SURF d, Mat src, struct KeyPoints kp, Mat desc) {
+    std::vector<cv::KeyPoint> computed;
+    for (size_t i = 0; i < kp.length; i++) {
+        cv::KeyPoint k = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
+            kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
+            kp.keypoints[i].octave, kp.keypoints[i].classID);
+        computed.push_back(k);
+    }
+
+    (*d)->compute(*src, computed, *desc);
+
+    KeyPoint* kps = new KeyPoint[computed.size()];
+
+    for (size_t i = 0; i < computed.size(); ++i) {
+        KeyPoint k = {computed[i].pt.x, computed[i].pt.y, computed[i].size, computed[i].angle,
+                      computed[i].response, computed[i].octave, computed[i].class_id
+                     };
+        kps[i] = k;
+    }
+
+    KeyPoints ret = {kps, (int)computed.size()};
+    return ret;
+}
+
 struct KeyPoints SURF_DetectAndCompute(SURF d, Mat src, Mat mask, Mat desc) {
     std::vector<cv::KeyPoint> detected;
     (*d)->detectAndCompute(*src, *mask, detected, *desc);

--- a/contrib/xfeatures2d.go
+++ b/contrib/xfeatures2d.go
@@ -57,7 +57,7 @@ func (d *SURF) Detect(src gocv.Mat) []gocv.KeyPoint {
 // Compute keypoints in an image using SURF.
 //
 // For further details, please see:
-// https://docs.opencv.org/3.4/d9/d37/classcv_1_1xfeatures2d_1_1DAISY.html#a12744f1611a374fb06ba251d9d2fec86
+// https://docs.opencv.org/4.x/d0/d13/classcv_1_1Feature2D.html#ab3cce8d56f4fc5e1d530b5931e1e8dc0
 func (d *SURF) Compute(src gocv.Mat, mask gocv.Mat, kps []gocv.KeyPoint) ([]gocv.KeyPoint, gocv.Mat) {
 	desc := gocv.NewMat()
 	kp2arr := make([]C.struct_KeyPoint, len(kps))

--- a/contrib/xfeatures2d.go
+++ b/contrib/xfeatures2d.go
@@ -58,7 +58,8 @@ func (d *SURF) Detect(src gocv.Mat) []gocv.KeyPoint {
 //
 // For further details, please see:
 // https://docs.opencv.org/3.4/d9/d37/classcv_1_1xfeatures2d_1_1DAISY.html#a12744f1611a374fb06ba251d9d2fec86
-func (d *SURF) Compute(src gocv.Mat, mask gocv.Mat, kps []gocv.KeyPoint, desc gocv.Mat) []gocv.KeyPoint {
+func (d *SURF) Compute(src gocv.Mat, mask gocv.Mat, kps []gocv.KeyPoint) ([]gocv.KeyPoint, gocv.Mat) {
+	desc := gocv.NewMat()
 	kp2arr := make([]C.struct_KeyPoint, len(kps))
 	for i, kp := range kps {
 		kp2arr[i].x = C.double(kp.X)
@@ -77,7 +78,7 @@ func (d *SURF) Compute(src gocv.Mat, mask gocv.Mat, kps []gocv.KeyPoint, desc go
 	ret := C.SURF_Compute((C.SURF)(d.p), C.Mat(src.Ptr()), cKeyPoints, C.Mat(desc.Ptr()))
 	defer C.KeyPoints_Close(ret)
 
-	return getKeyPoints(ret)
+	return getKeyPoints(ret), desc
 }
 
 // DetectAndCompute detects and computes keypoints in an image using SURF.

--- a/contrib/xfeatures2d.go
+++ b/contrib/xfeatures2d.go
@@ -74,9 +74,7 @@ func (d *SURF) Compute(src gocv.Mat, mask gocv.Mat, kps []gocv.KeyPoint) ([]gocv
 		keypoints: (*C.struct_KeyPoint)(&kp2arr[0]),
 		length:    (C.int)(len(kps)),
 	}
-
 	ret := C.SURF_Compute((C.SURF)(d.p), C.Mat(src.Ptr()), cKeyPoints, C.Mat(desc.Ptr()))
-	defer C.KeyPoints_Close(ret)
 
 	return getKeyPoints(ret), desc
 }

--- a/contrib/xfeatures2d.go
+++ b/contrib/xfeatures2d.go
@@ -54,6 +54,32 @@ func (d *SURF) Detect(src gocv.Mat) []gocv.KeyPoint {
 	return getKeyPoints(ret)
 }
 
+// Compute keypoints in an image using SURF.
+//
+// For further details, please see:
+// https://docs.opencv.org/3.4/d9/d37/classcv_1_1xfeatures2d_1_1DAISY.html#a12744f1611a374fb06ba251d9d2fec86
+func (d *SURF) Compute(src gocv.Mat, mask gocv.Mat, kps []gocv.KeyPoint, desc gocv.Mat) []gocv.KeyPoint {
+	kp2arr := make([]C.struct_KeyPoint, len(kps))
+	for i, kp := range kps {
+		kp2arr[i].x = C.double(kp.X)
+		kp2arr[i].y = C.double(kp.Y)
+		kp2arr[i].size = C.double(kp.Size)
+		kp2arr[i].angle = C.double(kp.Angle)
+		kp2arr[i].response = C.double(kp.Response)
+		kp2arr[i].octave = C.int(kp.Octave)
+		kp2arr[i].classID = C.int(kp.ClassID)
+	}
+	cKeyPoints := C.struct_KeyPoints{
+		keypoints: (*C.struct_KeyPoint)(&kp2arr[0]),
+		length:    (C.int)(len(kps)),
+	}
+
+	ret := C.SURF_Compute((C.SURF)(d.p), C.Mat(src.Ptr()), cKeyPoints, C.Mat(desc.Ptr()))
+	defer C.KeyPoints_Close(ret)
+
+	return getKeyPoints(ret)
+}
+
 // DetectAndCompute detects and computes keypoints in an image using SURF.
 //
 // For further details, please see:

--- a/contrib/xfeatures2d.h
+++ b/contrib/xfeatures2d.h
@@ -21,6 +21,7 @@ SURF SURF_Create();
 SURF SURF_CreateWithParams(double hessianThreshold, int nOctaves, int nOctaveLayers, bool extended, bool upright);
 void SURF_Close(SURF f);
 struct KeyPoints SURF_Detect(SURF f, Mat src);
+struct KeyPoints SURF_Compute(SURF f, Mat src, struct KeyPoints kp, Mat desc);
 struct KeyPoints SURF_DetectAndCompute(SURF f, Mat src, Mat mask, Mat desc);
 BriefDescriptorExtractor BriefDescriptorExtractor_Create();
 BriefDescriptorExtractor BriefDescriptorExtractor_CreateWithParams(int bytes, bool useOrientation);

--- a/contrib/xfeatures2d_test.go
+++ b/contrib/xfeatures2d_test.go
@@ -77,12 +77,20 @@ func TestSURFWithParams(t *testing.T) {
 	mask := gocv.NewMat()
 	defer mask.Close()
 
-	kp2, desc := si.DetectAndCompute(img, mask)
-	if len(kp2) == 512 {
-		t.Errorf("Invalid KeyPoint array in SURF DetectAndCompute: %d", len(kp2))
+	kpc, desc := si.Compute(img, mask, kp)
+	if len(kpc) < 512 {
+		t.Errorf("Invalid KeyPoint array in SURF Compute: %d", len(kpc))
+	}
+	if desc.Empty() {
+		t.Error("Invalid Mat desc in SURF Compute")
 	}
 
-	if desc.Empty() {
+	kpdc, desc2 := si.DetectAndCompute(img, mask)
+	defer desc2.Close()
+	if len(kpdc) < 512 {
+		t.Errorf("Invalid KeyPoint array in SURF DetectAndCompute: %d", len(kpdc))
+	}
+	if desc2.Empty() {
 		t.Error("Invalid Mat desc in SURF DetectAndCompute")
 	}
 }

--- a/contrib/xfeatures2d_test.go
+++ b/contrib/xfeatures2d_test.go
@@ -32,13 +32,23 @@ func TestSURF(t *testing.T) {
 
 	mask := gocv.NewMat()
 	defer mask.Close()
+	desc := gocv.NewMat()
+	defer desc.Close()
 
-	kp2, desc := si.DetectAndCompute(img, mask)
-	if len(kp2) == 512 {
-		t.Errorf("Invalid KeyPoint array in SURF DetectAndCompute: %d", len(kp2))
+	kpc := si.Compute(img, mask, kp, desc)
+	if len(kpc) < 512 {
+		t.Errorf("Invalid KeyPoint array in SURF Compute: %d", len(kpc))
+	}
+	if desc.Empty() {
+		t.Error("Invalid Mat desc in SURF Compute")
 	}
 
-	if desc.Empty() {
+	kpdc, desc2 := si.DetectAndCompute(img, mask)
+	defer desc2.Close()
+	if len(kpdc) < 512 {
+		t.Errorf("Invalid KeyPoint array in SURF DetectAndCompute: %d", len(kpdc))
+	}
+	if desc2.Empty() {
 		t.Error("Invalid Mat desc in SURF DetectAndCompute")
 	}
 }

--- a/contrib/xfeatures2d_test.go
+++ b/contrib/xfeatures2d_test.go
@@ -32,10 +32,8 @@ func TestSURF(t *testing.T) {
 
 	mask := gocv.NewMat()
 	defer mask.Close()
-	desc := gocv.NewMat()
-	defer desc.Close()
 
-	kpc := si.Compute(img, mask, kp, desc)
+	kpc, desc := si.Compute(img, mask, kp)
 	if len(kpc) < 512 {
 		t.Errorf("Invalid KeyPoint array in SURF Compute: %d", len(kpc))
 	}

--- a/contrib/xfeatures2d_test.go
+++ b/contrib/xfeatures2d_test.go
@@ -34,6 +34,7 @@ func TestSURF(t *testing.T) {
 	defer mask.Close()
 
 	kpc, desc := si.Compute(img, mask, kp)
+	defer desc.Close()
 	if len(kpc) < 512 {
 		t.Errorf("Invalid KeyPoint array in SURF Compute: %d", len(kpc))
 	}
@@ -78,6 +79,7 @@ func TestSURFWithParams(t *testing.T) {
 	defer mask.Close()
 
 	kpc, desc := si.Compute(img, mask, kp)
+	defer desc.Close()
 	if len(kpc) < 512 {
 		t.Errorf("Invalid KeyPoint array in SURF Compute: %d", len(kpc))
 	}

--- a/features2d.cpp
+++ b/features2d.cpp
@@ -26,6 +26,30 @@ struct KeyPoints AKAZE_Detect(AKAZE a, Mat src) {
     return ret;
 }
 
+struct KeyPoints AKAZE_Compute(AKAZE a, Mat src, struct KeyPoints kp, Mat desc) {
+    std::vector<cv::KeyPoint> computed;
+    for (size_t i = 0; i < kp.length; i++) {
+        cv::KeyPoint k = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
+            kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
+            kp.keypoints[i].octave, kp.keypoints[i].classID);
+        computed.push_back(k);
+    }
+
+    (*a)->compute(*src, computed, *desc);
+
+    KeyPoint* kps = new KeyPoint[computed.size()];
+
+    for (size_t i = 0; i < computed.size(); ++i) {
+        KeyPoint k = {computed[i].pt.x, computed[i].pt.y, computed[i].size, computed[i].angle,
+                      computed[i].response, computed[i].octave, computed[i].class_id
+                     };
+        kps[i] = k;
+    }
+
+    KeyPoints ret = {kps, (int)computed.size()};
+    return ret;
+}
+
 struct KeyPoints AKAZE_DetectAndCompute(AKAZE a, Mat src, Mat mask, Mat desc) {
     std::vector<cv::KeyPoint> detected;
     (*a)->detectAndCompute(*src, *mask, detected, *desc);
@@ -95,6 +119,30 @@ struct KeyPoints BRISK_Detect(BRISK b, Mat src) {
     return ret;
 }
 
+struct KeyPoints BRISK_Compute(BRISK b, Mat src, struct KeyPoints kp, Mat desc) {
+    std::vector<cv::KeyPoint> computed;
+    for (size_t i = 0; i < kp.length; i++) {
+        cv::KeyPoint k = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
+            kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
+            kp.keypoints[i].octave, kp.keypoints[i].classID);
+        computed.push_back(k);
+    }
+
+    (*b)->compute(*src, computed, *desc);
+
+    KeyPoint* kps = new KeyPoint[computed.size()];
+
+    for (size_t i = 0; i < computed.size(); ++i) {
+        KeyPoint k = {computed[i].pt.x, computed[i].pt.y, computed[i].size, computed[i].angle,
+                      computed[i].response, computed[i].octave, computed[i].class_id
+                     };
+        kps[i] = k;
+    }
+
+    KeyPoints ret = {kps, (int)computed.size()};
+    return ret;
+}
+
 struct KeyPoints BRISK_DetectAndCompute(BRISK b, Mat src, Mat mask, Mat desc) {
     std::vector<cv::KeyPoint> detected;
     (*b)->detectAndCompute(*src, *mask, detected, *desc);
@@ -161,6 +209,30 @@ struct KeyPoints KAZE_Detect(KAZE a, Mat src) {
     }
 
     KeyPoints ret = {kps, (int)detected.size()};
+    return ret;
+}
+
+struct KeyPoints KAZE_Compute(KAZE a, Mat src, struct KeyPoints kp, Mat desc) {
+    std::vector<cv::KeyPoint> computed;
+    for (size_t i = 0; i < kp.length; i++) {
+        cv::KeyPoint k = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
+            kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
+            kp.keypoints[i].octave, kp.keypoints[i].classID);
+        computed.push_back(k);
+    }
+
+    (*a)->compute(*src, computed, *desc);
+
+    KeyPoint* kps = new KeyPoint[computed.size()];
+
+    for (size_t i = 0; i < computed.size(); ++i) {
+        KeyPoint k = {computed[i].pt.x, computed[i].pt.y, computed[i].size, computed[i].angle,
+                      computed[i].response, computed[i].octave, computed[i].class_id
+                     };
+        kps[i] = k;
+    }
+
+    KeyPoints ret = {kps, (int)computed.size()};
     return ret;
 }
 
@@ -262,6 +334,30 @@ struct KeyPoints ORB_Detect(ORB o, Mat src) {
     }
 
     KeyPoints ret = {kps, (int)detected.size()};
+    return ret;
+}
+
+struct KeyPoints ORB_Compute(ORB o, Mat src, struct KeyPoints kp, Mat desc) {
+    std::vector<cv::KeyPoint> computed;
+    for (size_t i = 0; i < kp.length; i++) {
+        cv::KeyPoint k = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
+            kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
+            kp.keypoints[i].octave, kp.keypoints[i].classID);
+        computed.push_back(k);
+    }
+
+    (*o)->compute(*src, computed, *desc);
+
+    KeyPoint* kps = new KeyPoint[computed.size()];
+
+    for (size_t i = 0; i < computed.size(); ++i) {
+        KeyPoint k = {computed[i].pt.x, computed[i].pt.y, computed[i].size, computed[i].angle,
+                      computed[i].response, computed[i].octave, computed[i].class_id
+                     };
+        kps[i] = k;
+    }
+
+    KeyPoints ret = {kps, (int)computed.size()};
     return ret;
 }
 
@@ -512,6 +608,30 @@ struct KeyPoints SIFT_Detect(SIFT d, Mat src) {
     }
 
     KeyPoints ret = {kps, (int)detected.size()};
+    return ret;
+}
+
+struct KeyPoints SIFT_Compute(SIFT d, Mat src, struct KeyPoints kp, Mat desc) {
+    std::vector<cv::KeyPoint> computed;
+    for (size_t i = 0; i < kp.length; i++) {
+        cv::KeyPoint k = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
+            kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
+            kp.keypoints[i].octave, kp.keypoints[i].classID);
+        computed.push_back(k);
+    }
+
+    (*d)->compute(*src, computed, *desc);
+
+    KeyPoint* kps = new KeyPoint[computed.size()];
+
+    for (size_t i = 0; i < computed.size(); ++i) {
+        KeyPoint k = {computed[i].pt.x, computed[i].pt.y, computed[i].size, computed[i].angle,
+                      computed[i].response, computed[i].octave, computed[i].class_id
+                     };
+        kps[i] = k;
+    }
+
+    KeyPoints ret = {kps, (int)computed.size()};
     return ret;
 }
 

--- a/features2d.go
+++ b/features2d.go
@@ -43,6 +43,32 @@ func (a *AKAZE) Detect(src Mat) []KeyPoint {
 	return getKeyPoints(ret)
 }
 
+// Compute keypoints in an image using AKAZE.
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/d0/d13/classcv_1_1Feature2D.html#ab3cce8d56f4fc5e1d530b5931e1e8dc0
+func (a *AKAZE) Compute(src Mat, mask Mat, kps []KeyPoint, desc Mat) []KeyPoint {
+	kp2arr := make([]C.struct_KeyPoint, len(kps))
+	for i, kp := range kps {
+		kp2arr[i].x = C.double(kp.X)
+		kp2arr[i].y = C.double(kp.Y)
+		kp2arr[i].size = C.double(kp.Size)
+		kp2arr[i].angle = C.double(kp.Angle)
+		kp2arr[i].response = C.double(kp.Response)
+		kp2arr[i].octave = C.int(kp.Octave)
+		kp2arr[i].classID = C.int(kp.ClassID)
+	}
+	cKeyPoints := C.struct_KeyPoints{
+		keypoints: (*C.struct_KeyPoint)(&kp2arr[0]),
+		length:    (C.int)(len(kps)),
+	}
+
+	ret := C.AKAZE_Compute((C.AKAZE)(a.p), src.p, cKeyPoints, desc.p)
+	defer C.KeyPoints_Close(ret)
+
+	return getKeyPoints(ret)
+}
+
 // DetectAndCompute keypoints and compute in an image using AKAZE.
 //
 // For further details, please see:
@@ -114,6 +140,32 @@ func (b *BRISK) Close() error {
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#aa4e9a7082ec61ebc108806704fbd7887
 func (b *BRISK) Detect(src Mat) []KeyPoint {
 	ret := C.BRISK_Detect((C.BRISK)(b.p), src.p)
+	defer C.KeyPoints_Close(ret)
+
+	return getKeyPoints(ret)
+}
+
+// Compute keypoints in an image using BRISK.
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/d0/d13/classcv_1_1Feature2D.html#ab3cce8d56f4fc5e1d530b5931e1e8dc0
+func (b *BRISK) Compute(src Mat, mask Mat, kps []KeyPoint, desc Mat) []KeyPoint {
+	kp2arr := make([]C.struct_KeyPoint, len(kps))
+	for i, kp := range kps {
+		kp2arr[i].x = C.double(kp.X)
+		kp2arr[i].y = C.double(kp.Y)
+		kp2arr[i].size = C.double(kp.Size)
+		kp2arr[i].angle = C.double(kp.Angle)
+		kp2arr[i].response = C.double(kp.Response)
+		kp2arr[i].octave = C.int(kp.Octave)
+		kp2arr[i].classID = C.int(kp.ClassID)
+	}
+	cKeyPoints := C.struct_KeyPoints{
+		keypoints: (*C.struct_KeyPoint)(&kp2arr[0]),
+		length:    (C.int)(len(kps)),
+	}
+
+	ret := C.BRISK_Compute((C.BRISK)(b.p), src.p, cKeyPoints, desc.p)
 	defer C.KeyPoints_Close(ret)
 
 	return getKeyPoints(ret)
@@ -250,6 +302,32 @@ func (a *KAZE) Detect(src Mat) []KeyPoint {
 	return getKeyPoints(ret)
 }
 
+// Compute keypoints in an image using KAZE.
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/d0/d13/classcv_1_1Feature2D.html#ab3cce8d56f4fc5e1d530b5931e1e8dc0
+func (a *KAZE) Compute(src Mat, mask Mat, kps []KeyPoint, desc Mat) []KeyPoint {
+	kp2arr := make([]C.struct_KeyPoint, len(kps))
+	for i, kp := range kps {
+		kp2arr[i].x = C.double(kp.X)
+		kp2arr[i].y = C.double(kp.Y)
+		kp2arr[i].size = C.double(kp.Size)
+		kp2arr[i].angle = C.double(kp.Angle)
+		kp2arr[i].response = C.double(kp.Response)
+		kp2arr[i].octave = C.int(kp.Octave)
+		kp2arr[i].classID = C.int(kp.ClassID)
+	}
+	cKeyPoints := C.struct_KeyPoints{
+		keypoints: (*C.struct_KeyPoint)(&kp2arr[0]),
+		length:    (C.int)(len(kps)),
+	}
+
+	ret := C.KAZE_Compute((C.KAZE)(a.p), src.p, cKeyPoints, desc.p)
+	defer C.KeyPoints_Close(ret)
+
+	return getKeyPoints(ret)
+}
+
 // DetectAndCompute keypoints and compute in an image using KAZE.
 //
 // For further details, please see:
@@ -346,6 +424,32 @@ func (o *ORB) Close() error {
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#aa4e9a7082ec61ebc108806704fbd7887
 func (o *ORB) Detect(src Mat) []KeyPoint {
 	ret := C.ORB_Detect((C.ORB)(o.p), src.p)
+	defer C.KeyPoints_Close(ret)
+
+	return getKeyPoints(ret)
+}
+
+// Compute keypoints in an image using ORB.
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/d0/d13/classcv_1_1Feature2D.html#ab3cce8d56f4fc5e1d530b5931e1e8dc0
+func (o *ORB) Compute(src Mat, mask Mat, kps []KeyPoint, desc Mat) []KeyPoint {
+	kp2arr := make([]C.struct_KeyPoint, len(kps))
+	for i, kp := range kps {
+		kp2arr[i].x = C.double(kp.X)
+		kp2arr[i].y = C.double(kp.Y)
+		kp2arr[i].size = C.double(kp.Size)
+		kp2arr[i].angle = C.double(kp.Angle)
+		kp2arr[i].response = C.double(kp.Response)
+		kp2arr[i].octave = C.int(kp.Octave)
+		kp2arr[i].classID = C.int(kp.ClassID)
+	}
+	cKeyPoints := C.struct_KeyPoints{
+		keypoints: (*C.struct_KeyPoint)(&kp2arr[0]),
+		length:    (C.int)(len(kps)),
+	}
+
+	ret := C.ORB_Compute((C.ORB)(o.p), src.p, cKeyPoints, desc.p)
 	defer C.KeyPoints_Close(ret)
 
 	return getKeyPoints(ret)
@@ -818,6 +922,32 @@ func (d *SIFT) Close() error {
 // https://docs.opencv.org/master/d0/d13/classcv_1_1Feature2D.html#aa4e9a7082ec61ebc108806704fbd7887
 func (d *SIFT) Detect(src Mat) []KeyPoint {
 	ret := C.SIFT_Detect((C.SIFT)(d.p), C.Mat(src.Ptr()))
+	defer C.KeyPoints_Close(ret)
+
+	return getKeyPoints(ret)
+}
+
+// Compute keypoints in an image using SIFT.
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/d0/d13/classcv_1_1Feature2D.html#ab3cce8d56f4fc5e1d530b5931e1e8dc0
+func (d *SIFT) Compute(src Mat, mask Mat, kps []KeyPoint, desc Mat) []KeyPoint {
+	kp2arr := make([]C.struct_KeyPoint, len(kps))
+	for i, kp := range kps {
+		kp2arr[i].x = C.double(kp.X)
+		kp2arr[i].y = C.double(kp.Y)
+		kp2arr[i].size = C.double(kp.Size)
+		kp2arr[i].angle = C.double(kp.Angle)
+		kp2arr[i].response = C.double(kp.Response)
+		kp2arr[i].octave = C.int(kp.Octave)
+		kp2arr[i].classID = C.int(kp.ClassID)
+	}
+	cKeyPoints := C.struct_KeyPoints{
+		keypoints: (*C.struct_KeyPoint)(&kp2arr[0]),
+		length:    (C.int)(len(kps)),
+	}
+
+	ret := C.SIFT_Compute((C.SIFT)(d.p), src.p, cKeyPoints, desc.p)
 	defer C.KeyPoints_Close(ret)
 
 	return getKeyPoints(ret)

--- a/features2d.go
+++ b/features2d.go
@@ -47,7 +47,8 @@ func (a *AKAZE) Detect(src Mat) []KeyPoint {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d0/d13/classcv_1_1Feature2D.html#ab3cce8d56f4fc5e1d530b5931e1e8dc0
-func (a *AKAZE) Compute(src Mat, mask Mat, kps []KeyPoint, desc Mat) []KeyPoint {
+func (a *AKAZE) Compute(src Mat, mask Mat, kps []KeyPoint) ([]KeyPoint, Mat) {
+	desc := NewMat()
 	kp2arr := make([]C.struct_KeyPoint, len(kps))
 	for i, kp := range kps {
 		kp2arr[i].x = C.double(kp.X)
@@ -66,7 +67,7 @@ func (a *AKAZE) Compute(src Mat, mask Mat, kps []KeyPoint, desc Mat) []KeyPoint 
 	ret := C.AKAZE_Compute((C.AKAZE)(a.p), src.p, cKeyPoints, desc.p)
 	defer C.KeyPoints_Close(ret)
 
-	return getKeyPoints(ret)
+	return getKeyPoints(ret), desc
 }
 
 // DetectAndCompute keypoints and compute in an image using AKAZE.
@@ -149,7 +150,8 @@ func (b *BRISK) Detect(src Mat) []KeyPoint {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d0/d13/classcv_1_1Feature2D.html#ab3cce8d56f4fc5e1d530b5931e1e8dc0
-func (b *BRISK) Compute(src Mat, mask Mat, kps []KeyPoint, desc Mat) []KeyPoint {
+func (b *BRISK) Compute(src Mat, mask Mat, kps []KeyPoint) ([]KeyPoint, Mat) {
+	desc := NewMat()
 	kp2arr := make([]C.struct_KeyPoint, len(kps))
 	for i, kp := range kps {
 		kp2arr[i].x = C.double(kp.X)
@@ -168,7 +170,7 @@ func (b *BRISK) Compute(src Mat, mask Mat, kps []KeyPoint, desc Mat) []KeyPoint 
 	ret := C.BRISK_Compute((C.BRISK)(b.p), src.p, cKeyPoints, desc.p)
 	defer C.KeyPoints_Close(ret)
 
-	return getKeyPoints(ret)
+	return getKeyPoints(ret), desc
 }
 
 // DetectAndCompute keypoints and compute in an image using BRISK.
@@ -306,7 +308,8 @@ func (a *KAZE) Detect(src Mat) []KeyPoint {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d0/d13/classcv_1_1Feature2D.html#ab3cce8d56f4fc5e1d530b5931e1e8dc0
-func (a *KAZE) Compute(src Mat, mask Mat, kps []KeyPoint, desc Mat) []KeyPoint {
+func (a *KAZE) Compute(src Mat, mask Mat, kps []KeyPoint) ([]KeyPoint, Mat) {
+	desc := NewMat()
 	kp2arr := make([]C.struct_KeyPoint, len(kps))
 	for i, kp := range kps {
 		kp2arr[i].x = C.double(kp.X)
@@ -325,7 +328,7 @@ func (a *KAZE) Compute(src Mat, mask Mat, kps []KeyPoint, desc Mat) []KeyPoint {
 	ret := C.KAZE_Compute((C.KAZE)(a.p), src.p, cKeyPoints, desc.p)
 	defer C.KeyPoints_Close(ret)
 
-	return getKeyPoints(ret)
+	return getKeyPoints(ret), desc
 }
 
 // DetectAndCompute keypoints and compute in an image using KAZE.
@@ -433,7 +436,8 @@ func (o *ORB) Detect(src Mat) []KeyPoint {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d0/d13/classcv_1_1Feature2D.html#ab3cce8d56f4fc5e1d530b5931e1e8dc0
-func (o *ORB) Compute(src Mat, mask Mat, kps []KeyPoint, desc Mat) []KeyPoint {
+func (o *ORB) Compute(src Mat, mask Mat, kps []KeyPoint) ([]KeyPoint, Mat) {
+	desc := NewMat()
 	kp2arr := make([]C.struct_KeyPoint, len(kps))
 	for i, kp := range kps {
 		kp2arr[i].x = C.double(kp.X)
@@ -452,7 +456,7 @@ func (o *ORB) Compute(src Mat, mask Mat, kps []KeyPoint, desc Mat) []KeyPoint {
 	ret := C.ORB_Compute((C.ORB)(o.p), src.p, cKeyPoints, desc.p)
 	defer C.KeyPoints_Close(ret)
 
-	return getKeyPoints(ret)
+	return getKeyPoints(ret), desc
 }
 
 // DetectAndCompute detects keypoints and computes from an image using ORB.
@@ -931,7 +935,8 @@ func (d *SIFT) Detect(src Mat) []KeyPoint {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d0/d13/classcv_1_1Feature2D.html#ab3cce8d56f4fc5e1d530b5931e1e8dc0
-func (d *SIFT) Compute(src Mat, mask Mat, kps []KeyPoint, desc Mat) []KeyPoint {
+func (d *SIFT) Compute(src Mat, mask Mat, kps []KeyPoint) ([]KeyPoint, Mat) {
+	desc := NewMat()
 	kp2arr := make([]C.struct_KeyPoint, len(kps))
 	for i, kp := range kps {
 		kp2arr[i].x = C.double(kp.X)
@@ -950,7 +955,7 @@ func (d *SIFT) Compute(src Mat, mask Mat, kps []KeyPoint, desc Mat) []KeyPoint {
 	ret := C.SIFT_Compute((C.SIFT)(d.p), src.p, cKeyPoints, desc.p)
 	defer C.KeyPoints_Close(ret)
 
-	return getKeyPoints(ret)
+	return getKeyPoints(ret), desc
 }
 
 // DetectAndCompute detects and computes keypoints in an image using SIFT.

--- a/features2d.h
+++ b/features2d.h
@@ -39,6 +39,7 @@ typedef void* SIFT;
 AKAZE AKAZE_Create();
 void AKAZE_Close(AKAZE a);
 struct KeyPoints AKAZE_Detect(AKAZE a, Mat src);
+struct KeyPoints AKAZE_Compute(AKAZE a, Mat src, struct KeyPoints kp, Mat desc);
 struct KeyPoints AKAZE_DetectAndCompute(AKAZE a, Mat src, Mat mask, Mat desc);
 
 AgastFeatureDetector AgastFeatureDetector_Create();
@@ -48,6 +49,7 @@ struct KeyPoints AgastFeatureDetector_Detect(AgastFeatureDetector a, Mat src);
 BRISK BRISK_Create();
 void BRISK_Close(BRISK b);
 struct KeyPoints BRISK_Detect(BRISK b, Mat src);
+struct KeyPoints BRISK_Compute(BRISK b, Mat src, struct KeyPoints kp, Mat desc);
 struct KeyPoints BRISK_DetectAndCompute(BRISK b, Mat src, Mat mask, Mat desc);
 
 FastFeatureDetector FastFeatureDetector_Create();
@@ -62,6 +64,7 @@ struct KeyPoints GFTTDetector_Detect(GFTTDetector a, Mat src);
 KAZE KAZE_Create();
 void KAZE_Close(KAZE a);
 struct KeyPoints KAZE_Detect(KAZE a, Mat src);
+struct KeyPoints KAZE_Compute(KAZE a, Mat src, struct KeyPoints kp, Mat desc);
 struct KeyPoints KAZE_DetectAndCompute(KAZE a, Mat src, Mat mask, Mat desc);
 
 MSER MSER_Create();
@@ -72,6 +75,7 @@ ORB ORB_Create();
 ORB ORB_CreateWithParams(int nfeatures, float scaleFactor, int nlevels, int edgeThreshold, int firstLevel, int WTA_K, int scoreType, int patchSize, int fastThreshold);
 void ORB_Close(ORB o);
 struct KeyPoints ORB_Detect(ORB o, Mat src);
+struct KeyPoints ORB_Compute(ORB o, Mat src, struct KeyPoints kp, Mat desc);
 struct KeyPoints ORB_DetectAndCompute(ORB o, Mat src, Mat mask, Mat desc);
 
 SimpleBlobDetector SimpleBlobDetector_Create();
@@ -95,6 +99,7 @@ void DrawKeyPoints(Mat src, struct KeyPoints kp, Mat dst, const Scalar s, int fl
 SIFT SIFT_Create();
 void SIFT_Close(SIFT f);
 struct KeyPoints SIFT_Detect(SIFT f, Mat src);
+struct KeyPoints SIFT_Compute(SIFT f, Mat src, struct KeyPoints kp, Mat desc);
 struct KeyPoints SIFT_DetectAndCompute(SIFT f, Mat src, Mat mask, Mat desc);
 
 void DrawMatches(Mat img1, struct KeyPoints kp1, Mat img2, struct KeyPoints kp2, struct DMatches matches1to2, Mat outImg, const Scalar matchesColor, const Scalar pointColor, struct ByteArray matchesMask, int flags);

--- a/features2d_test.go
+++ b/features2d_test.go
@@ -25,10 +25,8 @@ func TestAKAZE(t *testing.T) {
 
 	mask := NewMat()
 	defer mask.Close()
-	desc := NewMat()
-	defer desc.Close()
 
-	kpc := ak.Compute(img, mask, kp, desc)
+	kpc, desc := ak.Compute(img, mask, kp)
 	if len(kpc) < 512 {
 		t.Errorf("Invalid KeyPoint array in AKAZE Compute: %d", len(kpc))
 	}
@@ -85,10 +83,8 @@ func TestBRISK(t *testing.T) {
 
 	mask := NewMat()
 	defer mask.Close()
-	desc := NewMat()
-	defer desc.Close()
 
-	kpc := br.Compute(img, mask, kp, desc)
+	kpc, desc := br.Compute(img, mask, kp)
 	if len(kpc) < 512 {
 		t.Errorf("Invalid KeyPoint array in BRISK Compute: %d", len(kpc))
 	}
@@ -183,10 +179,8 @@ func TestKAZE(t *testing.T) {
 
 	mask := NewMat()
 	defer mask.Close()
-	desc := NewMat()
-	defer desc.Close()
 
-	kpc := k.Compute(img, mask, kp, desc)
+	kpc, desc := k.Compute(img, mask, kp)
 	if len(kpc) < 512 {
 		t.Errorf("Invalid KeyPoint array in KAZE Compute: %d", len(kpc))
 	}
@@ -243,10 +237,8 @@ func TestORB(t *testing.T) {
 
 	mask := NewMat()
 	defer mask.Close()
-	desc := NewMat()
-	defer desc.Close()
 
-	kpc := od.Compute(img, mask, kp, desc)
+	kpc, desc := od.Compute(img, mask, kp)
 	if len(kpc) < 500 {
 		t.Errorf("Invalid KeyPoint array in ORB Compute: %d", len(kpc))
 	}
@@ -616,10 +608,8 @@ func TestSIFT(t *testing.T) {
 
 	mask := NewMat()
 	defer mask.Close()
-	desc := NewMat()
-	defer desc.Close()
 
-	kpc := si.Compute(img, mask, kp, desc)
+	kpc, desc := si.Compute(img, mask, kp)
 	if len(kpc) < 512 {
 		t.Errorf("Invalid KeyPoint array in SIFT Compute: %d", len(kpc))
 	}

--- a/features2d_test.go
+++ b/features2d_test.go
@@ -27,6 +27,7 @@ func TestAKAZE(t *testing.T) {
 	defer mask.Close()
 
 	kpc, desc := ak.Compute(img, mask, kp)
+	defer desc.Close()
 	if len(kpc) < 512 {
 		t.Errorf("Invalid KeyPoint array in AKAZE Compute: %d", len(kpc))
 	}
@@ -85,6 +86,7 @@ func TestBRISK(t *testing.T) {
 	defer mask.Close()
 
 	kpc, desc := br.Compute(img, mask, kp)
+	defer desc.Close()
 	if len(kpc) < 512 {
 		t.Errorf("Invalid KeyPoint array in BRISK Compute: %d", len(kpc))
 	}
@@ -181,6 +183,7 @@ func TestKAZE(t *testing.T) {
 	defer mask.Close()
 
 	kpc, desc := k.Compute(img, mask, kp)
+	defer desc.Close()
 	if len(kpc) < 512 {
 		t.Errorf("Invalid KeyPoint array in KAZE Compute: %d", len(kpc))
 	}
@@ -239,6 +242,7 @@ func TestORB(t *testing.T) {
 	defer mask.Close()
 
 	kpc, desc := od.Compute(img, mask, kp)
+	defer desc.Close()
 	if len(kpc) < 500 {
 		t.Errorf("Invalid KeyPoint array in ORB Compute: %d", len(kpc))
 	}
@@ -610,6 +614,7 @@ func TestSIFT(t *testing.T) {
 	defer mask.Close()
 
 	kpc, desc := si.Compute(img, mask, kp)
+	defer desc.Close()
 	if len(kpc) < 512 {
 		t.Errorf("Invalid KeyPoint array in SIFT Compute: %d", len(kpc))
 	}

--- a/features2d_test.go
+++ b/features2d_test.go
@@ -25,14 +25,23 @@ func TestAKAZE(t *testing.T) {
 
 	mask := NewMat()
 	defer mask.Close()
-
-	kp2, desc := ak.DetectAndCompute(img, mask)
+	desc := NewMat()
 	defer desc.Close()
-	if len(kp2) < 512 {
-		t.Errorf("Invalid KeyPoint array in AKAZE DetectAndCompute: %d", len(kp2))
+
+	kpc := ak.Compute(img, mask, kp, desc)
+	if len(kpc) < 512 {
+		t.Errorf("Invalid KeyPoint array in AKAZE Compute: %d", len(kpc))
+	}
+	if desc.Empty() {
+		t.Error("Invalid Mat desc in AKAZE Compute")
 	}
 
-	if desc.Empty() {
+	kpdc, desc2 := ak.DetectAndCompute(img, mask)
+	defer desc2.Close()
+	if len(kpdc) < 512 {
+		t.Errorf("Invalid KeyPoint array in AKAZE DetectAndCompute: %d", len(kpdc))
+	}
+	if desc2.Empty() {
 		t.Error("Invalid Mat desc in AKAZE DetectAndCompute")
 	}
 }
@@ -76,15 +85,24 @@ func TestBRISK(t *testing.T) {
 
 	mask := NewMat()
 	defer mask.Close()
-
-	kp2, desc := br.DetectAndCompute(img, mask)
+	desc := NewMat()
 	defer desc.Close()
-	if len(kp2) != 1105 {
-		t.Errorf("Invalid KeyPoint array in BRISK DetectAndCompute: %d", len(kp2))
+
+	kpc := br.Compute(img, mask, kp, desc)
+	if len(kpc) < 512 {
+		t.Errorf("Invalid KeyPoint array in BRISK Compute: %d", len(kpc))
+	}
+	if desc.Empty() {
+		t.Error("Invalid Mat desc in BRISK Compute")
 	}
 
-	if desc.Empty() {
-		t.Error("Invalid Mat desc in AKAZE DetectAndCompute")
+	kpdc, desc2 := br.DetectAndCompute(img, mask)
+	defer desc2.Close()
+	if len(kpdc) < 512 {
+		t.Errorf("Invalid KeyPoint array in BRISK DetectAndCompute: %d", len(kpdc))
+	}
+	if desc2.Empty() {
+		t.Error("Invalid Mat desc in BRISK DetectAndCompute")
 	}
 }
 
@@ -165,14 +183,23 @@ func TestKAZE(t *testing.T) {
 
 	mask := NewMat()
 	defer mask.Close()
-
-	kp2, desc := k.DetectAndCompute(img, mask)
+	desc := NewMat()
 	defer desc.Close()
-	if len(kp2) < 512 {
-		t.Errorf("Invalid KeyPoint array in KAZE DetectAndCompute: %d", len(kp2))
+
+	kpc := k.Compute(img, mask, kp, desc)
+	if len(kpc) < 512 {
+		t.Errorf("Invalid KeyPoint array in KAZE Compute: %d", len(kpc))
+	}
+	if desc.Empty() {
+		t.Error("Invalid Mat desc in KAZE Compute")
 	}
 
-	if desc.Empty() {
+	kpdc, desc2 := k.DetectAndCompute(img, mask)
+	defer desc2.Close()
+	if len(kpdc) < 512 {
+		t.Errorf("Invalid KeyPoint array in KAZE DetectAndCompute: %d", len(kpdc))
+	}
+	if desc2.Empty() {
 		t.Error("Invalid Mat desc in KAZE DetectAndCompute")
 	}
 }
@@ -216,14 +243,23 @@ func TestORB(t *testing.T) {
 
 	mask := NewMat()
 	defer mask.Close()
-
-	kp2, desc := od.DetectAndCompute(img, mask)
+	desc := NewMat()
 	defer desc.Close()
-	if len(kp2) != 500 {
-		t.Errorf("Invalid KeyPoint array in ORB DetectAndCompute: %d", len(kp2))
+
+	kpc := od.Compute(img, mask, kp, desc)
+	if len(kpc) < 500 {
+		t.Errorf("Invalid KeyPoint array in ORB Compute: %d", len(kpc))
+	}
+	if desc.Empty() {
+		t.Error("Invalid Mat desc in ORB Compute")
 	}
 
-	if desc.Empty() {
+	kpdc, desc2 := od.DetectAndCompute(img, mask)
+	defer desc2.Close()
+	if len(kpdc) < 500 {
+		t.Errorf("Invalid KeyPoint array in ORB DetectAndCompute: %d", len(kpdc))
+	}
+	if desc2.Empty() {
 		t.Error("Invalid Mat desc in ORB DetectAndCompute")
 	}
 }
@@ -580,14 +616,23 @@ func TestSIFT(t *testing.T) {
 
 	mask := NewMat()
 	defer mask.Close()
-
-	kp2, desc := si.DetectAndCompute(img, mask)
+	desc := NewMat()
 	defer desc.Close()
-	if len(kp2) == 512 {
-		t.Errorf("Invalid KeyPoint array in SIFT DetectAndCompute: %d", len(kp2))
+
+	kpc := si.Compute(img, mask, kp, desc)
+	if len(kpc) < 512 {
+		t.Errorf("Invalid KeyPoint array in SIFT Compute: %d", len(kpc))
+	}
+	if desc.Empty() {
+		t.Error("Invalid Mat desc in SIFT Compute")
 	}
 
-	if desc.Empty() {
+	kpdc, desc2 := si.DetectAndCompute(img, mask)
+	defer desc2.Close()
+	if len(kpdc) < 512 {
+		t.Errorf("Invalid KeyPoint array in SIFT DetectAndCompute: %d", len(kpdc))
+	}
+	if desc2.Empty() {
 		t.Error("Invalid Mat desc in SIFT DetectAndCompute")
 	}
 }


### PR DESCRIPTION
Related to #1049 implemented separate `Compute` bindings for the following, detection algorithms:
- AKAZE
- BRISK
- KAZE
- ORB
- SIFT (non-free)
- SURF (non-free)