### PR TITLE
Add interface for Feature2D detection algorithms

### DIFF
--- a/contrib/xfeatures2d.go
+++ b/contrib/xfeatures2d.go
@@ -21,6 +21,8 @@ type SURF struct {
 	p unsafe.Pointer
 }
 
+var _ gocv.Feature2D = (*SURF)(nil)
+
 // NewSURF returns a new SURF algorithm.
 //
 // For further details, please see:

--- a/features2d.go
+++ b/features2d.go
@@ -12,23 +12,23 @@ import (
 	"unsafe"
 )
 
-type Detector interface {
+type Feature2DDetector interface {
 	Detect(src Mat) []KeyPoint
 }
 
-type Computer interface {
+type Feature2DComputer interface {
 	Compute(src Mat, mask Mat, kps []KeyPoint) ([]KeyPoint, Mat)
 }
 
-type DetectComputer interface {
+type Feature2DDetectComputer interface {
 	DetectAndCompute(src Mat, mask Mat) ([]KeyPoint, Mat)
 }
 
 type Feature2D interface {
 	io.Closer
-	Detector
-	Computer
-	DetectComputer
+	Feature2DDetector
+	Feature2DComputer
+	Feature2DDetectComputer
 }
 
 // AKAZE is a wrapper around the cv::AKAZE algorithm.

--- a/features2d.go
+++ b/features2d.go
@@ -7,15 +7,37 @@ package gocv
 import "C"
 import (
 	"image/color"
+	"io"
 	"reflect"
 	"unsafe"
 )
+
+type Detector interface {
+	Detect(src Mat) []KeyPoint
+}
+
+type Computer interface {
+	Compute(src Mat, mask Mat, kps []KeyPoint) ([]KeyPoint, Mat)
+}
+
+type DetectComputer interface {
+	DetectAndCompute(src Mat, mask Mat) ([]KeyPoint, Mat)
+}
+
+type Feature2D interface {
+	io.Closer
+	Detector
+	Computer
+	DetectComputer
+}
 
 // AKAZE is a wrapper around the cv::AKAZE algorithm.
 type AKAZE struct {
 	// C.AKAZE
 	p unsafe.Pointer
 }
+
+var _ Feature2D = (*AKAZE)(nil)
 
 // NewAKAZE returns a new AKAZE algorithm
 //
@@ -119,6 +141,8 @@ type BRISK struct {
 	// C.BRISK
 	p unsafe.Pointer
 }
+
+var _ Feature2D = (*BRISK)(nil)
 
 // NewBRISK returns a new BRISK algorithm
 //
@@ -278,6 +302,8 @@ type KAZE struct {
 	p unsafe.Pointer
 }
 
+var _ Feature2D = (*KAZE)(nil)
+
 // NewKAZE returns a new KAZE algorithm
 //
 // For further details, please see:
@@ -380,6 +406,8 @@ type ORB struct {
 	// C.ORB
 	p unsafe.Pointer
 }
+
+var _ Feature2D = (*ORB)(nil)
 
 // NewORB returns a new ORB algorithm
 //
@@ -904,6 +932,8 @@ type SIFT struct {
 	// C.SIFT
 	p unsafe.Pointer
 }
+
+var _ Feature2D = (*SIFT)(nil)
 
 // NewSIFT returns a new SIFT algorithm.
 //


### PR DESCRIPTION
Related to query 4 in #1049, we added a `Feature2D` interface and interface assertions to check at compile time that Feature2D detection algorithms implement required functionality. Interface assertions have been added for the following algorithms:
- AKAZE
- BRISK
- KAZE
- ORB
- SIFT
- SURF

Would you like us to namespace the component interfaces of `Feature2D`, i.e. `Detector`, `Computer` and `DetectComputer` with a `Feature2D` prefix?