### PR TITLE
Makefile changes for building on Debian 12/Bookworm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ BUILD_SHARED_LIBS?=ON
 # Package list for each well-known Linux distribution
 RPMS=cmake curl wget git gtk2-devel libpng-devel libjpeg-devel libtiff-devel tbb tbb-devel libdc1394-devel unzip gcc-c++
 DEBS=unzip wget build-essential cmake curl git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libdc1394-22-dev
+DEBS_BOOKWORM=unzip wget build-essential cmake curl git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev libtbbmalloc2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev
 DEBS_UBUNTU_JAMMY=unzip wget build-essential cmake curl git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libdc1394-dev
 JETSON=build-essential cmake git unzip pkg-config libjpeg-dev libpng-dev libtiff-dev libavcodec-dev libavformat-dev libswscale-dev libgtk2.0-dev libcanberra-gtk* libxvidcore-dev libx264-dev libgtk-3-dev libtbb2 libtbb-dev libdc1394-22-dev libv4l-dev v4l-utils libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libavresample-dev libvorbis-dev libxine2-dev libfaac-dev libmp3lame-dev libtheora-dev libopencore-amrnb-dev libopencore-amrwb-dev libopenblas-dev libatlas-base-dev libblas-dev liblapack-dev libeigen3-dev gfortran libhdf5-dev protobuf-compiler libprotobuf-dev libgoogle-glog-dev libgflags-dev
 
@@ -34,7 +35,11 @@ ifneq ($(shell which apt-get 2>/dev/null),)
 ifneq ($(shell cat /etc/os-release 2>/dev/null | grep "Jammy Jellyfish"),)
 	distro_deps=deps_ubuntu_jammy
 else
+ifneq ($(shell cat /etc/debian_version 2>/dev/null | grep "12."),)
+	distro_deps=deps_debian_bookworm
+else
 	distro_deps=deps_debian
+endif
 endif
 else
 ifneq ($(shell which yum 2>/dev/null),)
@@ -51,6 +56,10 @@ deps_rh_centos:
 
 deps_fedora:
 	sudo dnf -y install pkgconf-pkg-config $(RPMS)
+
+deps_debian_bookworm:
+	sudo apt-get -y update
+	sudo apt-get -y install $(DEBS_BOOKWORM)
 
 deps_debian:
 	sudo apt-get -y update


### PR DESCRIPTION
The Raspberry Pi OS since October updated to Debian version 12 (Bookworm) and requires some adjustments to the Makefile to build.

The changes are;
* Removal of package `libdc1394-22-dev`
* Package `libtbb2` has been replaced with `libtbbmalloc2`