### PR TITLE
ADD Cuda MultiplyWithStream

### DIFF
--- a/cuda/arithm.go
+++ b/cuda/arithm.go
@@ -221,7 +221,7 @@ func MinWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 // Multiply computes a matrix-matrix or matrix-scalar multiplication.
 //
 // For further details, please see:
-// https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga124315aa226260841e25cc0b9ea99dc3
+// https://docs.opencv.org/4.x/d8/d34/group__cudaarithm__elem.html#ga497cc0615bf717e1e615143b56f00591
 func Multiply(src1, src2 GpuMat, dst *GpuMat) {
 	C.GpuMultiply(src1.p, src2.p, dst.p, nil)
 }
@@ -229,7 +229,7 @@ func Multiply(src1, src2 GpuMat, dst *GpuMat) {
 // MultiplyWithStream computes a matrix-matrix or matrix-scalar multiplication.
 //
 // For further details, please see:
-// https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga124315aa226260841e25cc0b9ea99dc3
+// https://docs.opencv.org/4.x/d8/d34/group__cudaarithm__elem.html#ga497cc0615bf717e1e615143b56f00591
 func MultiplyWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 	C.GpuMultiply(src1.p, src2.p, dst.p, s.p)
 }

--- a/cuda/arithm.go
+++ b/cuda/arithm.go
@@ -226,6 +226,14 @@ func Multiply(src1, src2 GpuMat, dst *GpuMat) {
 	C.GpuMultiply(src1.p, src2.p, dst.p, nil)
 }
 
+// MultiplyWithStream computes a matrix-matrix or matrix-scalar multiplication.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga124315aa226260841e25cc0b9ea99dc3
+func MultiplyWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
+	C.GpuMultiply(src1.p, src2.p, dst.p, s.p)
+}
+
 // Sqr computes a square value of each matrix element.
 //
 // For further details, please see:

--- a/cuda/arithm.go
+++ b/cuda/arithm.go
@@ -221,7 +221,7 @@ func MinWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 // Multiply computes a matrix-matrix or matrix-scalar multiplication.
 //
 // For further details, please see:
-// https://docs.opencv.org/4.x/d8/d34/group__cudaarithm__elem.html#ga497cc0615bf717e1e615143b56f00591
+// https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga497cc0615bf717e1e615143b56f00591
 func Multiply(src1, src2 GpuMat, dst *GpuMat) {
 	C.GpuMultiply(src1.p, src2.p, dst.p, nil)
 }
@@ -229,7 +229,7 @@ func Multiply(src1, src2 GpuMat, dst *GpuMat) {
 // MultiplyWithStream computes a matrix-matrix or matrix-scalar multiplication.
 //
 // For further details, please see:
-// https://docs.opencv.org/4.x/d8/d34/group__cudaarithm__elem.html#ga497cc0615bf717e1e615143b56f00591
+// https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga497cc0615bf717e1e615143b56f00591
 func MultiplyWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 	C.GpuMultiply(src1.p, src2.p, dst.p, s.p)
 }


### PR DESCRIPTION
I try to use [Multiply](https://github.com/hybridgroup/gocv/blob/1ce30bf65f8ede198102241f5103e9af2e89bcf6/cuda/arithm.go#L225) in Cuda.  
`MultiplyWithStream` was not available.  
OpenCV had Stream ready([cuda/arithm.cpp](https://github.com/hybridgroup/gocv/blob/1ce30bf65f8ede198102241f5103e9af2e89bcf6/cuda/arithm.cpp#L101), [cuda/arithm.h](https://github.com/hybridgroup/gocv/blob/1ce30bf65f8ede198102241f5103e9af2e89bcf6/cuda/arithm.h#L26) and [opencv multiply](https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga497cc0615bf717e1e615143b56f00591)), but GoCV did not have `MultiplyWithStream`.
So I added the function and confirmed that it works well.  
It would be nice if `MultiplyWithStream` were available.
And I fixed the multiply opencv link because it was incorrect.
[link in code](https://github.com/hybridgroup/gocv/blob/1ce30bf65f8ede198102241f5103e9af2e89bcf6/cuda/arithm.go#L224) : https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga124315aa226260841e25cc0b9ea99dc3
[correct link](https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga497cc0615bf717e1e615143b56f00591) : https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga497cc0615bf717e1e615143b56f00591