### PR TITLE
Correct MinMaxIdx function minIdx and maxIdx

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -660,8 +660,6 @@ void Mat_MinMaxIdx(Mat m, double* minVal, double* maxVal, int* minIdx, int* maxI
 
     for(unsigned int a = 0; a < sizeof(cMinIdx)/sizeof(cMinIdx[0]); a++) {
         minIdx[a] = cMinIdx[a];
-    }
-    for(unsigned int a = 0; a < sizeof(cMaxIdx)/sizeof(cMaxIdx[0]); a++) {
         maxIdx[a] = cMaxIdx[a];
     }
 }

--- a/core.cpp
+++ b/core.cpp
@@ -654,7 +654,16 @@ void Mat_Min(Mat src1, Mat src2, Mat dst) {
 }
 
 void Mat_MinMaxIdx(Mat m, double* minVal, double* maxVal, int* minIdx, int* maxIdx) {
-    cv::minMaxIdx(*m, minVal, maxVal, minIdx, maxIdx);
+    int cMinIdx[m->dims];
+    int cMaxIdx[m->dims];
+    cv::minMaxIdx(*m, minVal, maxVal, cMinIdx, cMaxIdx);
+
+    for(unsigned int a = 0; a < sizeof(cMinIdx)/sizeof(cMinIdx[0]); a++) {
+        minIdx[a] = cMinIdx[a];
+    }
+    for(unsigned int a = 0; a < sizeof(cMaxIdx)/sizeof(cMaxIdx[0]); a++) {
+        maxIdx[a] = cMaxIdx[a];
+    }
 }
 
 void Mat_MinMaxLoc(Mat m, double* minVal, double* maxVal, Point* minLoc, Point* maxLoc) {

--- a/core.go
+++ b/core.go
@@ -1512,15 +1512,24 @@ func Min(src1, src2 Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/de8/group__core__array.html#ga7622c466c628a75d9ed008b42250a73f
-func MinMaxIdx(input Mat) (minVal, maxVal float32, minIdx, maxIdx int) {
+func MinMaxIdx(input Mat) (minVal, maxVal float32, minIdx, maxIdx []int) {
 	var cMinVal C.double
 	var cMaxVal C.double
-	var cMinIdx C.int
-	var cMaxIdx C.int
 
-	C.Mat_MinMaxIdx(input.p, &cMinVal, &cMaxVal, &cMinIdx, &cMaxIdx)
+	dims := len(input.Size())
+	cMinIdx := make([]C.int, dims)
+	cMaxIdx := make([]C.int, dims)
 
-	return float32(cMinVal), float32(cMaxVal), int(minIdx), int(maxIdx)
+	C.Mat_MinMaxIdx(input.p, &cMinVal, &cMaxVal, &cMinIdx[0], &cMaxIdx[0])
+
+	for i := 0; i < dims; i++ {
+		minIdx = append(minIdx, int(cMinIdx[i]))
+	}
+	for i := 0; i < dims; i++ {
+		maxIdx = append(maxIdx, int(cMaxIdx[i]))
+	}
+
+	return float32(cMinVal), float32(cMaxVal), minIdx, maxIdx
 }
 
 // MinMaxLoc finds the global minimum and maximum in an array.

--- a/core_test.go
+++ b/core_test.go
@@ -2569,18 +2569,55 @@ func TestMatMin(t *testing.T) {
 }
 
 func TestMatMinMaxIdx(t *testing.T) {
-	src := NewMatWithSize(10, 10, MatTypeCV32F)
+	src := NewMatWithSize(10, 10, MatTypeCV32FC1)
 	defer src.Close()
 	src.SetFloatAt(3, 3, 17)
 	src.SetFloatAt(4, 4, 16)
 
-	minVal, maxVal, _, _ := MinMaxIdx(src)
+	minVal, maxVal, minIdx, maxIdx := MinMaxIdx(src)
 
 	if minVal != 0 {
 		t.Error("TestMatMinMaxIdx minVal should be 0.")
 	}
 	if maxVal != 17 {
 		t.Errorf("TestMatMinMaxIdx maxVal should be 17, was %f", maxVal)
+	}
+	if minIdx[0] != 0 || minIdx[1] != 0 {
+		t.Errorf("TestMatMinMaxIdx minIdx should be [0,0], was [%d,%d]", minIdx[0], minIdx[1])
+	}
+	if maxIdx[0] != 3 || maxIdx[1] != 3 {
+		t.Errorf("TestMatMinMaxIdx maxIdx should be [3,3], was [%d,%d]", maxIdx[0], maxIdx[1])
+	}
+}
+
+func TestMatMinMaxIdx3d(t *testing.T) {
+	src := NewMatWithSizes([]int{3,3,3}, MatTypeCV32FC1)
+	defer src.Close()
+	src.SetFloatAt3(2, 1, 2, 2)
+
+	minVal, maxVal, minIdx, maxIdx := MinMaxIdx(src)
+	if len(minIdx) != 3 {
+		t.Errorf("minIdx should have 3 dimensions. %d found", len(minIdx))
+	}
+
+	if len(maxIdx) != 3 {
+		t.Errorf("maxIdx should have 3 dimensions. %d found", len(maxIdx))
+	}
+
+	if minVal != 0 {
+		t.Errorf("TestMatMinMaxIdx3d minVal expected 0, got %f", minVal)
+	}
+	if maxVal != 2 {
+		t.Errorf("TestMatMinMaxIdx3d maxVal should be 2, was %f", maxVal)
+	}
+
+
+	if maxIdx[0] != 2 || maxIdx[1] != 1 || maxIdx[2] != 2 {
+		t.Errorf("TestMatMinMaxIdx3d maxIdx should be [2,1,2], was [%d,%d,%d]", maxIdx[0], maxIdx[1], maxIdx[2])
+	}
+
+	if minIdx[0] != 0 || minIdx[1] != 0 || minIdx[2] != 0 {
+		t.Errorf("TestMatMinMaxIdx3d minIdx should be [0,0,0], was [%d,%d,%d]", minIdx[0], minIdx[1], minIdx[2])
 	}
 }
 

--- a/core_test.go
+++ b/core_test.go
@@ -2575,7 +2575,6 @@ func TestMatMinMaxIdx(t *testing.T) {
 	src.SetFloatAt(4, 4, 16)
 
 	minVal, maxVal, minIdx, maxIdx := MinMaxIdx(src)
-
 	if minVal != 0 {
 		t.Error("TestMatMinMaxIdx minVal should be 0.")
 	}
@@ -2593,6 +2592,15 @@ func TestMatMinMaxIdx(t *testing.T) {
 func TestMatMinMaxIdx3d(t *testing.T) {
 	src := NewMatWithSizes([]int{3,3,3}, MatTypeCV32FC1)
 	defer src.Close()
+
+	for x := 0; x < 3; x++ {
+		for y := 0; y < 3; y++ {
+			for z := 0; z < 3; z++ {
+				src.SetFloatAt3(x, y, z, 0)
+			}
+		}
+	}
+
 	src.SetFloatAt3(2, 1, 2, 2)
 
 	minVal, maxVal, minIdx, maxIdx := MinMaxIdx(src)

--- a/core_test.go
+++ b/core_test.go
@@ -2569,12 +2569,12 @@ func TestMatMin(t *testing.T) {
 }
 
 func TestMatMinMaxIdx(t *testing.T) {
-	src := NewMatWithSize(10, 10, MatTypeCV32F)
+	src := NewMatWithSize(10, 10, MatTypeCV32FC1)
 	defer src.Close()
 	src.SetFloatAt(3, 3, 17)
 	src.SetFloatAt(4, 4, 16)
 
-	minVal, maxVal, _, _ := MinMaxIdx(src)
+	minVal, maxVal, minIdx, maxIdx := MinMaxIdx(src)
 
 	if minVal != 0 {
 		t.Error("TestMatMinMaxIdx minVal should be 0.")
@@ -2582,6 +2582,44 @@ func TestMatMinMaxIdx(t *testing.T) {
 	if maxVal != 17 {
 		t.Errorf("TestMatMinMaxIdx maxVal should be 17, was %f", maxVal)
 	}
+	if minIdx[0] != 0 || minIdx[1] != 0 {
+		t.Errorf("TestMatMinMaxIdx minIdx should be [0,0], was [%d,%d]", minIdx[0], minIdx[1])
+	}
+	if maxIdx[0] != 3 || maxIdx[1] != 3 {
+		t.Errorf("TestMatMinMaxIdx maxIdx should be [3,3], was [%d,%d]", maxIdx[0], maxIdx[1])
+	}
+}
+
+func TestMatMinMaxIdx3d(t *testing.T) {
+	src := NewMatWithSizes([]int{3,3,3}, MatTypeCV32FC1)
+	defer src.Close()
+	src.SetFloatAt3(2, 1, 2, 2)
+
+	minVal, maxVal, minIdx, maxIdx := MinMaxIdx(src)
+	if len(minIdx) != 3 {
+		t.Errorf("minIdx should have 3 dimensions. %d found", len(minIdx))
+	}
+
+	if len(maxIdx) != 3 {
+		t.Errorf("maxIdx should have 3 dimensions. %d found", len(maxIdx))
+	}
+
+	if minVal != 0 {
+		t.Errorf("TestMatMinMaxIdx3d minVal expected 0, got %f", minVal)
+	}
+	if maxVal != 2 {
+		t.Errorf("TestMatMinMaxIdx3d maxVal should be 2, was %f", maxVal)
+	}
+
+
+	if maxIdx[0] != 2 || maxIdx[1] != 1 || maxIdx[2] != 2 {
+		t.Errorf("TestMatMinMaxIdx3d maxIdx should be [2,1,2], was [%d,%d,%d]", maxIdx[0], maxIdx[1], maxIdx[2])
+	}
+
+	if minIdx[0] != 0 || minIdx[1] != 0 || minIdx[2] != 0 {
+		t.Errorf("TestMatMinMaxIdx3d minIdx should be [0,0,0], was [%d,%d,%d]", minIdx[0], minIdx[1], minIdx[2])
+	}
+
 }
 
 func TestMixChannels(t *testing.T) {

--- a/core_test.go
+++ b/core_test.go
@@ -2569,7 +2569,7 @@ func TestMatMin(t *testing.T) {
 }
 
 func TestMatMinMaxIdx(t *testing.T) {
-	src := NewMatWithSize(10, 10, MatTypeCV32FC1)
+	src := NewMatWithSize(10, 10, MatTypeCV32F)
 	defer src.Close()
 	src.SetFloatAt(3, 3, 17)
 	src.SetFloatAt(4, 4, 16)
@@ -2590,7 +2590,7 @@ func TestMatMinMaxIdx(t *testing.T) {
 }
 
 func TestMatMinMaxIdx3d(t *testing.T) {
-	src := NewMatWithSizes([]int{3,3,3}, MatTypeCV32FC1)
+	src := NewMatWithSizes([]int{3,3,3}, MatTypeCV32F)
 	defer src.Close()
 
 	for x := 0; x < 3; x++ {


### PR DESCRIPTION
Addresses issue #1151 

This PR looks into changing return type of `minIdx` and `maxIdx` in the `MinMaxIdx` function to be an `[]int` rather than `int`, i.e.

```
func MinMaxIdx(input Mat) (minVal, maxVal float32, minIdx, maxIdx []int) {
  ...
}
```

The return arrays will have input.dims elements.

---

Example:

```
	src := NewMatWithSize(10, 10, MatTypeCV32FC1)
	defer src.Close()
	src.SetFloatAt(3, 3, 17)
	src.SetFloatAt(4, 4, 16)

	minVal, maxVal, minIdx, maxIdx := MinMaxIdx(src)
```
In the above code snippet, `minVal` will be 0, `maxVal` will be 17, minIdx will be `[0,0]`, maxIdx will be `[3,3]`



