### PR TITLE
Add new binding for cv::Erode.

### DIFF
--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -154,6 +154,14 @@ void ErodeWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations,
     cv::erode(*src, *dst, *kernel, pt1, iterations, borderType, cv::morphologyDefaultBorderValue());
 }
 
+void ErodeWithParamsAndBorderValue(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType, Scalar borderValue) {
+    cv::Point pt1(anchor.x, anchor.y);
+    cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
+
+    cv::erode(*src, *dst, *kernel, pt1, iterations, borderType, c);
+}
+
+
 void MatchTemplate(Mat image, Mat templ, Mat result, int method, Mat mask) {
     cv::matchTemplate(*image, *templ, *result, method, *mask);
 }

--- a/imgproc.go
+++ b/imgproc.go
@@ -340,6 +340,28 @@ func ErodeWithParams(src Mat, dst *Mat, kernel Mat, anchor image.Point, iteratio
 	C.ErodeWithParams(src.p, dst.p, kernel.p, cAnchor, C.int(iterations), C.int(borderType))
 }
 
+// ErodeWithParamsAndBorderValue erodes an image by using a specific structuring
+// element. Same as ErodeWithParams but requires an additional borderValue
+// parameter.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#gaeb1e0c1033e3f6b891a25d0511362aeb
+func ErodeWithParamsAndBorderValue(src Mat, dst *Mat, kernel Mat, anchor image.Point, iterations, borderType int, borderValue Scalar) {
+	cAnchor := C.struct_Point{
+		x: C.int(anchor.X),
+		y: C.int(anchor.Y),
+	}
+
+	bv := C.struct_Scalar{
+		val1: C.double(borderValue.Val1),
+		val2: C.double(borderValue.Val2),
+		val3: C.double(borderValue.Val3),
+		val4: C.double(borderValue.Val4),
+	}
+
+	C.ErodeWithParamsAndBorderValue(src.p, dst.p, kernel.p, cAnchor, C.int(iterations), C.int(borderType), bv)
+}
+
 // RetrievalMode is the mode of the contour retrieval algorithm.
 type RetrievalMode int
 

--- a/imgproc.h
+++ b/imgproc.h
@@ -35,6 +35,7 @@ void DilateWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations
 void DistanceTransform(Mat src, Mat dst, Mat labels, int distanceType, int maskSize, int labelType);
 void Erode(Mat src, Mat dst, Mat kernel);
 void ErodeWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType);
+void ErodeWithParamsAndBorderValue(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType, Scalar borderValue);
 void MatchTemplate(Mat image, Mat templ, Mat result, int method, Mat mask);
 struct Moment Moments(Mat src, bool binaryImage);
 void PyrDown(Mat src, Mat dst, Size dstsize, int borderType);

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -692,6 +692,25 @@ func TestErodeWithParams(t *testing.T) {
 	}
 }
 
+func TestErodeWithParamsAndBorderValue(t *testing.T) {
+	img := IMRead("images/face-detect.jpg", IMReadColor)
+	if img.Empty() {
+		t.Error("Invalid read of Mat in ErodeWithParamsAndBorderValue test")
+	}
+	defer img.Close()
+
+	dest := NewMat()
+	defer dest.Close()
+
+	kernel := GetStructuringElement(MorphRect, image.Pt(1, 1))
+	defer kernel.Close()
+
+	ErodeWithParamsAndBorderValue(img, &dest, kernel, image.Pt(-1, -1), 3, 0, NewScalar(0,0,0,0))
+	if dest.Empty() || img.Rows() != dest.Rows() || img.Cols() != dest.Cols() {
+		t.Error("Invalid ErodeWithParamsAndBorderValue test")
+	}
+}
+
 func TestMorphologyDefaultBorderValue(t *testing.T) {
 	zeroScalar := Scalar{}
 	morphologyDefaultBorderValue := MorphologyDefaultBorderValue()


### PR DESCRIPTION
The original gocv.ErodeWithParams left out the border value parameter. A new method gocv.ErodeWithParamsAndBorderValue is added so the existing gocv.ErodeWithParams signature is not broken.