### PR TITLE
Add TestDivideWithStream, TestMultiplyWithStream and Fix NewTemplateMatching, TestTemplateMatching_Match

### DIFF
--- a/cuda/arithm_test.go
+++ b/cuda/arithm_test.go
@@ -228,6 +228,36 @@ func TestDivide(t *testing.T) {
 	}
 }
 
+func TestDivideWithStream(t *testing.T) {
+	src1 := gocv.IMRead("../images/gocvlogo.jpg", gocv.IMReadColor)
+	if src1.Empty() {
+		t.Error("Invalid read of Mat in Divide test")
+	}
+	defer src1.Close()
+
+	var cimg1, cimg2, dimg = NewGpuMat(), NewGpuMat(), NewGpuMat()
+	var s = NewStream()
+	defer cimg1.Close()
+	defer cimg2.Close()
+	defer dimg.Close()
+	defer s.Close()
+
+	cimg1.UploadWithStream(src1, s)
+	cimg2.UploadWithStream(src1, s)
+
+	dest := gocv.NewMat()
+	defer dest.Close()
+
+	DivideWithStream(cimg1, cimg2, &dimg, s)
+	dimg.DownloadWithStream(&dest, s)
+
+	s.WaitForCompletion()
+
+	if dest.Empty() || src1.Rows() != dest.Rows() || src1.Cols() != dest.Cols() {
+		t.Error("Invalid Divide test")
+	}
+}
+
 func TestExp(t *testing.T) {
 	src1 := gocv.IMRead("../images/gocvlogo.jpg", gocv.IMReadColor)
 	if src1.Empty() {

--- a/cuda/arithm_test.go
+++ b/cuda/arithm_test.go
@@ -379,6 +379,37 @@ func TestMultiply(t *testing.T) {
 	}
 }
 
+func TestMultiplyWithStream(t *testing.T) {
+	src1 := gocv.IMRead("../images/gocvlogo.jpg", gocv.IMReadColor)
+	if src1.Empty() {
+		t.Error("Invalid read of Mat in Multiply test")
+	}
+	defer src1.Close()
+
+	var cimg1, cimg2, dimg = NewGpuMat(), NewGpuMat(), NewGpuMat()
+	var s = NewStream()
+	defer cimg1.Close()
+	defer cimg2.Close()
+	defer dimg.Close()
+	defer s.Close()
+
+	cimg1.UploadWithStream(src1, s)
+	cimg2.UploadWithStream(src1, s)
+
+	dest := gocv.NewMat()
+	defer dest.Close()
+
+	MultiplyWithStream(cimg1, cimg2, &dimg, s)
+	dimg.DownloadWithStream(&dest, s)
+
+	s.WaitForCompletion()
+
+	if dest.Empty() || src1.Rows() != dest.Rows() || src1.Cols() != dest.Cols() {
+		t.Error("Invalid Multiply test")
+	}
+
+}
+
 func TestThreshold(t *testing.T) {
 	src := gocv.IMRead("../images/gocvlogo.jpg", gocv.IMReadColor)
 	if src.Empty() {

--- a/cuda/imgproc.go
+++ b/cuda/imgproc.go
@@ -233,10 +233,9 @@ type TemplateMatching struct {
 }
 
 // NewTemplateMatching returns a new TemplateMatching.
-func NewTemplateMatching(srcType int, method gocv.TemplateMatchMode) TemplateMatching {
+func NewTemplateMatching(srcType gocv.MatType, method gocv.TemplateMatchMode) TemplateMatching {
 	return TemplateMatching{p: unsafe.Pointer(C.TemplateMatching_Create(C.int(srcType), C.int(method)))}
 }
-
 // Close TemplateMatching
 func (tm *TemplateMatching) Close() error {
 	C.TemplateMatching_Close((C.TemplateMatching)(tm.p))

--- a/cuda/imgproc_test.go
+++ b/cuda/imgproc_test.go
@@ -283,11 +283,17 @@ func TestHoughSegment_CalcWithStream(t *testing.T) {
 }
 
 func TestTemplateMatching_Match(t *testing.T) {
-	src := gocv.IMRead("../images/face-detect.jpg", gocv.IMReadGrayScale)
-	if src.Empty() {
-		t.Error("Invalid read of Mat in TemplateMatching test")
+	imgScene := gocv.IMRead("../images/face.jpg", gocv.IMReadGrayScale)
+	if imgScene.Empty() {
+		t.Error("Invalid read of face.jpg in MatchTemplate test")
 	}
-	defer src.Close()
+	defer imgScene.Close()
+
+	imgTemplate := gocv.IMRead("../images/toy.jpg", gocv.IMReadGrayScale)
+	if imgTemplate.Empty() {
+		t.Error("Invalid read of toy.jpg in MatchTemplate test")
+	}
+	defer imgTemplate.Close()
 
 	cimg, timg, dimg := NewGpuMat(), NewGpuMat(), NewGpuMat()
 	defer cimg.Close()
@@ -300,18 +306,13 @@ func TestTemplateMatching_Match(t *testing.T) {
 	matcher := NewTemplateMatching(gocv.MatTypeCV8U, gocv.TmSqdiff)
 	defer matcher.Close()
 
-	cimg.Upload(src)
-	timg.Upload(src)
+	cimg.Upload(imgScene)
+	timg.Upload(imgTemplate)
 	matcher.Match(cimg, timg, &dimg)
 	dimg.Download(&dest)
 
-	if dest.Empty() {
-		t.Error("Empty TemplateMatching test")
-	}
-	if src.Rows() != dest.Rows() {
-		t.Error("Invalid TemplateMatching test rows")
-	}
-	if src.Cols() != dest.Cols() {
-		t.Error("Invalid TemplateMatching test cols")
+	_, maxConfidence, _, _ := gocv.MinMaxLoc(dest)
+	if maxConfidence < 0.95 {
+		t.Errorf("Max confidence of %f is too low. MatchTemplate could not find template in scene.", maxConfidence)
 	}
 }


### PR DESCRIPTION
# Add TestDivideWithStream and TestMultiplyWithStream
The [`cuda/arithm_test.go`](https://github.com/hybridgroup/gocv/blob/release/cuda/arithm_test.go) file was missing test code for two functions, so we added them.
- [`MultiplyWithStream`](https://github.com/hybridgroup/gocv/blob/e4613d6569007dac8af7b382df8b7940aa26e92f/cuda/arithm.go#L233) has not test code, but [`TestMultiply`](https://github.com/hybridgroup/gocv/blob/e4613d6569007dac8af7b382df8b7940aa26e92f/cuda/arithm_test.go#L327) is exist.
- [`DivideWithStream`](https://github.com/hybridgroup/gocv/blob/e4613d6569007dac8af7b382df8b7940aa26e92f/cuda/arithm.go#L149) has no test code, but [`TestDivide`](https://github.com/hybridgroup/gocv/blob/e4613d6569007dac8af7b382df8b7940aa26e92f/cuda/arithm_test.go#L206) is exist.

# Fix NewTemplateMatching and TestTemplateMatching_Match
Invalid arguments in the `NewTemplateMatching` function and an error in the `TestTemplateMatching_Match` code in [`cuda/imgproc.go`](https://github.com/hybridgroup/gocv/blob/e4613d6569007dac8af7b382df8b7940aa26e92f/cuda/imgproc.go)
## [NewTemplateMatching](https://github.com/hybridgroup/gocv/blob/e4613d6569007dac8af7b382df8b7940aa26e92f/cuda/imgproc.go#L236)
```go
// Original code
func NewTemplateMatching(srcType int, method gocv.TemplateMatchMode) TemplateMatching {
	return TemplateMatching{p: unsafe.Pointer(C.TemplateMatching_Create(C.int(srcType), C.int(method)))}
}
```
We change `srcType int` -> `srcType gocv.MatType`
```go
// Edit code
func NewTemplateMatching(srcType gocv.MatType, method gocv.TemplateMatchMode) TemplateMatching {
	return TemplateMatching{p: unsafe.Pointer(C.TemplateMatching_Create(C.int(srcType), C.int(method)))}
}
```

## [TestTemplateMatching_Match](https://github.com/hybridgroup/gocv/blob/e4613d6569007dac8af7b382df8b7940aa26e92f/cuda/imgproc_test.go#L285)
We believe that the [`TestMatchTemplateMatching_Match`](https://github.com/hybridgroup/gocv/blob/e4613d6569007dac8af7b382df8b7940aa26e92f/cuda/imgproc_test.go#L285) Test code is designed incorrectly, and we have modified it by referring to the [`TestMatchTemplate`](https://github.com/hybridgroup/gocv/blob/e4613d6569007dac8af7b382df8b7940aa26e92f/imgproc_test.go#L286) in the [`imgproc_test.go`](https://github.com/hybridgroup/gocv/blob/release/imgproc_test.go) file. 
The error in the test code is now gone, and you shouldn't see FAIL.