### PR TITLE
fix: syntax error in go build command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ ENV GOPATH /go
 COPY . /go/src/gocv.io/x/gocv/
 
 WORKDIR /go/src/gocv.io/x/gocv
-RUN go build -tags example -o /build/gocv_version -i ./cmd/version/
+RUN go build -tags example -o /build/gocv_version ./cmd/version/
 
 CMD ["/build/gocv_version"]


### PR DESCRIPTION
Building the Docker image with `Dockerfile` with `docker build .` was failing with the following error message:

```bash
 => ERROR [4/4] RUN go build -tags example -o /build/gocv_version -i ./cmd/version/                                                                                                                                                                                                                                                                                  0.3s
------
 > [4/4] RUN go build -tags example -o /build/gocv_version -i ./cmd/version/:
0.308 flag provided but not defined: -i
0.308 usage: go build [-o output] [build flags] [packages]
0.308 Run 'go help build' for details.
------
Dockerfile:10
--------------------
   8 |
   9 |     WORKDIR /go/src/gocv.io/x/gocv
  10 | >>> RUN go build -tags example -o /build/gocv_version -i ./cmd/version/
  11 |
  12 |     CMD ["/build/gocv_version"]
--------------------
ERROR: failed to solve: process "/bin/sh -c go build -tags example -o /build/gocv_version -i ./cmd/version/" did not complete successfully: exit code: 2
```

Removed the `-i` flag from `go build` as it's not defined