### PR TITLE
Missing HomographyMethodRHO HomographyMethod added

### DIFF
--- a/imgproc.go
+++ b/imgproc.go
@@ -1822,6 +1822,7 @@ const (
 	HomograpyMethodAllPoints HomographyMethod = 0
 	HomograpyMethodLMEDS     HomographyMethod = 4
 	HomograpyMethodRANSAC    HomographyMethod = 8
+	HomograpyMethodRHO       HomographyMethod = 16
 )
 
 // FindHomography finds an optimal homography matrix using 4 or more point pairs (as opposed to GetPerspectiveTransform, which uses exactly 4)

--- a/imgproc.go
+++ b/imgproc.go
@@ -1819,10 +1819,10 @@ func GetAffineTransform2f(src, dst Point2fVector) Mat {
 type HomographyMethod int
 
 const (
-	HomograpyMethodAllPoints HomographyMethod = 0
-	HomograpyMethodLMEDS     HomographyMethod = 4
-	HomograpyMethodRANSAC    HomographyMethod = 8
-	HomograpyMethodRHO       HomographyMethod = 16
+	HomographyMethodAllPoints HomographyMethod = 0
+	HomographyMethodLMEDS     HomographyMethod = 4
+	HomographyMethodRANSAC    HomographyMethod = 8
+	HomographyMethodRHO       HomographyMethod = 16
 )
 
 // FindHomography finds an optimal homography matrix using 4 or more point pairs (as opposed to GetPerspectiveTransform, which uses exactly 4)

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -776,7 +776,7 @@ func TestErodeWithParamsAndBorderValue(t *testing.T) {
 	kernel := GetStructuringElement(MorphRect, image.Pt(1, 1))
 	defer kernel.Close()
 
-	ErodeWithParamsAndBorderValue(img, &dest, kernel, image.Pt(-1, -1), 3, 0, NewScalar(0,0,0,0))
+	ErodeWithParamsAndBorderValue(img, &dest, kernel, image.Pt(-1, -1), 3, 0, NewScalar(0, 0, 0, 0))
 	if dest.Empty() || img.Rows() != dest.Rows() || img.Cols() != dest.Cols() {
 		t.Error("Invalid ErodeWithParamsAndBorderValue test")
 	}
@@ -2003,7 +2003,7 @@ func TestFindHomography(t *testing.T) {
 	mask := NewMat()
 	defer mask.Close()
 
-	m := FindHomography(src, &dst, HomograpyMethodAllPoints, 3, &mask, 2000, 0.995)
+	m := FindHomography(src, &dst, HomographyMethodAllPoints, 3, &mask, 2000, 0.995)
 	defer m.Close()
 
 	pvsrc := NewPoint2fVectorFromPoints(srcPoints)


### PR DESCRIPTION
Hello!
This is my first pull-request here. There is a link to the official **OpenCV** documentation attached to the `FindHomography` function. It mentions four supported homogpraphy methods, but in **gocv** only three of them have been implemented. I ran local tests on whether the library can work with the RHO method, and all the tests were successful. In accordance with the documentation, I propose to add the missing method.

I also noticed an inconsistency in the names of values and the type (*HomographyMethod/HomograpyMethod*), but I assume that due to compatibility with previous versions of the library, it will be hard to correct this (marking old values as deprecated and adding new ones without a typo?).

Greetings