### PR TITLE
dnn: allow ReadNet() function to only accept model file, remove Caffe tests, correct ONNX tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,11 +18,9 @@ jobs:
         run: "test -z $(gofmt -l .) || gofmt -d ."
       - name: Install dependencies
         run: apt-get update -yqq && apt-get install xvfb unzip -y
-      - name: Install Caffe test model
+      - name: Install WeChat test model
         run: |
           mkdir -p ${GITHUB_WORKSPACE}/testdata
-          curl -sL https://raw.githubusercontent.com/opencv/opencv_extra/master/testdata/dnn/bvlc_googlenet.prototxt > ${GITHUB_WORKSPACE}/testdata/bvlc_googlenet.prototxt
-          curl -sL http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel > ${GITHUB_WORKSPACE}/testdata/bvlc_googlenet.caffemodel
           curl -sL https://raw.githubusercontent.com/WeChatCV/opencv_3rdparty/wechat_qrcode/detect.caffemodel > ${GITHUB_WORKSPACE}/testdata/detect.caffemodel
           curl -sL https://raw.githubusercontent.com/WeChatCV/opencv_3rdparty/wechat_qrcode/detect.prototxt > ${GITHUB_WORKSPACE}/testdata/detect.prototxt
           curl -sL https://raw.githubusercontent.com/WeChatCV/opencv_3rdparty/wechat_qrcode/sr.caffemodel > ${GITHUB_WORKSPACE}/testdata/sr.caffemodel
@@ -40,7 +38,6 @@ jobs:
         run: xvfb-run -a --error-file /var/log/xvfb_error.log --server-args="-screen 0 1024x768x24 +extension RANDR" go test -v -coverprofile=/tmp/coverage.out -count=1 -tags matprofile .
         env:
           DISPLAY: 99.0
-          GOCV_CAFFE_TEST_FILES: ${{ github.workspace }}/testdata
           GOCV_TENSORFLOW_TEST_FILES: ${{ github.workspace }}/testdata
           NO_GOCV_ONNX_TEST_FILES: ${{ github.workspace }}/testdata
       - name: Run contrib tests

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -33,13 +33,13 @@ jobs:
       - name: Install ONNX test model
         run: |
           mkdir -p ${GITHUB_WORKSPACE}/testdata
-          curl -sL https://github.com/onnx/models/blob/master/vision/classification/inception_and_googlenet/googlenet/model/googlenet-9.onnx\?raw\=true > ${GITHUB_WORKSPACE}/testdata/googlenet-9.onnx
+          curl -sL https://github.com/onnx/models/raw/main/validated/vision/classification/inception_and_googlenet/googlenet/model/googlenet-9.onnx > ${GITHUB_WORKSPACE}/testdata/googlenet-9.onnx
       - name: Run main tests
         run: xvfb-run -a --error-file /var/log/xvfb_error.log --server-args="-screen 0 1024x768x24 +extension RANDR" go test -v -coverprofile=/tmp/coverage.out -count=1 -tags matprofile .
         env:
           DISPLAY: 99.0
           GOCV_TENSORFLOW_TEST_FILES: ${{ github.workspace }}/testdata
-          NO_GOCV_ONNX_TEST_FILES: ${{ github.workspace }}/testdata
+          GOCV_ONNX_TEST_FILES: ${{ github.workspace }}/testdata
       - name: Run contrib tests
         run: xvfb-run -a --error-file /var/log/xvfb_error.log --server-args="-screen 0 1024x768x24 +extension RANDR" go test -v -coverprofile=/tmp/contrib.out -count=1 -tags matprofile ./contrib
         env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,11 +42,11 @@ jobs:
       - name: Install ONNX test model
         run: |
           mkdir -p ${GITHUB_WORKSPACE}/testdata
-          curl -sL https://github.com/onnx/models/blob/master/vision/classification/inception_and_googlenet/googlenet/model/googlenet-9.onnx\?raw\=true > ${GITHUB_WORKSPACE}/testdata/googlenet-9.onnx
+          curl -sL https://github.com/onnx/models/raw/main/validated/vision/classification/inception_and_googlenet/googlenet/model/googlenet-9.onnx > ${GITHUB_WORKSPACE}/testdata/googlenet-9.onnx
       - name: Run main tests
         run: go test -v -tags matprofile .
         env:
           GOCV_TENSORFLOW_TEST_FILES: ${{ github.workspace }}/testdata
-          NO_GOCV_ONNX_TEST_FILES: ${{ github.workspace }}/testdata
+          GOCV_ONNX_TEST_FILES: ${{ github.workspace }}/testdata
       - name: Run contrib tests
         run: go test -v -tags matprofile ./contrib

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,11 +27,9 @@ jobs:
           cache: true
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Caffe test model
+      - name: Install WeChat test model
         run: |
           mkdir -p ${GITHUB_WORKSPACE}/testdata
-          curl -sL https://raw.githubusercontent.com/opencv/opencv_extra/master/testdata/dnn/bvlc_googlenet.prototxt > ${GITHUB_WORKSPACE}/testdata/bvlc_googlenet.prototxt
-          curl -sL http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel > ${GITHUB_WORKSPACE}/testdata/bvlc_googlenet.caffemodel
           curl -sL https://raw.githubusercontent.com/WeChatCV/opencv_3rdparty/wechat_qrcode/detect.caffemodel > ${GITHUB_WORKSPACE}/testdata/detect.caffemodel
           curl -sL https://raw.githubusercontent.com/WeChatCV/opencv_3rdparty/wechat_qrcode/detect.prototxt > ${GITHUB_WORKSPACE}/testdata/detect.prototxt
           curl -sL https://raw.githubusercontent.com/WeChatCV/opencv_3rdparty/wechat_qrcode/sr.caffemodel > ${GITHUB_WORKSPACE}/testdata/sr.caffemodel
@@ -48,7 +46,6 @@ jobs:
       - name: Run main tests
         run: go test -v -tags matprofile .
         env:
-          GOCV_CAFFE_TEST_FILES: ${{ github.workspace }}/testdata
           GOCV_TENSORFLOW_TEST_FILES: ${{ github.workspace }}/testdata
           NO_GOCV_ONNX_TEST_FILES: ${{ github.workspace }}/testdata
       - name: Run contrib tests

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -82,9 +82,21 @@ jobs:
             echo "CGO_CPPFLAGS=-I${env:GITHUB_WORKSPACE}\opencv\build\install\include" >> $env:GITHUB_ENV
             echo "CGO_LDFLAGS=-L${env:GITHUB_WORKSPACE}\opencv\build\install\x64\mingw\lib -lopencv_core4100 -lopencv_face4100 -lopencv_videoio4100 -lopencv_imgproc4100 -lopencv_highgui4100 -lopencv_imgcodecs4100 -lopencv_objdetect4100 -lopencv_features2d4100 -lopencv_video4100 -lopencv_dnn4100 -lopencv_xfeatures2d4100 -lopencv_plot4100 -lopencv_tracking4100 -lopencv_img_hash4100 -lopencv_calib3d4100 -lopencv_bgsegm4100 -lopencv_photo4100 -lopencv_aruco4100 -lopencv_wechat_qrcode4100 -lopencv_ximgproc4100 -lopencv_xphoto4100" >> $env:GITHUB_ENV
             echo "${env:GITHUB_WORKSPACE}/opencv/build/install/x64/mingw/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Test GoCV
+      - name: Install Tensorflow test model
+        run: |
+            mkdir -p ./testdata
+            curl -sL https://storage.googleapis.com/download.tensorflow.org/models/inception5h.zip > ./testdata/inception5h.zip
+            unzip -o ./testdata/inception5h.zip tensorflow_inception_graph.pb -d ./testdata
+      - name: Install ONNX test model
+        run: |
+            curl -sL https://github.com/onnx/models/raw/main/validated/vision/classification/inception_and_googlenet/googlenet/model/googlenet-9.onnx > ./testdata/googlenet-9.onnx
+      - name: Set GoCV model env
         run: |
             go env
+            echo "GOCV_TENSORFLOW_TEST_FILES=${env:GITHUB_WORKSPACE}\testdata" >> $env:GITHUB_ENV
+            echo "GOCV_ONNX_TEST_FILES=${env:GITHUB_WORKSPACE}\testdata" >> $env:GITHUB_ENV
+      - name: Test GoCV
+        run: |
             go test -v -tags="matprofile,customenv" .
       - name: Test GoCV Contrib
         run: |

--- a/dnn.go
+++ b/dnn.go
@@ -348,11 +348,17 @@ func ReadNetBytes(framework string, model []byte, config []byte) (Net, error) {
 	if err != nil {
 		return Net{}, err
 	}
-	bConfig, err := toByteArray(config)
-	if err != nil {
-		return Net{}, err
+
+	var bConfig C.ByteArray
+	if len(config) > 0 {
+		pbConfig, err := toByteArray(config)
+		if err != nil {
+			return Net{}, err
+		}
+		bConfig = *pbConfig
 	}
-	return Net{p: unsafe.Pointer(C.Net_ReadNetBytes(cFramework, *bModel, *bConfig))}, nil
+
+	return Net{p: unsafe.Pointer(C.Net_ReadNetBytes(cFramework, *bModel, bConfig))}, nil
 }
 
 // ReadNetFromCaffe reads a network model stored in Caffe framework's format.


### PR DESCRIPTION
This PR improves the `ReadNet()` function to allow passing only a model file, and also removes the CI tests that use the old Caffe Googlenet.

It also corrects the download location and syntax for the ONNX tests.

Lastly, it adds the DNN tests to be run under Windows.