### PR TITLE
cuda: correct go fmt error

### DIFF
--- a/cuda/imgproc.go
+++ b/cuda/imgproc.go
@@ -257,6 +257,7 @@ type TemplateMatching struct {
 func NewTemplateMatching(srcType gocv.MatType, method gocv.TemplateMatchMode) TemplateMatching {
 	return TemplateMatching{p: unsafe.Pointer(C.TemplateMatching_Create(C.int(srcType), C.int(method)))}
 }
+
 // Close TemplateMatching
 func (tm *TemplateMatching) Close() error {
 	C.TemplateMatching_Close((C.TemplateMatching)(tm.p))


### PR DESCRIPTION
This PR just corrects a go fmt error missed during some recent CUDA changes.