### PR TITLE
core, cuda: add Closed() function to Mat/GpuMat

### DIFF
--- a/core.go
+++ b/core.go
@@ -355,6 +355,11 @@ func (m *Mat) Empty() bool {
 	return isEmpty != 0
 }
 
+// Closed determines if the Mat is closed or not.
+func (m *Mat) Closed() bool {
+	return m.p == nil
+}
+
 // IsContinuous determines if the Mat is continuous.
 //
 // For further details, please see:

--- a/core_test.go
+++ b/core_test.go
@@ -19,6 +19,14 @@ func TestMat(t *testing.T) {
 	}
 }
 
+func TestMatClosed(t *testing.T) {
+	mat := NewMat()
+	mat.Close()
+	if !mat.Closed() {
+		t.Error("Closed Mat should be closed")
+	}
+}
+
 func TestMatWithSizes(t *testing.T) {
 	t.Run("create mat with multidimensional array", func(t *testing.T) {
 		sizes := []int{100, 100, 100}

--- a/cuda/cuda.go
+++ b/cuda/cuda.go
@@ -85,6 +85,11 @@ func (g *GpuMat) Close() error {
 	return nil
 }
 
+// Closed determines if the GpuMat is closed or not.
+func (g *GpuMat) Closed() bool {
+	return g.p == nil
+}
+
 // NewGpuMat returns a new empty GpuMat
 func NewGpuMat() GpuMat {
 	return newGpuMat(C.GpuMat_New())

--- a/cuda/cuda_test.go
+++ b/cuda/cuda_test.go
@@ -15,6 +15,15 @@ func TestNewGpuMat(t *testing.T) {
 	}
 }
 
+func TestGpuMatClosed(t *testing.T) {
+	mat := NewGpuMat()
+	mat.Close()
+
+	if !mat.Closed() {
+		t.Error("Closed GpuMat should be closed")
+	}
+}
+
 func TestNewGpuMatFromMat(t *testing.T) {
 	mat := gocv.NewMat()
 	defer mat.Close()


### PR DESCRIPTION
This PR adds a `Closed()` function to both `Mat` and `GpuMat` to make it easier to check if in fact the Mat is closed.