### PR TITLE
ci: move download for GOTURN models into testdata subdirectory

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,14 +25,16 @@ jobs:
           curl -sL https://raw.githubusercontent.com/WeChatCV/opencv_3rdparty/wechat_qrcode/detect.prototxt > ${GITHUB_WORKSPACE}/testdata/detect.prototxt
           curl -sL https://raw.githubusercontent.com/WeChatCV/opencv_3rdparty/wechat_qrcode/sr.caffemodel > ${GITHUB_WORKSPACE}/testdata/sr.caffemodel
           curl -sL https://raw.githubusercontent.com/WeChatCV/opencv_3rdparty/wechat_qrcode/sr.prototxt > ${GITHUB_WORKSPACE}/testdata/sr.prototxt
-          curl -sL https://raw.githubusercontent.com/opencv/opencv_extra/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.prototxt > ${GITHUB_WORKSPACE}/goturn.prototxt
-          curl -sL https://github.com/opencv/opencv_extra/raw/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.caffemodel.zip.001 > ${GITHUB_WORKSPACE}/goturn.caffemodel.zip.001
-          curl -sL https://github.com/opencv/opencv_extra/raw/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.caffemodel.zip.002 > ${GITHUB_WORKSPACE}/goturn.caffemodel.zip.002
-          curl -sL https://github.com/opencv/opencv_extra/raw/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.caffemodel.zip.003 > ${GITHUB_WORKSPACE}/goturn.caffemodel.zip.003
-          curl -sL https://github.com/opencv/opencv_extra/raw/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.caffemodel.zip.004 > ${GITHUB_WORKSPACE}/goturn.caffemodel.zip.004
-          cat ${GITHUB_WORKSPACE}/goturn.caffemodel.zip.001 ${GITHUB_WORKSPACE}/goturn.caffemodel.zip.002 ${GITHUB_WORKSPACE}/goturn.caffemodel.zip.003 ${GITHUB_WORKSPACE}/goturn.caffemodel.zip.004 > ${GITHUB_WORKSPACE}/goturn.caffemodel.zip
-          unzip -o ${GITHUB_WORKSPACE}/goturn.caffemodel.zip goturn.caffemodel -d ${GITHUB_WORKSPACE}/
-
+      - name: Install GOTURN test model
+        run: |
+          mkdir -p ${GITHUB_WORKSPACE}/testdata
+          curl -sL https://raw.githubusercontent.com/opencv/opencv_extra/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.prototxt > ${GITHUB_WORKSPACE}/testdata/goturn.prototxt
+          curl -sL https://github.com/opencv/opencv_extra/raw/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.caffemodel.zip.001 > ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip.001
+          curl -sL https://github.com/opencv/opencv_extra/raw/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.caffemodel.zip.002 > ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip.002
+          curl -sL https://github.com/opencv/opencv_extra/raw/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.caffemodel.zip.003 > ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip.003
+          curl -sL https://github.com/opencv/opencv_extra/raw/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.caffemodel.zip.004 > ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip.004
+          cat ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip.001 ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip.002 ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip.003 ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip.004 > ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip
+          unzip -o ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip goturn.caffemodel -d ${GITHUB_WORKSPACE}/testdata
       - name: Install Tensorflow test model
         run: |
           mkdir -p ${GITHUB_WORKSPACE}/testdata
@@ -48,7 +50,7 @@ jobs:
           DISPLAY: 99.0
           GOCV_TENSORFLOW_TEST_FILES: ${{ github.workspace }}/testdata
           GOCV_ONNX_TEST_FILES: ${{ github.workspace }}/testdata
-          GOCV_TRACKER_GOTURN_TEST_FILES: ${{ github.workspace }}
+          GOCV_TRACKER_GOTURN_TEST_FILES: ${{ github.workspace }}/testdata
       - name: Run contrib tests
         run: xvfb-run -a --error-file /var/log/xvfb_error.log --server-args="-screen 0 1024x768x24 +extension RANDR" go test -v -coverprofile=/tmp/contrib.out -count=1 -tags matprofile ./contrib
         env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -34,14 +34,16 @@ jobs:
           curl -sL https://raw.githubusercontent.com/WeChatCV/opencv_3rdparty/wechat_qrcode/detect.prototxt > ${GITHUB_WORKSPACE}/testdata/detect.prototxt
           curl -sL https://raw.githubusercontent.com/WeChatCV/opencv_3rdparty/wechat_qrcode/sr.caffemodel > ${GITHUB_WORKSPACE}/testdata/sr.caffemodel
           curl -sL https://raw.githubusercontent.com/WeChatCV/opencv_3rdparty/wechat_qrcode/sr.prototxt > ${GITHUB_WORKSPACE}/testdata/sr.prototxt
-          curl -sL https://raw.githubusercontent.com/opencv/opencv_extra/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.prototxt > ${GITHUB_WORKSPACE}/goturn.prototxt
-          curl -sL https://github.com/opencv/opencv_extra/raw/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.caffemodel.zip.001 > ${GITHUB_WORKSPACE}/goturn.caffemodel.zip.001
-          curl -sL https://github.com/opencv/opencv_extra/raw/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.caffemodel.zip.002 > ${GITHUB_WORKSPACE}/goturn.caffemodel.zip.002
-          curl -sL https://github.com/opencv/opencv_extra/raw/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.caffemodel.zip.003 > ${GITHUB_WORKSPACE}/goturn.caffemodel.zip.003
-          curl -sL https://github.com/opencv/opencv_extra/raw/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.caffemodel.zip.004 > ${GITHUB_WORKSPACE}/goturn.caffemodel.zip.004
-          cat ${GITHUB_WORKSPACE}/goturn.caffemodel.zip.001 ${GITHUB_WORKSPACE}/goturn.caffemodel.zip.002 ${GITHUB_WORKSPACE}/goturn.caffemodel.zip.003 ${GITHUB_WORKSPACE}/goturn.caffemodel.zip.004 > ${GITHUB_WORKSPACE}/goturn.caffemodel.zip
-          unzip -o ${GITHUB_WORKSPACE}/goturn.caffemodel.zip goturn.caffemodel -d ${GITHUB_WORKSPACE}/
-
+      - name: Install GOTURN test model
+        run: |
+          mkdir -p ${GITHUB_WORKSPACE}/testdata
+          curl -sL https://raw.githubusercontent.com/opencv/opencv_extra/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.prototxt > ${GITHUB_WORKSPACE}/testdata/goturn.prototxt
+          curl -sL https://github.com/opencv/opencv_extra/raw/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.caffemodel.zip.001 > ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip.001
+          curl -sL https://github.com/opencv/opencv_extra/raw/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.caffemodel.zip.002 > ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip.002
+          curl -sL https://github.com/opencv/opencv_extra/raw/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.caffemodel.zip.003 > ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip.003
+          curl -sL https://github.com/opencv/opencv_extra/raw/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.caffemodel.zip.004 > ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip.004
+          cat ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip.001 ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip.002 ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip.003 ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip.004 > ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip
+          unzip -o ${GITHUB_WORKSPACE}/testdata/goturn.caffemodel.zip goturn.caffemodel -d ${GITHUB_WORKSPACE}/testdata
       - name: Install Tensorflow test model
         run: |
           mkdir -p ${GITHUB_WORKSPACE}/testdata
@@ -56,6 +58,6 @@ jobs:
         env:
           GOCV_TENSORFLOW_TEST_FILES: ${{ github.workspace }}/testdata
           GOCV_ONNX_TEST_FILES: ${{ github.workspace }}/testdata
-          GOCV_TRACKER_GOTURN_TEST_FILES: ${{ github.workspace }}
+          GOCV_TRACKER_GOTURN_TEST_FILES: ${{ github.workspace }}/testdata
       - name: Run contrib tests
         run: go test -v -tags matprofile ./contrib

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -90,8 +90,7 @@ jobs:
       - name: Install ONNX test model
         run: |
           curl -sL https://github.com/onnx/models/raw/main/validated/vision/classification/inception_and_googlenet/googlenet/model/googlenet-9.onnx > ./testdata/googlenet-9.onnx
-
-      - name: Install Caffe test model
+      - name: Install GOTURN test model
         shell: bash
         run: |
           curl -sL https://raw.githubusercontent.com/opencv/opencv_extra/c4219d5eb3105ed8e634278fad312a1a8d2c182d/testdata/tracking/goturn.prototxt > ./testdata/goturn.prototxt


### PR DESCRIPTION
This PR moves the download of the GOTURN models for the CI builds into testdata subdirectory.

Soon I will submit a different PR that caches the model downloads to reduce build times.