### PR TITLE
Fix mingw link typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ In order to build and install OpenCV 4.10.0 on Windows, you must first download 
 
 #### MinGW-W64
 
-Download and run the MinGW-W64 compiler installer from [https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/8.1.0/](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/8.1.0/).
+Download and run the MinGW-W64 compiler installer from [https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/).
 
 The latest version of the MinGW-W64 toolchain is `8.1.0`, but any version from `8.X` on should work.
 


### PR DESCRIPTION
The existing mingw link is pointing to `Toolchains targetting Win32`, I suppose it should be `Toolchains targetting Win64`. Otherwise, there is no `"seh" exceptions handling` as mentioned.