### PR TITLE
Added VideoWriterFile with API and API Params

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,8 +80,8 @@ Your pull requests will be greatly appreciated!
     - [X] **Object Detection**
 
 - [X] **imgcodecs. Image file reading and writing.**
-- [ ] **videoio. Video I/O - WORK STARTED**
-    - [ ] VideoWriterWithGStreamer
+- [X] **videoio. Video I/O - WORK STARTED**
+    - [X] VideoWriterWithGStreamer
 
 - [X] **highgui. High-level GUI**
 - [ ] **video. Video Analysis - WORK STARTED**

--- a/videoio.cpp
+++ b/videoio.cpp
@@ -88,6 +88,25 @@ void VideoWriter_Open(VideoWriter vw, const char* name, const char* codec, doubl
     vw->open(name, codecCode, fps, cv::Size(width, height), isColor);
 }
 
+void VideoWriter_OpenWithAPI(VideoWriter vw, const char* name, int apiPreference, const char* codec, double fps, int width,
+                      int height, bool isColor) {
+    int codecCode = cv::VideoWriter::fourcc(codec[0], codec[1], codec[2], codec[3]);
+    vw->open(name, apiPreference, codecCode, fps, cv::Size(width, height), isColor);
+}
+
+void VideoWriter_OpenWithAPIParams(VideoWriter vw, const char* name, int apiPreference, const char* codec, double fps, int width,
+                      int height, IntVector params) {
+    
+    std::vector<int>  cpp_params;
+
+    for(int i = 0; i < params.length; i++) {
+        cpp_params.push_back(params.val[i]);
+    }
+
+    int codecCode = cv::VideoWriter::fourcc(codec[0], codec[1], codec[2], codec[3]);
+    vw->open(name, apiPreference, codecCode, fps, cv::Size(width, height), cpp_params);
+}
+
 int VideoWriter_IsOpened(VideoWriter vw) {
     return vw->isOpened();
 }

--- a/videoio.h
+++ b/videoio.h
@@ -38,6 +38,11 @@ VideoWriter VideoWriter_New();
 void VideoWriter_Close(VideoWriter vw);
 void VideoWriter_Open(VideoWriter vw, const char* name, const char* codec, double fps, int width,
                       int height, bool isColor);
+void VideoWriter_OpenWithAPI(VideoWriter vw, const char* name, int apiPreference, const char* codec, double fps,
+                      int width, int height, bool isColor);
+void VideoWriter_OpenWithAPIParams(VideoWriter vw, const char* name, int apiPreference, const char* codec, double fps,
+                      int width, int height, IntVector params);
+
 int VideoWriter_IsOpened(VideoWriter vw);
 void VideoWriter_Write(VideoWriter vw, Mat img);
 

--- a/videoio_test.go
+++ b/videoio_test.go
@@ -3,6 +3,7 @@ package gocv
 import (
 	"io/ioutil"
 	"math"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -200,6 +201,53 @@ func TestVideoWriterFile(t *testing.T) {
 	defer img.Close()
 
 	vw, _ := VideoWriterFile(tmpfn, "MJPG", 25, img.Cols(), img.Rows(), true)
+	defer vw.Close()
+
+	if !vw.IsOpened() {
+		t.Error("Unable to open VideoWriterFile")
+	}
+
+	err := vw.Write(img)
+	if err != nil {
+		t.Error("Invalid Write() in VideoWriter")
+	}
+}
+
+func TestVideoWriterFileWithAPI(t *testing.T) {
+	dir := os.TempDir()
+	tmpfn := filepath.Join(dir, "test.avi")
+
+	img := IMRead("images/face-detect.jpg", IMReadColor)
+	if img.Empty() {
+		t.Error("Invalid read of Mat in VideoWriterFile test")
+	}
+	defer img.Close()
+
+	vw, _ := VideoWriterFileWithAPI(tmpfn, VideoCaptureFFmpeg, "MJPG", 25, img.Cols(), img.Rows(), true)
+	defer vw.Close()
+
+	if !vw.IsOpened() {
+		t.Error("Unable to open VideoWriterFile")
+	}
+
+	err := vw.Write(img)
+	if err != nil {
+		t.Error("Invalid Write() in VideoWriter")
+	}
+}
+
+func TestVideoWriterFileWithAPIParams(t *testing.T) {
+	dir := os.TempDir()
+	tmpfn := filepath.Join(dir, "test.avi")
+
+	img := IMRead("images/face-detect.jpg", IMReadColor)
+	if img.Empty() {
+		t.Error("Invalid read of Mat in VideoWriterFile test")
+	}
+	defer img.Close()
+
+	vw, _ := VideoWriterFileWithAPIParams(tmpfn, VideoCaptureFFmpeg, "MJPG", 25, img.Cols(), img.Rows(),
+		[]VideoWriterProperty{VideoWriterHwAcceleration, 0, VideoWriterIsColor, 1})
 	defer vw.Close()
 
 	if !vw.IsOpened() {


### PR DESCRIPTION
This PR adds the VideoWriterFileWithAPI and VideoWriterFileWithAPIParams functions enabling the use of gstreamer among others backends for video writing.

Solves: https://github.com/hybridgroup/gocv/issues/1155
