### PR TITLE
[Bugfix] VideoCaptureProperties being an int64 does not correctly unpack the parameters for OpenCV VideoCapture.open

### DIFF
--- a/videoio.go
+++ b/videoio.go
@@ -119,7 +119,7 @@ const (
 )
 
 // VideoCaptureProperties are the properties used for VideoCapture operations.
-type VideoCaptureProperties int
+type VideoCaptureProperties int32
 
 const (
 	// VideoCapturePosMsec contains current position of the


### PR DESCRIPTION
This patch changes the type of `VideoCaptureProperties` to `int32`. It is currently set to `int`. This breaks `VideoCapture_OpenDeviceWithAPIParams` because it doesn't correclty unpack the slice into the `std::vector<int>` here:

```c++
bool VideoCapture_OpenDeviceWithAPIParams(VideoCapture v, int device, int apiPreference, int *paramsv, int paramsc) {
    std::vector< int > params;

    for( int i = 0; i< paramsc; i++) {
        params.push_back(paramsv[i]);
    }

    return v->open(device, apiPreference, params);
}
```

With `int64` this for loop will create only zeros in the value parts of the array that OpenCV expects (`[p1, v1, ..., pn, vn]`).

Changing it to `int32` unpacks the slice correctly and OpenCV will pass the parameters correctly to the respective VideoCapture backends.