### PR TITLE
fix: correct signature for FindHomography

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
         matrix:
-          os: [macos-13, macos-14]
+          os: [macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install OpenCV
@@ -19,6 +19,7 @@ jobs:
           rm /usr/local/bin/idle3*
           rm /usr/local/bin/pydoc*
           rm /usr/local/bin/python3*
+          brew unlink pkg-config@0.29.2
           brew install opencv
       - name: Install Go
         uses: actions/setup-go@v5

--- a/imgproc.go
+++ b/imgproc.go
@@ -1839,8 +1839,8 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d0c/group__calib3d.html#ga4abc2ece9fab9398f2e560d53c8c9780
-func FindHomography(srcPoints Mat, dstPoints *Mat, method HomographyMethod, ransacReprojThreshold float64, mask *Mat, maxIters int, confidence float64) Mat {
-	return newMat(C.FindHomography(srcPoints.Ptr(), dstPoints.Ptr(), C.int(method), C.double(ransacReprojThreshold), mask.Ptr(), C.int(maxIters), C.double(confidence)))
+func FindHomography(srcPoints Mat, targetPoints Mat, method HomographyMethod, ransacReprojThreshold float64, mask *Mat, maxIters int, confidence float64) Mat {
+	return newMat(C.FindHomography(srcPoints.Ptr(), targetPoints.Ptr(), C.int(method), C.double(ransacReprojThreshold), mask.Ptr(), C.int(maxIters), C.double(confidence)))
 }
 
 // DrawContours draws contours outlines or filled contours.

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -2079,8 +2079,8 @@ func TestGetAffineTransform2f(t *testing.T) {
 func TestFindHomography(t *testing.T) {
 	src := NewMatWithSize(4, 1, MatTypeCV64FC2)
 	defer src.Close()
-	dst := NewMatWithSize(4, 1, MatTypeCV64FC2)
-	defer dst.Close()
+	target := NewMatWithSize(4, 1, MatTypeCV64FC2)
+	defer target.Close()
 
 	srcPoints := []Point2f{
 		{193, 932},
@@ -2088,7 +2088,7 @@ func TestFindHomography(t *testing.T) {
 		{1497, 183},
 		{1889, 681},
 	}
-	dstPoints := []Point2f{
+	targetPoints := []Point2f{
 		{51.51206544281359, -0.10425475260813055},
 		{51.51211051314331, -0.10437947532732306},
 		{51.512222354139325, -0.10437679311830816},
@@ -2100,21 +2100,21 @@ func TestFindHomography(t *testing.T) {
 		src.SetDoubleAt(i, 1, float64(point.Y))
 	}
 
-	for i, point := range dstPoints {
-		dst.SetDoubleAt(i, 0, float64(point.X))
-		dst.SetDoubleAt(i, 1, float64(point.Y))
+	for i, point := range targetPoints {
+		target.SetDoubleAt(i, 0, float64(point.X))
+		target.SetDoubleAt(i, 1, float64(point.Y))
 	}
 
 	mask := NewMat()
 	defer mask.Close()
 
-	m := FindHomography(src, &dst, HomographyMethodAllPoints, 3, &mask, 2000, 0.995)
+	m := FindHomography(src, target, HomographyMethodAllPoints, 3, &mask, 2000, 0.995)
 	defer m.Close()
 
 	pvsrc := NewPoint2fVectorFromPoints(srcPoints)
 	defer pvsrc.Close()
 
-	pvdst := NewPoint2fVectorFromPoints(dstPoints)
+	pvdst := NewPoint2fVectorFromPoints(targetPoints)
 	defer pvdst.Close()
 
 	m2 := GetPerspectiveTransform2f(pvsrc, pvdst)


### PR DESCRIPTION
This PR is to correct the function signature for `FindHomography()`, since the dst param is actually the target format for the operation, not something changed by the operation. As such, there is no need to pass it as a pointer.