### PR TITLE
fix: correct ifndef for wrappers to avoid include conflcts

### DIFF
--- a/contrib/bgsegm.h
+++ b/contrib/bgsegm.h
@@ -1,5 +1,5 @@
-#ifndef _OPENCV3_VIDEO_H_
-#define _OPENCV3_VIDEO_H_
+#ifndef _OPENCV3_BGSEGM_H_
+#define _OPENCV3_BGSEGM_H_
 
 #ifdef __cplusplus
 #include <opencv2/opencv.hpp>
@@ -23,4 +23,4 @@ void BackgroundSubtractorCNT_Apply(BackgroundSubtractorCNT b, Mat src, Mat dst);
 }
 #endif
 
-#endif //_OPENCV3_VIDEO_H_
+#endif //_OPENCV3_BGSEGM_H_

--- a/persistence.h
+++ b/persistence.h
@@ -1,5 +1,5 @@
-#ifndef _OPENCV3_OBJDETECT_H_
-#define _OPENCV3_OBJDETECT_H_
+#ifndef _OPENCV3_PERSISTENCE_H_
+#define _OPENCV3_PERSISTENCE_H_
 
 #include <stdbool.h>
 
@@ -74,4 +74,4 @@ void FileNode_Close(FileNode fn);
 }
 #endif
 
-#endif //_OPENCV3_OBJDETECT_H_
+#endif //_OPENCV3_PERSISTENCE_H_


### PR DESCRIPTION
This PR is to correct `#ifndef` directives for a couple of wrappers to avoid possible include conflicts due to ordering.