### PR TITLE
feature: add exception handling function and try/catch blocks

### DIFF
--- a/aruco.cpp
+++ b/aruco.cpp
@@ -1,11 +1,21 @@
 #include "aruco.h"
 
 ArucoDetector ArucoDetector_New() {
-    return new cv::aruco::ArucoDetector();
+    try {
+        return new cv::aruco::ArucoDetector();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 ArucoDetector ArucoDetector_NewWithParams(ArucoDictionary dictionary, ArucoDetectorParameters params) {
-    return new cv::aruco::ArucoDetector(*dictionary, *params);
+    try {
+        return new cv::aruco::ArucoDetector(*dictionary, *params);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void ArucoDetector_Close(ArucoDetector ad) {
@@ -13,23 +23,32 @@ void ArucoDetector_Close(ArucoDetector ad) {
 }
 
 void ArucoDetector_DetectMarkers(ArucoDetector ad, Mat inputArr, Points2fVector markerCorners, IntVector *markerIds, Points2fVector rejectedCandidates) {
-    std::vector<int> _markerIds;
-    ad->detectMarkers(*inputArr, *markerCorners, _markerIds, *rejectedCandidates);
+    try {
+        std::vector<int> _markerIds;
+        ad->detectMarkers(*inputArr, *markerCorners, _markerIds, *rejectedCandidates);
 
-    int *ids = new int[_markerIds.size()];
+        int *ids = new int[_markerIds.size()];
 
-    for (size_t i = 0; i < _markerIds.size(); ++i)
-    {
-        ids[i] = _markerIds[i];
+        for (size_t i = 0; i < _markerIds.size(); ++i)
+        {
+            ids[i] = _markerIds[i];
+        }
+
+        markerIds->length = _markerIds.size();
+        markerIds->val = ids;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    markerIds->length = _markerIds.size();
-    markerIds->val = ids;
 }
 
 ArucoDetectorParameters ArucoDetectorParameters_Create()
 {
-    return new cv::aruco::DetectorParameters();
+    try {
+        return new cv::aruco::DetectorParameters();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void ArucoDetectorParameters_SetAdaptiveThreshWinSizeMin(ArucoDetectorParameters ap, int adaptiveThreshWinSizeMin) {
@@ -266,22 +285,35 @@ bool ArucoDetectorParameters_GetDetectInvertedMarker(ArucoDetectorParameters ap)
 
 void ArucoDrawDetectedMarkers(Mat image, Points2fVector markerCorners, IntVector markerIds, Scalar borderColor)
 {
-    std::vector<int> _markerIds;
-    for (int i = 0, *v = markerIds.val; i < markerIds.length; ++v, ++i)
-    {
-        _markerIds.push_back(*v);
+    try {
+        std::vector<int> _markerIds;
+        for (int i = 0, *v = markerIds.val; i < markerIds.length; ++v, ++i)
+        {
+            _markerIds.push_back(*v);
+        }
+        cv::Scalar _borderColor = cv::Scalar(borderColor.val1, borderColor.val2, borderColor.val3);
+        cv::aruco::drawDetectedMarkers(*image, *markerCorners, _markerIds, _borderColor);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::Scalar _borderColor = cv::Scalar(borderColor.val1, borderColor.val2, borderColor.val3);
-    cv::aruco::drawDetectedMarkers(*image, *markerCorners, _markerIds, _borderColor);
 }
 
 void ArucoGenerateImageMarker(int dictionaryId, int id, int sidePixels, Mat img, int borderBits)
 {
-    cv::aruco::Dictionary dict = cv::aruco::getPredefinedDictionary(dictionaryId);
-    cv::aruco::generateImageMarker(dict, id, sidePixels, *img, borderBits);
+    try {
+        cv::aruco::Dictionary dict = cv::aruco::getPredefinedDictionary(dictionaryId);
+        cv::aruco::generateImageMarker(dict, id, sidePixels, *img, borderBits);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 ArucoDictionary getPredefinedDictionary(int dictionaryId)
 {
-    return new cv::aruco::Dictionary(cv::aruco::getPredefinedDictionary(dictionaryId));
+    try {
+        return new cv::aruco::Dictionary(cv::aruco::getPredefinedDictionary(dictionaryId));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }

--- a/aruco.cpp
+++ b/aruco.cpp
@@ -283,7 +283,7 @@ bool ArucoDetectorParameters_GetDetectInvertedMarker(ArucoDetectorParameters ap)
     return ap->detectInvertedMarker;
 }
 
-void ArucoDrawDetectedMarkers(Mat image, Points2fVector markerCorners, IntVector markerIds, Scalar borderColor)
+OpenCVResult ArucoDrawDetectedMarkers(Mat image, Points2fVector markerCorners, IntVector markerIds, Scalar borderColor)
 {
     try {
         std::vector<int> _markerIds;
@@ -293,18 +293,20 @@ void ArucoDrawDetectedMarkers(Mat image, Points2fVector markerCorners, IntVector
         }
         cv::Scalar _borderColor = cv::Scalar(borderColor.val1, borderColor.val2, borderColor.val3);
         cv::aruco::drawDetectedMarkers(*image, *markerCorners, _markerIds, _borderColor);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void ArucoGenerateImageMarker(int dictionaryId, int id, int sidePixels, Mat img, int borderBits)
+OpenCVResult ArucoGenerateImageMarker(int dictionaryId, int id, int sidePixels, Mat img, int borderBits)
 {
     try {
         cv::aruco::Dictionary dict = cv::aruco::getPredefinedDictionary(dictionaryId);
         cv::aruco::generateImageMarker(dict, id, sidePixels, *img, borderBits);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 

--- a/aruco.go
+++ b/aruco.go
@@ -65,7 +65,7 @@ func (a *ArucoDetector) DetectMarkers(input Mat) (
 	return pvsCorners.ToPoints(), markerIds, pvsRejected.ToPoints()
 }
 
-func ArucoDrawDetectedMarkers(img Mat, markerCorners [][]Point2f, markerIds []int, borderColor Scalar) {
+func ArucoDrawDetectedMarkers(img Mat, markerCorners [][]Point2f, markerIds []int, borderColor Scalar) error {
 	cMarkerIds := make([]C.int, len(markerIds))
 	for i, s := range markerIds {
 		cMarkerIds[i] = C.int(s)
@@ -83,16 +83,16 @@ func ArucoDrawDetectedMarkers(img Mat, markerCorners [][]Point2f, markerIds []in
 		val4: C.double(borderColor.Val4),
 	}
 
-	C.ArucoDrawDetectedMarkers(
+	return OpenCVResult(C.ArucoDrawDetectedMarkers(
 		C.Mat(img.Ptr()),
 		C.Points2fVector(_markerCorners.P()),
 		markerIdsIntVec,
 		cBorderColor,
-	)
+	))
 }
 
-func ArucoGenerateImageMarker(dictionaryId ArucoDictionaryCode, id int, sidePixels int, img Mat, borderBits int) {
-	C.ArucoGenerateImageMarker(C.int(dictionaryId), C.int(id), C.int(sidePixels), C.Mat(img.Ptr()), C.int(borderBits))
+func ArucoGenerateImageMarker(dictionaryId ArucoDictionaryCode, id int, sidePixels int, img Mat, borderBits int) error {
+	return OpenCVResult(C.ArucoGenerateImageMarker(C.int(dictionaryId), C.int(id), C.int(sidePixels), C.Mat(img.Ptr()), C.int(borderBits)))
 }
 
 type ArucoDetectorParameters struct {

--- a/aruco.h
+++ b/aruco.h
@@ -86,8 +86,8 @@ ArucoDetector ArucoDetector_NewWithParams(ArucoDictionary dictionary, ArucoDetec
 void ArucoDetector_Close(ArucoDetector ad);
 void ArucoDetector_DetectMarkers(ArucoDetector ad, Mat inputArr, Points2fVector markerCorners, IntVector *markerIds, Points2fVector rejectedCandidates);
 
-void ArucoDrawDetectedMarkers(Mat image, Points2fVector markerCorners, IntVector markerIds, Scalar borderColor);
-void ArucoGenerateImageMarker(int dictionaryId, int id, int sidePixels, Mat img, int borderBits);
+OpenCVResult ArucoDrawDetectedMarkers(Mat image, Points2fVector markerCorners, IntVector markerIds, Scalar borderColor);
+OpenCVResult ArucoGenerateImageMarker(int dictionaryId, int id, int sidePixels, Mat img, int borderBits);
 
 #ifdef __cplusplus
 }

--- a/asyncarray.cpp
+++ b/asyncarray.cpp
@@ -6,7 +6,12 @@
 
 // AsyncArray_New creates a new empty AsyncArray
 AsyncArray AsyncArray_New() {
-    return new cv::AsyncArray();
+    try {
+        return new cv::AsyncArray();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 // AsyncArray_Close deletes an existing AsyncArray
@@ -17,12 +22,17 @@ void AsyncArray_Close(AsyncArray a) {
 const char* AsyncArray_GetAsync(AsyncArray async_out,Mat out) {
     try {
        async_out->get(*out);
-    } catch(cv::Exception ex) {
-        return ex.err.c_str();
+    } catch(const cv::Exception& ex) {
+        return ex.what();
     }
     return "";
 }
 
 AsyncArray Net_forwardAsync(Net net, const char* outputName) {
-    return new cv::AsyncArray(net->forwardAsync(outputName));
+    try {
+        return new cv::AsyncArray(net->forwardAsync(outputName));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }

--- a/calib3d.cpp
+++ b/calib3d.cpp
@@ -1,115 +1,223 @@
 #include "calib3d.h"
 
 double Fisheye_Calibrate(Points3fVector objectPoints, Points2fVector imagePoints, Size size, Mat k, Mat d, Mat rvecs, Mat tvecs, int flags) {
-    cv::Size sz(size.width, size.height);
-    return cv::fisheye::calibrate(*objectPoints, *imagePoints, sz, *k, *d, *rvecs, *tvecs, flags);
+    try {
+        cv::Size sz(size.width, size.height);
+        return cv::fisheye::calibrate(*objectPoints, *imagePoints, sz, *k, *d, *rvecs, *tvecs, flags);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void Fisheye_DistortPoints(Mat undistorted, Mat distorted, Mat k, Mat d) {
-    cv::fisheye::distortPoints(*undistorted, *distorted, *k, *d);
+    try {
+        cv::fisheye::distortPoints(*undistorted, *distorted, *k, *d);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Fisheye_UndistortImage(Mat distorted, Mat undistorted, Mat k, Mat d) {
-    cv::fisheye::undistortImage(*distorted, *undistorted, *k, *d);
+    try {
+        cv::fisheye::undistortImage(*distorted, *undistorted, *k, *d);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Fisheye_UndistortImageWithParams(Mat distorted, Mat undistorted, Mat k, Mat d, Mat knew, Size size) {
-    cv::Size sz(size.width, size.height);
-    cv::fisheye::undistortImage(*distorted, *undistorted, *k, *d, *knew, sz);
+    try {
+        cv::Size sz(size.width, size.height);
+        cv::fisheye::undistortImage(*distorted, *undistorted, *k, *d, *knew, sz);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Fisheye_UndistortPoints(Mat distorted, Mat undistorted, Mat k, Mat d, Mat r, Mat p) {
-    cv::fisheye::undistortPoints(*distorted, *undistorted, *k, *d, *r, *p);
+    try {
+        cv::fisheye::undistortPoints(*distorted, *undistorted, *k, *d, *r, *p);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Fisheye_EstimateNewCameraMatrixForUndistortRectify(Mat k, Mat d, Size imgSize, Mat r, Mat p, double balance, Size newSize, double fovScale) {
-    cv::Size newSz(newSize.width, newSize.height);
-    cv::Size imgSz(imgSize.width, imgSize.height);
-    cv::fisheye::estimateNewCameraMatrixForUndistortRectify(*k, *d, imgSz, *r, *p, balance, newSz, fovScale);
+    try {
+        cv::Size newSz(newSize.width, newSize.height);
+        cv::Size imgSz(imgSize.width, imgSize.height);
+        cv::fisheye::estimateNewCameraMatrixForUndistortRectify(*k, *d, imgSz, *r, *p, balance, newSz, fovScale);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void InitUndistortRectifyMap(Mat cameraMatrix,Mat distCoeffs,Mat r,Mat newCameraMatrix,Size size,int m1type,Mat map1,Mat map2) {
-    cv::Size sz(size.width, size.height);
-    cv::initUndistortRectifyMap(*cameraMatrix,*distCoeffs,*r,*newCameraMatrix,sz,m1type,*map1,*map2);
+    try {
+        cv::Size sz(size.width, size.height);
+        cv::initUndistortRectifyMap(*cameraMatrix,*distCoeffs,*r,*newCameraMatrix,sz,m1type,*map1,*map2);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 Mat GetOptimalNewCameraMatrixWithParams(Mat cameraMatrix,Mat distCoeffs,Size size,double alpha,Size newImgSize,Rect* validPixROI,bool centerPrincipalPoint) {
-    cv::Size sz(size.width, size.height);
-    cv::Size newSize(newImgSize.width, newImgSize.height);
-    cv::Rect rect(validPixROI->x,validPixROI->y,validPixROI->width,validPixROI->height);
-    cv::Mat* mat = new cv::Mat(cv::getOptimalNewCameraMatrix(*cameraMatrix,*distCoeffs,sz,alpha,newSize,&rect,centerPrincipalPoint));
-    validPixROI->x = rect.x;
-    validPixROI->y = rect.y;
-    validPixROI->width = rect.width;
-    validPixROI->height = rect.height;
-    return mat;
+    try {
+        cv::Size sz(size.width, size.height);
+        cv::Size newSize(newImgSize.width, newImgSize.height);
+        cv::Rect rect(validPixROI->x,validPixROI->y,validPixROI->width,validPixROI->height);
+        cv::Mat* mat = new cv::Mat(cv::getOptimalNewCameraMatrix(*cameraMatrix,*distCoeffs,sz,alpha,newSize,&rect,centerPrincipalPoint));
+        validPixROI->x = rect.x;
+        validPixROI->y = rect.y;
+        validPixROI->width = rect.width;
+        validPixROI->height = rect.height;
+        return mat;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 double CalibrateCamera(Points3fVector objectPoints, Points2fVector imagePoints, Size imageSize, Mat cameraMatrix, Mat distCoeffs, Mat rvecs, Mat tvecs, int flag) {
-    return cv::calibrateCamera(*objectPoints, *imagePoints, cv::Size(imageSize.width, imageSize.height), *cameraMatrix, *distCoeffs, *rvecs, *tvecs, flag);
+    try {
+        return cv::calibrateCamera(*objectPoints, *imagePoints, cv::Size(imageSize.width, imageSize.height), *cameraMatrix, *distCoeffs, *rvecs, *tvecs, flag);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void Undistort(Mat src, Mat dst, Mat cameraMatrix, Mat distCoeffs, Mat newCameraMatrix) {
-    cv::undistort(*src, *dst, *cameraMatrix, *distCoeffs, *newCameraMatrix);
+    try {
+        cv::undistort(*src, *dst, *cameraMatrix, *distCoeffs, *newCameraMatrix);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void UndistortPoints(Mat distorted, Mat undistorted, Mat k, Mat d, Mat r, Mat p) {
-    cv::undistortPoints(*distorted, *undistorted, *k, *d, *r, *p);
+    try {
+        cv::undistortPoints(*distorted, *undistorted, *k, *d, *r, *p);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 bool CheckChessboard(Mat image, Size size) {
-    cv::Size sz(size.width, size.height);
-    return cv::checkChessboard(*image, sz);
+    try {
+        cv::Size sz(size.width, size.height);
+        return cv::checkChessboard(*image, sz);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 bool FindChessboardCorners(Mat image, Size patternSize, Mat corners, int flags) {
-    cv::Size sz(patternSize.width, patternSize.height);
-    return cv::findChessboardCorners(*image, sz, *corners, flags);
+    try {
+        cv::Size sz(patternSize.width, patternSize.height);
+        return cv::findChessboardCorners(*image, sz, *corners, flags);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 bool FindChessboardCornersSB(Mat image, Size patternSize, Mat corners, int flags) {
-    cv::Size sz(patternSize.width, patternSize.height);
-    return cv::findChessboardCornersSB(*image, sz, *corners, flags);
+    try {
+        cv::Size sz(patternSize.width, patternSize.height);
+        return cv::findChessboardCornersSB(*image, sz, *corners, flags);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 bool FindChessboardCornersSBWithMeta(Mat image, Size patternSize, Mat corners, int flags, Mat meta) {
-    cv::Size sz(patternSize.width, patternSize.height);
-    return cv::findChessboardCornersSB(*image, sz, *corners, flags, *meta);
+    try {
+        cv::Size sz(patternSize.width, patternSize.height);
+        return cv::findChessboardCornersSB(*image, sz, *corners, flags, *meta);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 void DrawChessboardCorners(Mat image, Size patternSize, Mat corners, bool patternWasFound) {
-    cv::Size sz(patternSize.width, patternSize.height);
-    cv::drawChessboardCorners(*image, sz, *corners, patternWasFound);
+    try {
+        cv::Size sz(patternSize.width, patternSize.height);
+        cv::drawChessboardCorners(*image, sz, *corners, patternWasFound);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 Mat EstimateAffinePartial2D(Point2fVector from, Point2fVector to) {
-    return new cv::Mat(cv::estimateAffinePartial2D(*from, *to));
+    try {
+        return new cv::Mat(cv::estimateAffinePartial2D(*from, *to));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 Mat EstimateAffinePartial2DWithParams(Point2fVector from, Point2fVector to, Mat inliers, int method, double ransacReprojThreshold, size_t maxIters, double confidence, size_t refineIters) {
-    return new cv::Mat(cv::estimateAffinePartial2D(*from, *to, *inliers, method, ransacReprojThreshold, maxIters, confidence, refineIters));
+    try {
+        return new cv::Mat(cv::estimateAffinePartial2D(*from, *to, *inliers, method, ransacReprojThreshold, maxIters, confidence, refineIters));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 Mat EstimateAffine2D(Point2fVector from, Point2fVector to) {
-    return new cv::Mat(cv::estimateAffine2D(*from, *to));
+    try {
+        return new cv::Mat(cv::estimateAffine2D(*from, *to));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 Mat EstimateAffine2DWithParams(Point2fVector from, Point2fVector to, Mat inliers, int method, double ransacReprojThreshold, size_t maxIters, double confidence, size_t refineIters) {
-    return new cv::Mat(cv::estimateAffine2D(*from, *to, *inliers, method, ransacReprojThreshold, maxIters, confidence, refineIters));
+    try {
+        return new cv::Mat(cv::estimateAffine2D(*from, *to, *inliers, method, ransacReprojThreshold, maxIters, confidence, refineIters));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 void TriangulatePoints(Mat projMatr1, Mat projMatr2, Point2fVector projPoints1, Point2fVector projPoints2, Mat points4D) {
-  return cv::triangulatePoints(*projMatr1, *projMatr2, *projPoints1, *projPoints2, *points4D);
+    try {
+        cv::triangulatePoints(*projMatr1, *projMatr2, *projPoints1, *projPoints2, *points4D);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void ConvertPointsFromHomogeneous(Mat src, Mat dst) {
-  return cv::convertPointsFromHomogeneous(*src, *dst);
+    try {
+        cv::convertPointsFromHomogeneous(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Rodrigues(Mat src, Mat dst) {
-	cv::Rodrigues(*src, *dst);
+    try {
+        cv::Rodrigues(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 bool SolvePnP(Point3fVector objectPoints, Point2fVector imagePoints, Mat cameraMatrix, Mat distCoeffs, Mat rvec, Mat tvec, bool useExtrinsicGuess, int flags) {
-    return cv::solvePnP(*objectPoints, *imagePoints, *cameraMatrix, *distCoeffs, *rvec, *tvec, useExtrinsicGuess, flags);
+    try {
+        return cv::solvePnP(*objectPoints, *imagePoints, *cameraMatrix, *distCoeffs, *rvec, *tvec, useExtrinsicGuess, flags);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }

--- a/calib3d.cpp
+++ b/calib3d.cpp
@@ -10,55 +10,61 @@ double Fisheye_Calibrate(Points3fVector objectPoints, Points2fVector imagePoints
     }
 }
 
-void Fisheye_DistortPoints(Mat undistorted, Mat distorted, Mat k, Mat d) {
+OpenCVResult Fisheye_DistortPoints(Mat undistorted, Mat distorted, Mat k, Mat d) {
     try {
         cv::fisheye::distortPoints(*undistorted, *distorted, *k, *d);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Fisheye_UndistortImage(Mat distorted, Mat undistorted, Mat k, Mat d) {
+OpenCVResult Fisheye_UndistortImage(Mat distorted, Mat undistorted, Mat k, Mat d) {
     try {
         cv::fisheye::undistortImage(*distorted, *undistorted, *k, *d);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Fisheye_UndistortImageWithParams(Mat distorted, Mat undistorted, Mat k, Mat d, Mat knew, Size size) {
+OpenCVResult Fisheye_UndistortImageWithParams(Mat distorted, Mat undistorted, Mat k, Mat d, Mat knew, Size size) {
     try {
         cv::Size sz(size.width, size.height);
         cv::fisheye::undistortImage(*distorted, *undistorted, *k, *d, *knew, sz);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Fisheye_UndistortPoints(Mat distorted, Mat undistorted, Mat k, Mat d, Mat r, Mat p) {
+OpenCVResult Fisheye_UndistortPoints(Mat distorted, Mat undistorted, Mat k, Mat d, Mat r, Mat p) {
     try {
         cv::fisheye::undistortPoints(*distorted, *undistorted, *k, *d, *r, *p);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Fisheye_EstimateNewCameraMatrixForUndistortRectify(Mat k, Mat d, Size imgSize, Mat r, Mat p, double balance, Size newSize, double fovScale) {
+OpenCVResult Fisheye_EstimateNewCameraMatrixForUndistortRectify(Mat k, Mat d, Size imgSize, Mat r, Mat p, double balance, Size newSize, double fovScale) {
     try {
         cv::Size newSz(newSize.width, newSize.height);
         cv::Size imgSz(imgSize.width, imgSize.height);
         cv::fisheye::estimateNewCameraMatrixForUndistortRectify(*k, *d, imgSz, *r, *p, balance, newSz, fovScale);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void InitUndistortRectifyMap(Mat cameraMatrix,Mat distCoeffs,Mat r,Mat newCameraMatrix,Size size,int m1type,Mat map1,Mat map2) {
+OpenCVResult InitUndistortRectifyMap(Mat cameraMatrix,Mat distCoeffs,Mat r,Mat newCameraMatrix,Size size,int m1type,Mat map1,Mat map2) {
     try {
         cv::Size sz(size.width, size.height);
         cv::initUndistortRectifyMap(*cameraMatrix,*distCoeffs,*r,*newCameraMatrix,sz,m1type,*map1,*map2);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -88,19 +94,21 @@ double CalibrateCamera(Points3fVector objectPoints, Points2fVector imagePoints, 
     }
 }
 
-void Undistort(Mat src, Mat dst, Mat cameraMatrix, Mat distCoeffs, Mat newCameraMatrix) {
+OpenCVResult Undistort(Mat src, Mat dst, Mat cameraMatrix, Mat distCoeffs, Mat newCameraMatrix) {
     try {
         cv::undistort(*src, *dst, *cameraMatrix, *distCoeffs, *newCameraMatrix);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void UndistortPoints(Mat distorted, Mat undistorted, Mat k, Mat d, Mat r, Mat p) {
+OpenCVResult UndistortPoints(Mat distorted, Mat undistorted, Mat k, Mat d, Mat r, Mat p) {
     try {
         cv::undistortPoints(*distorted, *undistorted, *k, *d, *r, *p);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -144,12 +152,13 @@ bool FindChessboardCornersSBWithMeta(Mat image, Size patternSize, Mat corners, i
     }
 }
 
-void DrawChessboardCorners(Mat image, Size patternSize, Mat corners, bool patternWasFound) {
+OpenCVResult DrawChessboardCorners(Mat image, Size patternSize, Mat corners, bool patternWasFound) {
     try {
         cv::Size sz(patternSize.width, patternSize.height);
         cv::drawChessboardCorners(*image, sz, *corners, patternWasFound);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -189,27 +198,30 @@ Mat EstimateAffine2DWithParams(Point2fVector from, Point2fVector to, Mat inliers
     }
 }
 
-void TriangulatePoints(Mat projMatr1, Mat projMatr2, Point2fVector projPoints1, Point2fVector projPoints2, Mat points4D) {
+OpenCVResult TriangulatePoints(Mat projMatr1, Mat projMatr2, Point2fVector projPoints1, Point2fVector projPoints2, Mat points4D) {
     try {
         cv::triangulatePoints(*projMatr1, *projMatr2, *projPoints1, *projPoints2, *points4D);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void ConvertPointsFromHomogeneous(Mat src, Mat dst) {
+OpenCVResult ConvertPointsFromHomogeneous(Mat src, Mat dst) {
     try {
         cv::convertPointsFromHomogeneous(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Rodrigues(Mat src, Mat dst) {
+OpenCVResult Rodrigues(Mat src, Mat dst) {
     try {
         cv::Rodrigues(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 

--- a/calib3d.go
+++ b/calib3d.go
@@ -72,37 +72,37 @@ func FisheyeCalibrate(objectPoints Points3fVector, imagePoints Points2fVector, s
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d58/group__calib3d__fisheye.html#gab738cdf90ceee97b2b52b0d0e7511541
-func FisheyeDistortPoints(undistorted Mat, distorted *Mat, k, d Mat) {
-	C.Fisheye_DistortPoints(undistorted.Ptr(), distorted.Ptr(), k.Ptr(), d.Ptr())
+func FisheyeDistortPoints(undistorted Mat, distorted *Mat, k, d Mat) error {
+	return OpenCVResult(C.Fisheye_DistortPoints(undistorted.Ptr(), distorted.Ptr(), k.Ptr(), d.Ptr()))
 }
 
 // FisheyeUndistortImage transforms an image to compensate for fisheye lens distortion
-func FisheyeUndistortImage(distorted Mat, undistorted *Mat, k, d Mat) {
-	C.Fisheye_UndistortImage(distorted.Ptr(), undistorted.Ptr(), k.Ptr(), d.Ptr())
+func FisheyeUndistortImage(distorted Mat, undistorted *Mat, k, d Mat) error {
+	return OpenCVResult(C.Fisheye_UndistortImage(distorted.Ptr(), undistorted.Ptr(), k.Ptr(), d.Ptr()))
 }
 
 // FisheyeUndistortImageWithParams transforms an image to compensate for fisheye lens distortion with Knew matrix
-func FisheyeUndistortImageWithParams(distorted Mat, undistorted *Mat, k, d, knew Mat, size image.Point) {
+func FisheyeUndistortImageWithParams(distorted Mat, undistorted *Mat, k, d, knew Mat, size image.Point) error {
 	sz := C.struct_Size{
 		width:  C.int(size.X),
 		height: C.int(size.Y),
 	}
-	C.Fisheye_UndistortImageWithParams(distorted.Ptr(), undistorted.Ptr(), k.Ptr(), d.Ptr(), knew.Ptr(), sz)
+	return OpenCVResult(C.Fisheye_UndistortImageWithParams(distorted.Ptr(), undistorted.Ptr(), k.Ptr(), d.Ptr(), knew.Ptr(), sz))
 }
 
 // FisheyeUndistortPoints transforms points to compensate for fisheye lens distortion
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d58/group__calib3d__fisheye.html#gab738cdf90ceee97b2b52b0d0e7511541
-func FisheyeUndistortPoints(distorted Mat, undistorted *Mat, k, d, r, p Mat) {
-	C.Fisheye_UndistortPoints(distorted.Ptr(), undistorted.Ptr(), k.Ptr(), d.Ptr(), r.Ptr(), p.Ptr())
+func FisheyeUndistortPoints(distorted Mat, undistorted *Mat, k, d, r, p Mat) error {
+	return OpenCVResult(C.Fisheye_UndistortPoints(distorted.Ptr(), undistorted.Ptr(), k.Ptr(), d.Ptr(), r.Ptr(), p.Ptr()))
 }
 
 // EstimateNewCameraMatrixForUndistortRectify estimates new camera matrix for undistortion or rectification.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d58/group__calib3d__fisheye.html#ga384940fdf04c03e362e94b6eb9b673c9
-func EstimateNewCameraMatrixForUndistortRectify(k, d Mat, imgSize image.Point, r Mat, p *Mat, balance float64, newSize image.Point, fovScale float64) {
+func EstimateNewCameraMatrixForUndistortRectify(k, d Mat, imgSize image.Point, r Mat, p *Mat, balance float64, newSize image.Point, fovScale float64) error {
 	imgSz := C.struct_Size{
 		width:  C.int(imgSize.X),
 		height: C.int(imgSize.Y),
@@ -111,19 +111,19 @@ func EstimateNewCameraMatrixForUndistortRectify(k, d Mat, imgSize image.Point, r
 		width:  C.int(newSize.X),
 		height: C.int(newSize.Y),
 	}
-	C.Fisheye_EstimateNewCameraMatrixForUndistortRectify(k.Ptr(), d.Ptr(), imgSz, r.Ptr(), p.Ptr(), C.double(balance), newSz, C.double(fovScale))
+	return OpenCVResult(C.Fisheye_EstimateNewCameraMatrixForUndistortRectify(k.Ptr(), d.Ptr(), imgSz, r.Ptr(), p.Ptr(), C.double(balance), newSz, C.double(fovScale)))
 }
 
 // InitUndistortRectifyMap computes the joint undistortion and rectification transformation and represents the result in the form of maps for remap
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d0c/group__calib3d.html#ga7dfb72c9cf9780a347fbe3d1c47e5d5a
-func InitUndistortRectifyMap(cameraMatrix Mat, distCoeffs Mat, r Mat, newCameraMatrix Mat, size image.Point, m1type int, map1 Mat, map2 Mat) {
+func InitUndistortRectifyMap(cameraMatrix Mat, distCoeffs Mat, r Mat, newCameraMatrix Mat, size image.Point, m1type int, map1 Mat, map2 Mat) error {
 	sz := C.struct_Size{
 		width:  C.int(size.X),
 		height: C.int(size.Y),
 	}
-	C.InitUndistortRectifyMap(cameraMatrix.Ptr(), distCoeffs.Ptr(), r.Ptr(), newCameraMatrix.Ptr(), sz, C.int(m1type), map1.Ptr(), map2.Ptr())
+	return OpenCVResult(C.InitUndistortRectifyMap(cameraMatrix.Ptr(), distCoeffs.Ptr(), r.Ptr(), newCameraMatrix.Ptr(), sz, C.int(m1type), map1.Ptr(), map2.Ptr()))
 }
 
 // GetOptimalNewCameraMatrixWithParams computes and returns the optimal new camera matrix based on the free scaling parameter.
@@ -162,16 +162,16 @@ func CalibrateCamera(objectPoints Points3fVector, imagePoints Points2fVector, im
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d9/d0c/group__calib3d.html#ga69f2545a8b62a6b0fc2ee060dc30559d
-func Undistort(src Mat, dst *Mat, cameraMatrix Mat, distCoeffs Mat, newCameraMatrix Mat) {
-	C.Undistort(src.Ptr(), dst.Ptr(), cameraMatrix.Ptr(), distCoeffs.Ptr(), newCameraMatrix.Ptr())
+func Undistort(src Mat, dst *Mat, cameraMatrix Mat, distCoeffs Mat, newCameraMatrix Mat) error {
+	return OpenCVResult(C.Undistort(src.Ptr(), dst.Ptr(), cameraMatrix.Ptr(), distCoeffs.Ptr(), newCameraMatrix.Ptr()))
 }
 
 // UndistortPoints transforms points to compensate for lens distortion
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d0c/group__calib3d.html#ga55c716492470bfe86b0ee9bf3a1f0f7e
-func UndistortPoints(src Mat, dst *Mat, cameraMatrix, distCoeffs, rectificationTransform, newCameraMatrix Mat) {
-	C.UndistortPoints(src.Ptr(), dst.Ptr(), cameraMatrix.Ptr(), distCoeffs.Ptr(), rectificationTransform.Ptr(), newCameraMatrix.Ptr())
+func UndistortPoints(src Mat, dst *Mat, cameraMatrix, distCoeffs, rectificationTransform, newCameraMatrix Mat) error {
+	return OpenCVResult(C.UndistortPoints(src.Ptr(), dst.Ptr(), cameraMatrix.Ptr(), distCoeffs.Ptr(), rectificationTransform.Ptr(), newCameraMatrix.Ptr()))
 }
 
 // CheckChessboard renders the detected chessboard corners.
@@ -251,12 +251,12 @@ func FindChessboardCornersSBWithMeta(image Mat, patternSize image.Point, corners
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d0c/group__calib3d.html#ga6a10b0bb120c4907e5eabbcd22319022
-func DrawChessboardCorners(image *Mat, patternSize image.Point, corners Mat, patternWasFound bool) {
+func DrawChessboardCorners(image *Mat, patternSize image.Point, corners Mat, patternWasFound bool) error {
 	sz := C.struct_Size{
 		width:  C.int(patternSize.X),
 		height: C.int(patternSize.Y),
 	}
-	C.DrawChessboardCorners(image.Ptr(), sz, corners.Ptr(), C.bool(patternWasFound))
+	return OpenCVResult(C.DrawChessboardCorners(image.Ptr(), sz, corners.Ptr(), C.bool(patternWasFound)))
 }
 
 // EstimateAffinePartial2D computes an optimal limited affine transformation
@@ -300,24 +300,24 @@ func EstimateAffine2DWithParams(from Point2fVector, to Point2fVector, inliers Ma
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d9/d0c/group__calib3d.html#gad3fc9a0c82b08df034234979960b778c
-func TriangulatePoints(projMatr1, projMatr2 Mat, projPoints1, projPoints2 Point2fVector, points4D *Mat) {
-	C.TriangulatePoints(projMatr1.Ptr(), projMatr2.Ptr(), projPoints1.p, projPoints2.p, points4D.Ptr())
+func TriangulatePoints(projMatr1, projMatr2 Mat, projPoints1, projPoints2 Point2fVector, points4D *Mat) error {
+	return OpenCVResult(C.TriangulatePoints(projMatr1.Ptr(), projMatr2.Ptr(), projPoints1.p, projPoints2.p, points4D.Ptr()))
 }
 
 // ConvertPointsFromHomogeneous converts points from homogeneous to Euclidean space.
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d9/d0c/group__calib3d.html#gac42edda3a3a0f717979589fcd6ac0035
-func ConvertPointsFromHomogeneous(src Mat, dst *Mat) {
-	C.ConvertPointsFromHomogeneous(src.Ptr(), dst.Ptr())
+func ConvertPointsFromHomogeneous(src Mat, dst *Mat) error {
+	return OpenCVResult(C.ConvertPointsFromHomogeneous(src.Ptr(), dst.Ptr()))
 }
 
 // Rodrigues converts a rotation matrix to a rotation vector or vice versa.
 //
 // For further details, please see:
 // https://docs.opencv.org/4.0.0/d9/d0c/group__calib3d.html#ga61585db663d9da06b68e70cfbf6a1eac
-func Rodrigues(src Mat, dst *Mat) {
-	C.Rodrigues(src.p, dst.p)
+func Rodrigues(src Mat, dst *Mat) error {
+	return OpenCVResult(C.Rodrigues(src.p, dst.p))
 }
 
 // SolvePnP finds an object pose from 3D-2D point correspondences.

--- a/calib3d.h
+++ b/calib3d.h
@@ -13,29 +13,29 @@ extern "C" {
 
 //Calib
 double Fisheye_Calibrate(Points3fVector objectPoints, Points2fVector imagePoints, Size size, Mat k, Mat d, Mat rvecs, Mat tvecs, int flags);
-void Fisheye_DistortPoints(Mat undistorted, Mat distorted, Mat k, Mat d);
-void Fisheye_UndistortImage(Mat distorted, Mat undistorted, Mat k, Mat d);
-void Fisheye_UndistortImageWithParams(Mat distorted, Mat undistorted, Mat k, Mat d, Mat knew, Size size);
-void Fisheye_UndistortPoints(Mat distorted, Mat undistorted, Mat k, Mat d, Mat R, Mat P);
-void Fisheye_EstimateNewCameraMatrixForUndistortRectify(Mat k, Mat d, Size imgSize, Mat r, Mat p, double balance, Size newSize, double fovScale);
+OpenCVResult Fisheye_DistortPoints(Mat undistorted, Mat distorted, Mat k, Mat d);
+OpenCVResult Fisheye_UndistortImage(Mat distorted, Mat undistorted, Mat k, Mat d);
+OpenCVResult Fisheye_UndistortImageWithParams(Mat distorted, Mat undistorted, Mat k, Mat d, Mat knew, Size size);
+OpenCVResult Fisheye_UndistortPoints(Mat distorted, Mat undistorted, Mat k, Mat d, Mat R, Mat P);
+OpenCVResult Fisheye_EstimateNewCameraMatrixForUndistortRectify(Mat k, Mat d, Size imgSize, Mat r, Mat p, double balance, Size newSize, double fovScale);
 
-void InitUndistortRectifyMap(Mat cameraMatrix,Mat distCoeffs,Mat r,Mat newCameraMatrix,Size size,int m1type,Mat map1,Mat map2);
+OpenCVResult InitUndistortRectifyMap(Mat cameraMatrix,Mat distCoeffs,Mat r,Mat newCameraMatrix,Size size,int m1type,Mat map1,Mat map2);
 Mat GetOptimalNewCameraMatrixWithParams(Mat cameraMatrix,Mat distCoeffs,Size size,double alpha,Size newImgSize,Rect* validPixROI,bool centerPrincipalPoint);
 double CalibrateCamera(Points3fVector objectPoints, Points2fVector imagePoints, Size imageSize, Mat cameraMatrix, Mat distCoeffs, Mat rvecs, Mat tvecs, int flag);
-void Undistort(Mat src, Mat dst, Mat cameraMatrix, Mat distCoeffs, Mat newCameraMatrix);
-void UndistortPoints(Mat distorted, Mat undistorted, Mat k, Mat d, Mat r, Mat p);
+OpenCVResult Undistort(Mat src, Mat dst, Mat cameraMatrix, Mat distCoeffs, Mat newCameraMatrix);
+OpenCVResult UndistortPoints(Mat distorted, Mat undistorted, Mat k, Mat d, Mat r, Mat p);
 bool CheckChessboard(Mat image, Size sz);
 bool FindChessboardCorners(Mat image, Size patternSize, Mat corners, int flags);
 bool FindChessboardCornersSB(Mat image, Size patternSize, Mat corners, int flags);
 bool FindChessboardCornersSBWithMeta(Mat image, Size patternSize, Mat corners, int flags, Mat meta);
-void DrawChessboardCorners(Mat image, Size patternSize, Mat corners, bool patternWasFound);
+OpenCVResult DrawChessboardCorners(Mat image, Size patternSize, Mat corners, bool patternWasFound);
 Mat EstimateAffinePartial2D(Point2fVector from, Point2fVector to);
 Mat EstimateAffinePartial2DWithParams(Point2fVector from, Point2fVector to, Mat inliers, int method, double ransacReprojThreshold, size_t maxIters, double confidence, size_t refineIters);
 Mat EstimateAffine2D(Point2fVector from, Point2fVector to);
 Mat EstimateAffine2DWithParams(Point2fVector from, Point2fVector to, Mat inliers, int method, double ransacReprojThreshold, size_t maxIters, double confidence, size_t refineIters);
-void TriangulatePoints(Mat projMatr1, Mat projMatr2, Point2fVector projPoints1, Point2fVector projPoints2, Mat points4D);
-void ConvertPointsFromHomogeneous(Mat src, Mat dst);
-void Rodrigues(Mat src, Mat dst);
+OpenCVResult TriangulatePoints(Mat projMatr1, Mat projMatr2, Point2fVector projPoints1, Point2fVector projPoints2, Mat points4D);
+OpenCVResult ConvertPointsFromHomogeneous(Mat src, Mat dst);
+OpenCVResult Rodrigues(Mat src, Mat dst);
 bool SolvePnP(Point3fVector objectPoints, Point2fVector imagePoints, Mat cameraMatrix, Mat distCoeffs, Mat rvec, Mat tvec, bool useExtrinsicGuess, int flags);
 #ifdef __cplusplus
 }

--- a/contrib/bgsegm.cpp
+++ b/contrib/bgsegm.cpp
@@ -1,7 +1,12 @@
 #include "bgsegm.h"
 
 BackgroundSubtractorCNT BackgroundSubtractorCNT_Create() {
-    return new cv::Ptr<cv::bgsegm::BackgroundSubtractorCNT>(cv::bgsegm::createBackgroundSubtractorCNT());
+    try {
+        return new cv::Ptr<cv::bgsegm::BackgroundSubtractorCNT>(cv::bgsegm::createBackgroundSubtractorCNT());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void BackgroundSubtractorCNT_Close(BackgroundSubtractorCNT b) {
@@ -9,5 +14,9 @@ void BackgroundSubtractorCNT_Close(BackgroundSubtractorCNT b) {
 }
 
 void BackgroundSubtractorCNT_Apply(BackgroundSubtractorCNT b, Mat src, Mat dst) {
-    (*b)->apply(*src, *dst);
+    try {
+        (*b)->apply(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }

--- a/contrib/bgsegm.cpp
+++ b/contrib/bgsegm.cpp
@@ -13,10 +13,11 @@ void BackgroundSubtractorCNT_Close(BackgroundSubtractorCNT b) {
     delete b;
 }
 
-void BackgroundSubtractorCNT_Apply(BackgroundSubtractorCNT b, Mat src, Mat dst) {
+OpenCVResult BackgroundSubtractorCNT_Apply(BackgroundSubtractorCNT b, Mat src, Mat dst) {
     try {
         (*b)->apply(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }

--- a/contrib/bgsegm.go
+++ b/contrib/bgsegm.go
@@ -41,8 +41,6 @@ func (b *BackgroundSubtractorCNT) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/3.4/de/dca/classcv_1_1bgsegm_1_1BackgroundSubtractorCNT.html
-func (b *BackgroundSubtractorCNT) Apply(src gocv.Mat, dst *gocv.Mat) {
-	C.BackgroundSubtractorCNT_Apply((C.BackgroundSubtractorCNT)(b.p), (C.Mat)(src.Ptr()), (C.Mat)(dst.Ptr()))
-
-	return
+func (b *BackgroundSubtractorCNT) Apply(src gocv.Mat, dst *gocv.Mat) error {
+	return OpenCVResult(C.BackgroundSubtractorCNT_Apply((C.BackgroundSubtractorCNT)(b.p), (C.Mat)(src.Ptr()), (C.Mat)(dst.Ptr())))
 }

--- a/contrib/bgsegm.h
+++ b/contrib/bgsegm.h
@@ -17,7 +17,7 @@ typedef void* BackgroundSubtractorCNT;
 
 BackgroundSubtractorCNT BackgroundSubtractorCNT_Create();
 void BackgroundSubtractorCNT_Close(BackgroundSubtractorCNT b);
-void BackgroundSubtractorCNT_Apply(BackgroundSubtractorCNT b, Mat src, Mat dst);
+OpenCVResult BackgroundSubtractorCNT_Apply(BackgroundSubtractorCNT b, Mat src, Mat dst);
 
 #ifdef __cplusplus
 }

--- a/contrib/errors.go
+++ b/contrib/errors.go
@@ -1,0 +1,15 @@
+package contrib
+
+/*
+#include "../core.h"
+*/
+import "C"
+import "errors"
+
+// Converts a OpenCVResult struct to an error.
+func OpenCVResult(result C.OpenCVResult) error {
+	if result.Code == 0 {
+		return nil
+	}
+	return errors.New(C.GoString(result.Message))
+}

--- a/contrib/face.cpp
+++ b/contrib/face.cpp
@@ -1,230 +1,355 @@
 #include "face.h"
 
 bool FaceRecognizer_Empty(FaceRecognizer fr) {
-    return (*fr)->empty();
+    try {
+        return (*fr)->empty();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 void FaceRecognizer_Train(FaceRecognizer fr, Mats mats, IntVector labels_in) {
-    std::vector<int> labels;
+    try {
+        std::vector<int> labels;
 
-    for (int i = 0, *v = labels_in.val; i < labels_in.length; ++v, ++i) {
-        labels.push_back(*v);
+        for (int i = 0, *v = labels_in.val; i < labels_in.length; ++v, ++i) {
+            labels.push_back(*v);
+        }
+    
+        std::vector<cv::Mat> images;
+    
+        for (int i = 0; i < mats.length; ++i) {
+            images.push_back(*mats.mats[i]);
+        }
+    
+        (*fr)->train(images, labels);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    std::vector<cv::Mat> images;
-
-    for (int i = 0; i < mats.length; ++i) {
-        images.push_back(*mats.mats[i]);
-    }
-
-    (*fr)->train(images, labels);
-
-    return;
 }
 
 void FaceRecognizer_Update(FaceRecognizer fr, Mats mats, IntVector labels_in) {
-    std::vector<int> labels;
+    try {
+        std::vector<int> labels;
 
-    for (int i = 0, *v = labels_in.val; i < labels_in.length; ++v, ++i) {
-        labels.push_back(*v);
+        for (int i = 0, *v = labels_in.val; i < labels_in.length; ++v, ++i) {
+            labels.push_back(*v);
+        }
+    
+        std::vector<cv::Mat> images;
+    
+        for (int i = 0; i < mats.length; ++i) {
+            images.push_back(*mats.mats[i]);
+        }
+    
+        (*fr)->update(images, labels);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    std::vector<cv::Mat> images;
-
-    for (int i = 0; i < mats.length; ++i) {
-        images.push_back(*mats.mats[i]);
-    }
-
-    (*fr)->update(images, labels);
-
-    return;
 }
 
 int FaceRecognizer_Predict(FaceRecognizer fr, Mat sample) {
-    int label;
-    label = (*fr)->predict(*sample);
-
-    return label;
+    try {
+        int label;
+        label = (*fr)->predict(*sample);
+    
+        return label;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 struct PredictResponse FaceRecognizer_PredictExtended(FaceRecognizer fr, Mat sample) {
-    struct PredictResponse response;
-    int label;
-    double confidence;
-
-    (*fr)->predict(*sample, label, confidence);
-    response.label = label;
-    response.confidence = confidence;
-
-    return response;
+    try {
+        struct PredictResponse response;
+        int label;
+        double confidence;
+    
+        (*fr)->predict(*sample, label, confidence);
+        response.label = label;
+        response.confidence = confidence;
+    
+        return response;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        struct PredictResponse response;
+        return response;
+    }
 }
 
 double FaceRecognizer_GetThreshold(FaceRecognizer fr){
-    return (*fr)->getThreshold();
+    try {
+        return (*fr)->getThreshold();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void FaceRecognizer_SetThreshold(FaceRecognizer fr, double threshold) {
-    (*fr)->setThreshold(threshold);
-    return;
+    try {
+        (*fr)->setThreshold(threshold);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void FaceRecognizer_SaveFile(FaceRecognizer fr, const char*  filename) {
-    (*fr)->write(filename);
-    return;
+    try {
+        (*fr)->write(filename);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void FaceRecognizer_LoadFile(FaceRecognizer fr, const char*  filename) {
-    (*fr)->read(filename);
-    return;
+    try {
+        (*fr)->read(filename);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void BasicFaceRecognizer_Train(BasicFaceRecognizer fr, Mats mats, IntVector labels_in){
-    std::vector<int> labels;
+    try {
+        std::vector<int> labels;
 
-    for (int i = 0, *v = labels_in.val; i < labels_in.length; ++v, ++i) {
-        labels.push_back(*v);
+        for (int i = 0, *v = labels_in.val; i < labels_in.length; ++v, ++i) {
+            labels.push_back(*v);
+        }
+    
+        std::vector<cv::Mat> images;
+    
+        for (int i = 0; i < mats.length; ++i) {
+            images.push_back(*mats.mats[i]);
+        }
+    
+        (*fr)->train(images, labels);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    std::vector<cv::Mat> images;
-
-    for (int i = 0; i < mats.length; ++i) {
-        images.push_back(*mats.mats[i]);
-    }
-
-    (*fr)->train(images, labels);
-
-    return;
 }
 
 void BasicFaceRecognizer_Update(BasicFaceRecognizer fr, Mats mats, IntVector labels_in){
-    std::vector<int> labels;
+    try {
+        std::vector<int> labels;
     
-    for (int i = 0, *v = labels_in.val; i < labels_in.length; ++v, ++i) {
-        labels.push_back(*v);
+        for (int i = 0, *v = labels_in.val; i < labels_in.length; ++v, ++i) {
+            labels.push_back(*v);
+        }
+    
+        std::vector<cv::Mat> images;
+    
+        for (int i = 0; i < mats.length; ++i) {
+            images.push_back(*mats.mats[i]);
+        }
+        (*fr)->update(images, labels);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    std::vector<cv::Mat> images;
-
-    for (int i = 0; i < mats.length; ++i) {
-        images.push_back(*mats.mats[i]);
-    }
-    (*fr)->update(images, labels);
 }
 
 Mat BasicFaceRecognizer_getEigenValues(BasicFaceRecognizer fr){
-    return new cv::Mat((*fr)->getEigenValues());
+    try {
+        return new cv::Mat((*fr)->getEigenValues());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 Mat BasicFaceRecognizer_getEigenVectors(BasicFaceRecognizer fr){
-    return new cv::Mat((*fr)->getEigenVectors());
+    try {
+        return new cv::Mat((*fr)->getEigenVectors());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 Mat BasicFaceRecognizer_getLabels(BasicFaceRecognizer fr){
-    return new cv::Mat((*fr)->getLabels());
+    try {
+        return new cv::Mat((*fr)->getLabels());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 Mat BasicFaceRecognizer_getMean(BasicFaceRecognizer fr){
-    return new cv::Mat((*fr)->getMean());
+    try {
+        return new cv::Mat((*fr)->getMean());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 int BasicFaceRecognizer_getNumComponents(BasicFaceRecognizer fr) {
-    return (*fr)->getNumComponents();
+    try {
+        return (*fr)->getNumComponents();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 Mats BasicFaceRecognizer_getProjections(BasicFaceRecognizer fr) {
-    Mats mats;
+    try {
+        Mats mats;
 
-    std::vector<cv::Mat> vec = (*fr)->getProjections();
-
-    mats.length = (int)vec.size();
-    mats.mats = new Mat[vec.size()];
-
-    for(size_t i = 0; i < vec.size(); i++) {
-        mats.mats[i] = new cv::Mat(vec[i]);
+        std::vector<cv::Mat> vec = (*fr)->getProjections();
+    
+        mats.length = (int)vec.size();
+        mats.mats = new Mat[vec.size()];
+    
+        for(size_t i = 0; i < vec.size(); i++) {
+            mats.mats[i] = new cv::Mat(vec[i]);
+        }
+        return mats;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Mats mats;
+        return mats;
     }
-    return mats;
 }
 
 void BasicFaceRecognizer_setNumComponents(BasicFaceRecognizer fr, int val){
-    (*fr)->setNumComponents(val);
+    try {
+        (*fr)->setNumComponents(val);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }	
 
 void BasicFaceRecognizer_SaveFile(BasicFaceRecognizer fr, const char*  filename){
-    (*fr)->write(filename);
+    try {
+        (*fr)->write(filename);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void BasicFaceRecognizer_LoadFile(BasicFaceRecognizer fr, const char*  filename){
-    (*fr)->read(filename);
+    try {
+        (*fr)->read(filename);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
-
-
-
 LBPHFaceRecognizer CreateLBPHFaceRecognizer() {
-    return new cv::Ptr<cv::face::LBPHFaceRecognizer>(cv::face::LBPHFaceRecognizer::create());
+    try {
+        return new cv::Ptr<cv::face::LBPHFaceRecognizer>(cv::face::LBPHFaceRecognizer::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void LBPHFaceRecognizer_SetRadius(LBPHFaceRecognizer fr, int radius) {
-    (*fr)->setRadius(radius);
-    return;
+    try {
+        (*fr)->setRadius(radius);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void LBPHFaceRecognizer_SetNeighbors(LBPHFaceRecognizer fr, int neighbors) {
-    (*fr)->setNeighbors(neighbors);
-    return;
+    try {
+        (*fr)->setNeighbors(neighbors);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 int LBPHFaceRecognizer_GetNeighbors(LBPHFaceRecognizer fr) {
-    int n;
-
-    n = (*fr)->getNeighbors();
-    return n;
+    try {
+        return (*fr)->getNeighbors();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 void LBPHFaceRecognizer_SetGridX(LBPHFaceRecognizer fr, int x) {
-    (*fr)->setGridX(x);
-    return;
+    try {
+        (*fr)->setGridX(x);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void LBPHFaceRecognizer_SetGridY(LBPHFaceRecognizer fr, int y) {
-    (*fr)->setGridY(y);
-    return;
+    try {
+        (*fr)->setGridY(y);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 int LBPHFaceRecognizer_GetGridX(LBPHFaceRecognizer fr) {
-    int n = (*fr)->getGridX();
-    return n;
+    try {
+        return (*fr)->getGridX();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 int LBPHFaceRecognizer_GetGridY(LBPHFaceRecognizer fr) {
-    int n = (*fr)->getGridY();
-    return n;
+    try {
+        return (*fr)->getGridY();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 void LBPHFaceRecognizer_Close(LBPHFaceRecognizer fr) {
     delete fr;
 }
 
-
 FisherFaceRecognizer FisherFaceRecognizer_Create(void) {
-    return new cv::Ptr<cv::face::FisherFaceRecognizer>(cv::face::FisherFaceRecognizer::create());
+    try {
+        return new cv::Ptr<cv::face::FisherFaceRecognizer>(cv::face::FisherFaceRecognizer::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 FisherFaceRecognizer FisherFaceRecognizer_CreateWithParams(int num_components, float threshold) {
-    return new cv::Ptr<cv::face::FisherFaceRecognizer>(cv::face::FisherFaceRecognizer::create(num_components, threshold));
+    try {
+        return new cv::Ptr<cv::face::FisherFaceRecognizer>(cv::face::FisherFaceRecognizer::create(num_components, threshold));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void FisherFaceRecognizer_Close(FisherFaceRecognizer fr) {
     delete fr;
 }
 
-
 EigenFaceRecognizer EigenFaceRecognizer_Create(void) {
-    return new cv::Ptr<cv::face::EigenFaceRecognizer>(cv::face::EigenFaceRecognizer::create());
+    try {
+        return new cv::Ptr<cv::face::EigenFaceRecognizer>(cv::face::EigenFaceRecognizer::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 EigenFaceRecognizer EigenFaceRecognizer_CreateWithParams(int num_components, float threshold) {
-    return new cv::Ptr<cv::face::EigenFaceRecognizer>(cv::face::EigenFaceRecognizer::create(num_components, threshold));
+    try {
+        return new cv::Ptr<cv::face::EigenFaceRecognizer>(cv::face::EigenFaceRecognizer::create(num_components, threshold));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void EigenFaceRecognizer_Close(EigenFaceRecognizer fr) {

--- a/contrib/face.cpp
+++ b/contrib/face.cpp
@@ -9,7 +9,7 @@ bool FaceRecognizer_Empty(FaceRecognizer fr) {
     }
 }
 
-void FaceRecognizer_Train(FaceRecognizer fr, Mats mats, IntVector labels_in) {
+OpenCVResult FaceRecognizer_Train(FaceRecognizer fr, Mats mats, IntVector labels_in) {
     try {
         std::vector<int> labels;
 
@@ -24,12 +24,13 @@ void FaceRecognizer_Train(FaceRecognizer fr, Mats mats, IntVector labels_in) {
         }
     
         (*fr)->train(images, labels);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void FaceRecognizer_Update(FaceRecognizer fr, Mats mats, IntVector labels_in) {
+OpenCVResult FaceRecognizer_Update(FaceRecognizer fr, Mats mats, IntVector labels_in) {
     try {
         std::vector<int> labels;
 
@@ -44,8 +45,9 @@ void FaceRecognizer_Update(FaceRecognizer fr, Mats mats, IntVector labels_in) {
         }
     
         (*fr)->update(images, labels);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -96,23 +98,25 @@ void FaceRecognizer_SetThreshold(FaceRecognizer fr, double threshold) {
     }
 }
 
-void FaceRecognizer_SaveFile(FaceRecognizer fr, const char*  filename) {
+OpenCVResult FaceRecognizer_SaveFile(FaceRecognizer fr, const char*  filename) {
     try {
         (*fr)->write(filename);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void FaceRecognizer_LoadFile(FaceRecognizer fr, const char*  filename) {
+OpenCVResult FaceRecognizer_LoadFile(FaceRecognizer fr, const char*  filename) {
     try {
         (*fr)->read(filename);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void BasicFaceRecognizer_Train(BasicFaceRecognizer fr, Mats mats, IntVector labels_in){
+OpenCVResult BasicFaceRecognizer_Train(BasicFaceRecognizer fr, Mats mats, IntVector labels_in){
     try {
         std::vector<int> labels;
 
@@ -127,12 +131,13 @@ void BasicFaceRecognizer_Train(BasicFaceRecognizer fr, Mats mats, IntVector labe
         }
     
         (*fr)->train(images, labels);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void BasicFaceRecognizer_Update(BasicFaceRecognizer fr, Mats mats, IntVector labels_in){
+OpenCVResult BasicFaceRecognizer_Update(BasicFaceRecognizer fr, Mats mats, IntVector labels_in){
     try {
         std::vector<int> labels;
     
@@ -146,8 +151,9 @@ void BasicFaceRecognizer_Update(BasicFaceRecognizer fr, Mats mats, IntVector lab
             images.push_back(*mats.mats[i]);
         }
         (*fr)->update(images, labels);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -224,19 +230,21 @@ void BasicFaceRecognizer_setNumComponents(BasicFaceRecognizer fr, int val){
     }
 }	
 
-void BasicFaceRecognizer_SaveFile(BasicFaceRecognizer fr, const char*  filename){
+OpenCVResult BasicFaceRecognizer_SaveFile(BasicFaceRecognizer fr, const char*  filename){
     try {
         (*fr)->write(filename);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void BasicFaceRecognizer_LoadFile(BasicFaceRecognizer fr, const char*  filename){
+OpenCVResult BasicFaceRecognizer_LoadFile(BasicFaceRecognizer fr, const char*  filename){
     try {
         (*fr)->read(filename);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 

--- a/contrib/face.go
+++ b/contrib/face.go
@@ -45,16 +45,16 @@ func NewLBPHFaceRecognizer() *LBPHFaceRecognizer {
 // Train loaded model with images and their labels
 //
 // see https://docs.opencv.org/master/dd/d65/classcv_1_1face_1_1FaceRecognizer.html#ac8680c2aa9649ad3f55e27761165c0d6
-func (fr *LBPHFaceRecognizer) Train(images []gocv.Mat, labels []int) {
-	faceRecognizer_Train(C.FaceRecognizer(fr.p), images, labels)
+func (fr *LBPHFaceRecognizer) Train(images []gocv.Mat, labels []int) error {
+	return faceRecognizer_Train(C.FaceRecognizer(fr.p), images, labels)
 }
 
 // Update updates the existing trained model with new images and labels.
 //
 // For further information, see:
 // https://docs.opencv.org/master/dd/d65/classcv_1_1face_1_1FaceRecognizer.html#a8a4e73ea878dcd0c235d0487189d25f3
-func (fr *LBPHFaceRecognizer) Update(newImages []gocv.Mat, newLabels []int) {
-	faceRecognizer_Update(C.FaceRecognizer(fr.p), newImages, newLabels)
+func (fr *LBPHFaceRecognizer) Update(newImages []gocv.Mat, newLabels []int) error {
+	return faceRecognizer_Update(C.FaceRecognizer(fr.p), newImages, newLabels)
 }
 
 // Predict predicts a label for a given input image. It returns the label for
@@ -133,16 +133,16 @@ func (fr *LBPHFaceRecognizer) SetRadius(radius int) {
 //
 // For further information, see:
 // https://docs.opencv.org/master/dd/d65/classcv_1_1face_1_1FaceRecognizer.html#a2adf2d555550194244b05c91fefcb4d6
-func (fr *LBPHFaceRecognizer) SaveFile(fname string) {
-	faceRecognizer_SaveFile(C.FaceRecognizer(fr.p), fname)
+func (fr *LBPHFaceRecognizer) SaveFile(fname string) error {
+	return faceRecognizer_SaveFile(C.FaceRecognizer(fr.p), fname)
 }
 
 // LoadFile loads a trained model data from file.
 //
 // For further information, see:
 // https://docs.opencv.org/master/dd/d65/classcv_1_1face_1_1FaceRecognizer.html#acc42e5b04595dba71f0777c7179af8c3
-func (fr *LBPHFaceRecognizer) LoadFile(fname string) {
-	faceRecognizer_LoadFile(C.FaceRecognizer(fr.p), fname)
+func (fr *LBPHFaceRecognizer) LoadFile(fname string) error {
+	return faceRecognizer_LoadFile(C.FaceRecognizer(fr.p), fname)
 }
 
 // SetGridX sets grid's X value
@@ -276,16 +276,16 @@ func (fr *FisherFaceRecognizer) SetThreshold(threshold float32) {
 //
 // For further information, see:
 // https://docs.opencv.org/master/dd/d65/classcv_1_1face_1_1FaceRecognizer.html#acc42e5b04595dba71f0777c7179af8c3
-func (fr *FisherFaceRecognizer) LoadFile(filename string) {
-	basicFaceRecognizer_LoadFile(C.BasicFaceRecognizer(fr.p), filename)
+func (fr *FisherFaceRecognizer) LoadFile(filename string) error {
+	return basicFaceRecognizer_LoadFile(C.BasicFaceRecognizer(fr.p), filename)
 }
 
 // SaveFile saves the trained model data to file.
 //
 // For further information, see:
 // https://docs.opencv.org/master/dd/d65/classcv_1_1face_1_1FaceRecognizer.html#a2adf2d555550194244b05c91fefcb4d6
-func (fr *FisherFaceRecognizer) SaveFile(filename string) {
-	basicFaceRecognizer_SaveFile(C.BasicFaceRecognizer(fr.p), filename)
+func (fr *FisherFaceRecognizer) SaveFile(filename string) error {
+	return basicFaceRecognizer_SaveFile(C.BasicFaceRecognizer(fr.p), filename)
 }
 
 // Predict predicts a label for a given input image. It returns the label for
@@ -310,16 +310,16 @@ func (fr *FisherFaceRecognizer) PredictExtendedResponse(sample gocv.Mat) Predict
 // Train loaded model with images and their labels
 //
 // see https://docs.opencv.org/master/dd/d65/classcv_1_1face_1_1FaceRecognizer.html#ac8680c2aa9649ad3f55e27761165c0d6
-func (fr *FisherFaceRecognizer) Train(images []gocv.Mat, labels []int) {
-	basicFaceRecognizer_Train(C.BasicFaceRecognizer(fr.p), images, labels)
+func (fr *FisherFaceRecognizer) Train(images []gocv.Mat, labels []int) error {
+	return basicFaceRecognizer_Train(C.BasicFaceRecognizer(fr.p), images, labels)
 }
 
 // Update This model does not support updating.
 //
 // For further information, see:
 // https://docs.opencv.org/4.x/d2/de9/classcv_1_1face_1_1FisherFaceRecognizer.html#ac6e204df6d7e526f4c77d3e0389dfbaa
-func (fr *FisherFaceRecognizer) Update(newImages []gocv.Mat, newLabels []int) {
-	faceRecognizer_Train(C.FaceRecognizer(fr.p), newImages, newLabels)
+func (fr *FisherFaceRecognizer) Update(newImages []gocv.Mat, newLabels []int) error {
+	return faceRecognizer_Train(C.FaceRecognizer(fr.p), newImages, newLabels)
 
 }
 
@@ -408,16 +408,16 @@ func (fr *EigenFaceRecognizer) SetThreshold(threshold float32) {
 //
 // For further information, see:
 // https://docs.opencv.org/master/dd/d65/classcv_1_1face_1_1FaceRecognizer.html#acc42e5b04595dba71f0777c7179af8c3
-func (fr *EigenFaceRecognizer) LoadFile(filename string) {
-	basicFaceRecognizer_LoadFile(C.BasicFaceRecognizer(fr.p), filename)
+func (fr *EigenFaceRecognizer) LoadFile(filename string) error {
+	return basicFaceRecognizer_LoadFile(C.BasicFaceRecognizer(fr.p), filename)
 }
 
 // SaveFile saves the trained model data to file.
 //
 // For further information, see:
 // https://docs.opencv.org/master/dd/d65/classcv_1_1face_1_1FaceRecognizer.html#a2adf2d555550194244b05c91fefcb4d6
-func (fr *EigenFaceRecognizer) SaveFile(filename string) {
-	basicFaceRecognizer_SaveFile(C.BasicFaceRecognizer(fr.p), filename)
+func (fr *EigenFaceRecognizer) SaveFile(filename string) error {
+	return basicFaceRecognizer_SaveFile(C.BasicFaceRecognizer(fr.p), filename)
 }
 
 // Predict predicts a label for a given input image. It returns the label for
@@ -442,16 +442,16 @@ func (fr *EigenFaceRecognizer) PredictExtendedResponse(sample gocv.Mat) PredictR
 // Train loaded model with images and their labels
 //
 // see https://docs.opencv.org/master/dd/d65/classcv_1_1face_1_1FaceRecognizer.html#ac8680c2aa9649ad3f55e27761165c0d6
-func (fr *EigenFaceRecognizer) Train(images []gocv.Mat, labels []int) {
-	basicFaceRecognizer_Train(C.BasicFaceRecognizer(fr.p), images, labels)
+func (fr *EigenFaceRecognizer) Train(images []gocv.Mat, labels []int) error {
+	return basicFaceRecognizer_Train(C.BasicFaceRecognizer(fr.p), images, labels)
 }
 
 // Update This model does not support updating.
 //
 // For further information, see:
 // https://docs.opencv.org/4.x/dd/d7c/classcv_1_1face_1_1EigenFaceRecognizer.html#a22c8392f27a20b24d04351b675e7b6db
-func (fr *EigenFaceRecognizer) Update(newImages []gocv.Mat, newLabels []int) {
-	basicFaceRecognizer_Train(C.BasicFaceRecognizer(fr.p), newImages, newLabels)
+func (fr *EigenFaceRecognizer) Update(newImages []gocv.Mat, newLabels []int) error {
+	return basicFaceRecognizer_Train(C.BasicFaceRecognizer(fr.p), newImages, newLabels)
 }
 
 func (fr *EigenFaceRecognizer) Close() error {

--- a/contrib/face.h
+++ b/contrib/face.h
@@ -30,18 +30,18 @@ struct PredictResponse {
 };
 
 bool FaceRecognizer_Empty(FaceRecognizer fr);
-void FaceRecognizer_Train(FaceRecognizer fr, Mats images, IntVector labels);
-void FaceRecognizer_Update(FaceRecognizer fr, Mats images, IntVector labels);
+OpenCVResult FaceRecognizer_Train(FaceRecognizer fr, Mats images, IntVector labels);
+OpenCVResult FaceRecognizer_Update(FaceRecognizer fr, Mats images, IntVector labels);
 int FaceRecognizer_Predict(FaceRecognizer fr, Mat sample);
 struct PredictResponse FaceRecognizer_PredictExtended(FaceRecognizer fr, Mat sample);
 double FaceRecognizer_GetThreshold(FaceRecognizer fr);
 void FaceRecognizer_SetThreshold(FaceRecognizer fr, double threshold);
-void FaceRecognizer_SaveFile(FaceRecognizer fr, const char*  filename);
-void FaceRecognizer_LoadFile(FaceRecognizer fr, const char*  filename);
+OpenCVResult FaceRecognizer_SaveFile(FaceRecognizer fr, const char*  filename);
+OpenCVResult FaceRecognizer_LoadFile(FaceRecognizer fr, const char*  filename);
 
 
-void BasicFaceRecognizer_Train(BasicFaceRecognizer fr, Mats images, IntVector labels);
-void BasicFaceRecognizer_Update(BasicFaceRecognizer fr, Mats images, IntVector labels);
+OpenCVResult BasicFaceRecognizer_Train(BasicFaceRecognizer fr, Mats images, IntVector labels);
+OpenCVResult BasicFaceRecognizer_Update(BasicFaceRecognizer fr, Mats images, IntVector labels);
 Mat BasicFaceRecognizer_getEigenValues(BasicFaceRecognizer fr);
 Mat BasicFaceRecognizer_getEigenVectors(BasicFaceRecognizer fr);
 Mat BasicFaceRecognizer_getLabels(BasicFaceRecognizer fr);
@@ -49,8 +49,8 @@ Mat BasicFaceRecognizer_getMean(BasicFaceRecognizer fr);
 int BasicFaceRecognizer_getNumComponents(BasicFaceRecognizer fr);
 Mats BasicFaceRecognizer_getProjections(BasicFaceRecognizer fr);
 void BasicFaceRecognizer_setNumComponents(BasicFaceRecognizer fr, int val);	
-void BasicFaceRecognizer_SaveFile(BasicFaceRecognizer fr, const char*  filename);
-void BasicFaceRecognizer_LoadFile(BasicFaceRecognizer fr, const char*  filename);
+OpenCVResult BasicFaceRecognizer_SaveFile(BasicFaceRecognizer fr, const char*  filename);
+OpenCVResult BasicFaceRecognizer_LoadFile(BasicFaceRecognizer fr, const char*  filename);
 
 LBPHFaceRecognizer CreateLBPHFaceRecognizer(void);
 void LBPHFaceRecognizer_SetRadius(LBPHFaceRecognizer fr, int radius);

--- a/contrib/face_recognizer.go
+++ b/contrib/face_recognizer.go
@@ -13,14 +13,14 @@ import (
 
 type FaceRecognizer interface {
 	Empty() bool
-	Train(images []gocv.Mat, labels []int)
-	Update(newImages []gocv.Mat, newLabels []int)
+	Train(images []gocv.Mat, labels []int) error
+	Update(newImages []gocv.Mat, newLabels []int) error
 	Predict(sample gocv.Mat) int
 	PredictExtendedResponse(sample gocv.Mat) PredictResponse
 	GetThreshold() float32
 	SetThreshold(threshold float32)
-	SaveFile(fname string)
-	LoadFile(fname string)
+	SaveFile(fname string) error
+	LoadFile(fname string) error
 	Close() error
 }
 
@@ -32,8 +32,8 @@ type BasicFaceRecognizer interface {
 	GetNumComponents() int
 	SetNumComponents(val int)
 	GetProjections() []gocv.Mat
-	SaveFile(fname string)
-	LoadFile(fname string)
+	SaveFile(fname string) error
+	LoadFile(fname string) error
 }
 
 func faceRecognizer_Empty(fr C.FaceRecognizer) bool {
@@ -41,7 +41,7 @@ func faceRecognizer_Empty(fr C.FaceRecognizer) bool {
 	return bool(b)
 }
 
-func faceRecognizer_Train(fr C.FaceRecognizer, images []gocv.Mat, labels []int) {
+func faceRecognizer_Train(fr C.FaceRecognizer, images []gocv.Mat, labels []int) error {
 	cparams := []C.int{}
 	for _, v := range labels {
 		cparams = append(cparams, C.int(v))
@@ -59,10 +59,10 @@ func faceRecognizer_Train(fr C.FaceRecognizer, images []gocv.Mat, labels []int) 
 		length: C.int(len(images)),
 	}
 
-	C.FaceRecognizer_Train(fr, matsVector, labelsVector)
+	return OpenCVResult(C.FaceRecognizer_Train(fr, matsVector, labelsVector))
 }
 
-func faceRecognizer_Update(fr C.FaceRecognizer, newImages []gocv.Mat, newLabels []int) {
+func faceRecognizer_Update(fr C.FaceRecognizer, newImages []gocv.Mat, newLabels []int) error {
 	cparams := []C.int{}
 	for _, v := range newLabels {
 		cparams = append(cparams, C.int(v))
@@ -80,7 +80,7 @@ func faceRecognizer_Update(fr C.FaceRecognizer, newImages []gocv.Mat, newLabels 
 		length: C.int(len(newImages)),
 	}
 
-	C.FaceRecognizer_Update(fr, matsVector, labelsVector)
+	return OpenCVResult(C.FaceRecognizer_Update(fr, matsVector, labelsVector))
 }
 
 func faceRecognizer_Predict(fr C.FaceRecognizer, sample gocv.Mat) int {
@@ -108,19 +108,19 @@ func faceRecognizer_SetThreshold(fr C.FaceRecognizer, threshold float32) {
 	C.FaceRecognizer_SetThreshold(fr, (C.double)(threshold))
 }
 
-func faceRecognizer_SaveFile(fr C.FaceRecognizer, fname string) {
+func faceRecognizer_SaveFile(fr C.FaceRecognizer, fname string) error {
 	cName := C.CString(fname)
 	defer C.free(unsafe.Pointer(cName))
-	C.FaceRecognizer_SaveFile(fr, cName)
+	return OpenCVResult(C.FaceRecognizer_SaveFile(fr, cName))
 }
 
-func faceRecognizer_LoadFile(fr C.FaceRecognizer, fname string) {
+func faceRecognizer_LoadFile(fr C.FaceRecognizer, fname string) error {
 	cName := C.CString(fname)
 	defer C.free(unsafe.Pointer(cName))
-	C.FaceRecognizer_LoadFile(fr, cName)
+	return OpenCVResult(C.FaceRecognizer_LoadFile(fr, cName))
 }
 
-func basicFaceRecognizer_Train(fr C.BasicFaceRecognizer, images []gocv.Mat, labels []int) {
+func basicFaceRecognizer_Train(fr C.BasicFaceRecognizer, images []gocv.Mat, labels []int) error {
 	cparams := []C.int{}
 	for _, v := range labels {
 		cparams = append(cparams, C.int(v))
@@ -138,10 +138,10 @@ func basicFaceRecognizer_Train(fr C.BasicFaceRecognizer, images []gocv.Mat, labe
 		length: C.int(len(images)),
 	}
 
-	C.BasicFaceRecognizer_Train(fr, matsVector, labelsVector)
+	return OpenCVResult(C.BasicFaceRecognizer_Train(fr, matsVector, labelsVector))
 }
 
-func basicFaceRecognizer_Update(fr C.BasicFaceRecognizer, newImages []gocv.Mat, newLabels []int) {
+func basicFaceRecognizer_Update(fr C.BasicFaceRecognizer, newImages []gocv.Mat, newLabels []int) error {
 	cparams := []C.int{}
 	for _, v := range newLabels {
 		cparams = append(cparams, C.int(v))
@@ -159,7 +159,7 @@ func basicFaceRecognizer_Update(fr C.BasicFaceRecognizer, newImages []gocv.Mat, 
 		length: C.int(len(newImages)),
 	}
 
-	C.BasicFaceRecognizer_Update(fr, matsVector, labelsVector)
+	return OpenCVResult(C.BasicFaceRecognizer_Update(fr, matsVector, labelsVector))
 }
 
 func basicFaceRecognizer_GetEigenValues(fr C.BasicFaceRecognizer) gocv.Mat {
@@ -207,14 +207,14 @@ func basicFaceRecognizer_GetProjections(fr C.BasicFaceRecognizer) []gocv.Mat {
 	return mats
 }
 
-func basicFaceRecognizer_SaveFile(fr C.BasicFaceRecognizer, fname string) {
+func basicFaceRecognizer_SaveFile(fr C.BasicFaceRecognizer, fname string) error {
 	cName := C.CString(fname)
 	defer C.free(unsafe.Pointer(cName))
-	C.BasicFaceRecognizer_SaveFile(fr, cName)
+	return OpenCVResult(C.BasicFaceRecognizer_SaveFile(fr, cName))
 }
 
-func basicFaceRecognizer_LoadFile(fr C.BasicFaceRecognizer, fname string) {
+func basicFaceRecognizer_LoadFile(fr C.BasicFaceRecognizer, fname string) error {
 	cName := C.CString(fname)
 	defer C.free(unsafe.Pointer(cName))
-	C.BasicFaceRecognizer_LoadFile(fr, cName)
+	return OpenCVResult(C.BasicFaceRecognizer_LoadFile(fr, cName))
 }

--- a/contrib/freetype.cpp
+++ b/contrib/freetype.cpp
@@ -16,11 +16,12 @@ void FreeType2_Close(FreeType2 f) {
     delete f;
 }
 
-void FreeType2_LoadFontData(FreeType2 f, const char *fontFileName, int id) {
+OpenCVResult FreeType2_LoadFontData(FreeType2 f, const char *fontFileName, int id) {
     try {
         (*f)->loadFontData(fontFileName, id);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -32,15 +33,16 @@ void FreeType2_SetSplitNumber(FreeType2 f, int num) {
     }
 }
 
-void FreeType2_PutText(FreeType2 f, Mat img, const char *text, Point org,
+OpenCVResult FreeType2_PutText(FreeType2 f, Mat img, const char *text, Point org,
                        int fontHeight, Scalar color,
                        int thickness, int line_type, bool bottomLeftOrigin) {
     try {
         cv::Point pt(org.x, org.y);
         cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
         (*f)->putText(*img, text, pt, fontHeight, c, thickness, line_type, bottomLeftOrigin);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }                    
 }
 

--- a/contrib/freetype.cpp
+++ b/contrib/freetype.cpp
@@ -4,7 +4,12 @@
 #include "freetype.h"
 
 FreeType2 FreeType2_CreateFreeType2() {
-    return new cv::Ptr<cv::freetype::FreeType2>(cv::freetype::createFreeType2());
+    try {
+        return new cv::Ptr<cv::freetype::FreeType2>(cv::freetype::createFreeType2());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void FreeType2_Close(FreeType2 f) {
@@ -12,25 +17,42 @@ void FreeType2_Close(FreeType2 f) {
 }
 
 void FreeType2_LoadFontData(FreeType2 f, const char *fontFileName, int id) {
-    (*f)->loadFontData(fontFileName, id);
+    try {
+        (*f)->loadFontData(fontFileName, id);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void FreeType2_SetSplitNumber(FreeType2 f, int num) {
-    (*f)->setSplitNumber(num);
+    try {
+        (*f)->setSplitNumber(num);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void FreeType2_PutText(FreeType2 f, Mat img, const char *text, Point org,
                        int fontHeight, Scalar color,
                        int thickness, int line_type, bool bottomLeftOrigin) {
-    cv::Point pt(org.x, org.y);
-    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
-    (*f)->putText(*img, text, pt, fontHeight, c, thickness, line_type, bottomLeftOrigin);
+    try {
+        cv::Point pt(org.x, org.y);
+        cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+        (*f)->putText(*img, text, pt, fontHeight, c, thickness, line_type, bottomLeftOrigin);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }                    
 }
 
-Size FreeType2_GetTextSize(FreeType2 f, const char *text,
-                           int fontHeight, int thickness, int *baseLine) {
-    cv::Size sz = (*f)->getTextSize(text, fontHeight, thickness, baseLine);
-    return Size{sz.width, sz.height};
+Size FreeType2_GetTextSize(FreeType2 f, const char *text, int fontHeight, int thickness, int *baseLine) {
+    try {
+        cv::Size sz = (*f)->getTextSize(text, fontHeight, thickness, baseLine);
+        return Size{sz.width, sz.height};
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Size sz = {0, 0};
+        return sz;
+    }                        
 }
 
 #endif // _WIN32

--- a/contrib/freetype.go
+++ b/contrib/freetype.go
@@ -39,10 +39,10 @@ func (f *FreeType2) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/dfa/classcv_1_1freetype_1_1FreeType2.html#af059d49b806b916ffdd6380b9eb2f59a
-func (f *FreeType2) LoadFontData(fontFileName string, id int) {
+func (f *FreeType2) LoadFontData(fontFileName string, id int) error {
 	cFontFileName := C.CString(fontFileName)
 	defer C.free(unsafe.Pointer(cFontFileName))
-	C.FreeType2_LoadFontData((C.FreeType2)(f.p), cFontFileName, C.int(id))
+	return OpenCVResult(C.FreeType2_LoadFontData((C.FreeType2)(f.p), cFontFileName, C.int(id)))
 }
 
 // SetSplitNumber set the number of split points from bezier-curve to line.
@@ -62,7 +62,7 @@ func (f *FreeType2) SetSplitNumber(num int) {
 // For further details, please see:
 // https://docs.opencv.org/master/d9/dfa/classcv_1_1freetype_1_1FreeType2.html#aba641f774c47a70eaeb76bf7aa865915
 func (f *FreeType2) PutText(img *gocv.Mat, text string, org image.Point,
-	fontHeight int, c color.RGBA, thickness int, lineType gocv.LineType, bottomLeftOrigin bool) {
+	fontHeight int, c color.RGBA, thickness int, lineType gocv.LineType, bottomLeftOrigin bool) error {
 	cText := C.CString(text)
 	defer C.free(unsafe.Pointer(cText))
 
@@ -78,7 +78,7 @@ func (f *FreeType2) PutText(img *gocv.Mat, text string, org image.Point,
 		val4: C.double(c.A),
 	}
 
-	C.FreeType2_PutText((C.FreeType2)(f.p), (C.Mat)(img.Ptr()), cText, sOrg, C.int(fontHeight), sColor, C.int(thickness), C.int(lineType), C.bool(bottomLeftOrigin))
+	return OpenCVResult(C.FreeType2_PutText((C.FreeType2)(f.p), (C.Mat)(img.Ptr()), cText, sOrg, C.int(fontHeight), sColor, C.int(thickness), C.int(lineType), C.bool(bottomLeftOrigin)))
 }
 
 // GetTextSize calculates the width and height of a text string.

--- a/contrib/freetype.h
+++ b/contrib/freetype.h
@@ -17,9 +17,9 @@ typedef void* FreeType2;
 
 FreeType2 FreeType2_CreateFreeType2();
 void FreeType2_Close(FreeType2 f);
-void FreeType2_LoadFontData(FreeType2 f, const char* fontFileName, int id);
+OpenCVResult FreeType2_LoadFontData(FreeType2 f, const char* fontFileName, int id);
 void FreeType2_SetSplitNumber(FreeType2 f, int num);
-void FreeType2_PutText(FreeType2 f, Mat img, const char* text, Point org,
+OpenCVResult FreeType2_PutText(FreeType2 f, Mat img, const char* text, Point org,
         int fontHeight, Scalar color,
         int thickness, int line_type, bool bottomLeftOrigin
     );

--- a/contrib/img_hash.cpp
+++ b/contrib/img_hash.cpp
@@ -1,43 +1,102 @@
 #include "img_hash.h"
 
 void pHashCompute(Mat inputArr, Mat outputArr) {
-    cv::img_hash::pHash(*inputArr, *outputArr);
+    try {
+        cv::img_hash::pHash(*inputArr, *outputArr);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 double pHashCompare(Mat a, Mat b) {
-    return cv::img_hash::PHash::create()->compare(*a, *b);
+    try {
+        return cv::img_hash::PHash::create()->compare(*a, *b);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void averageHashCompute(Mat inputArr, Mat outputArr) {
-    cv::img_hash::averageHash(*inputArr, *outputArr);
+    try {
+        cv::img_hash::averageHash(*inputArr, *outputArr);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
+
 double averageHashCompare(Mat a, Mat b) {
-    return cv::img_hash::AverageHash::create()->compare(*a, *b);
+    try {
+        return cv::img_hash::AverageHash::create()->compare(*a, *b);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void blockMeanHashCompute(Mat inputArr, Mat outputArr, int mode) {
-    cv::img_hash::blockMeanHash(*inputArr, *outputArr, mode);
+    try {
+        cv::img_hash::blockMeanHash(*inputArr, *outputArr, mode);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
+
 double blockMeanHashCompare(Mat a, Mat b, int mode) {
-    return cv::img_hash::BlockMeanHash::create(mode)->compare(*a, *b);
+    try {
+        return cv::img_hash::BlockMeanHash::create(mode)->compare(*a, *b);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void colorMomentHashCompute(Mat inputArr, Mat outputArr) {
-    cv::img_hash::colorMomentHash(*inputArr, *outputArr);
+    try {
+        cv::img_hash::colorMomentHash(*inputArr, *outputArr);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }    
 }
+
 double colorMomentHashCompare(Mat a, Mat b) {
-    return cv::img_hash::ColorMomentHash::create()->compare(*a, *b);
+    try {
+        return cv::img_hash::ColorMomentHash::create()->compare(*a, *b);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void marrHildrethHashCompute(Mat inputArr, Mat outputArr, float alpha, float scale) {
-    cv::img_hash::marrHildrethHash(*inputArr, *outputArr, alpha, scale);
+    try {
+        cv::img_hash::marrHildrethHash(*inputArr, *outputArr, alpha, scale);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
+
 double marrHildrethHashCompare(Mat a, Mat b, float alpha, float scale) {
-    return cv::img_hash::MarrHildrethHash::create(alpha, scale)->compare(*a, *b);
+    try {
+        return cv::img_hash::MarrHildrethHash::create(alpha, scale)->compare(*a, *b);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void radialVarianceHashCompute(Mat inputArr, Mat outputArr, double sigma, int numOfAngleLine) {
-    cv::img_hash::radialVarianceHash(*inputArr, *outputArr, sigma, numOfAngleLine);
+    try {
+        cv::img_hash::radialVarianceHash(*inputArr, *outputArr, sigma, numOfAngleLine);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
+
 double radialVarianceHashCompare(Mat a, Mat b, double sigma, int numOfAngleLine) {
-    return cv::img_hash::RadialVarianceHash::create(sigma, numOfAngleLine)->compare(*a, *b);
+    try {
+        return cv::img_hash::RadialVarianceHash::create(sigma, numOfAngleLine)->compare(*a, *b);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }

--- a/contrib/tracking.cpp
+++ b/contrib/tracking.cpp
@@ -1,26 +1,40 @@
 #include "tracking.h"
 #include <opencv2/opencv.hpp>
 
-
 bool TrackerSubclass_Init(Tracker self, Mat image, Rect boundingBox) {
-    cv::Rect bb(boundingBox.x, boundingBox.y, boundingBox.width, boundingBox.height);
+    try {
+        cv::Rect bb(boundingBox.x, boundingBox.y, boundingBox.width, boundingBox.height);
 
-    (*self)->init(*image, bb);
-    return true;
+        (*self)->init(*image, bb);
+        return true;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 bool TrackerSubclass_Update(Tracker self, Mat image, Rect* boundingBox) {
-    cv::Rect bb;
-    bool ret = (*self)->update(*image, bb);
-    boundingBox->x = int(bb.x);
-    boundingBox->y = int(bb.y);
-    boundingBox->width = int(bb.width);
-    boundingBox->height = int(bb.height);
-    return ret;
+    try {
+        cv::Rect bb;
+        bool ret = (*self)->update(*image, bb);
+        boundingBox->x = int(bb.x);
+        boundingBox->y = int(bb.y);
+        boundingBox->width = int(bb.width);
+        boundingBox->height = int(bb.height);
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 TrackerKCF TrackerKCF_Create() {
-    return new cv::Ptr<cv::TrackerKCF>(cv::TrackerKCF::create());
+    try {
+        return new cv::Ptr<cv::TrackerKCF>(cv::TrackerKCF::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void TrackerKCF_Close(TrackerKCF self) {
@@ -28,7 +42,12 @@ void TrackerKCF_Close(TrackerKCF self) {
 }
 
 TrackerCSRT TrackerCSRT_Create() {
-    return new cv::Ptr<cv::TrackerCSRT>(cv::TrackerCSRT::create());
+    try {
+        return new cv::Ptr<cv::TrackerCSRT>(cv::TrackerCSRT::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void TrackerCSRT_Close(TrackerCSRT self) {

--- a/contrib/wechat_qrcode.cpp
+++ b/contrib/wechat_qrcode.cpp
@@ -4,10 +4,15 @@ WeChatQRCode NewWeChatQRCode(const char *detector_prototxt_path,
                              const char *detector_caffe_model_path,
                              const char *super_resolution_prototxt_path,
                              const char *super_resolution_caffe_model_path) {
-    return new cv::Ptr<cv::wechat_qrcode::WeChatQRCode>(
+    try {
+        return new cv::Ptr<cv::wechat_qrcode::WeChatQRCode>(
             cv::makePtr<cv::wechat_qrcode::WeChatQRCode>(detector_prototxt_path, detector_caffe_model_path,
                                                          super_resolution_prototxt_path,
                                                          super_resolution_caffe_model_path));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 StringsVector NewStringsVector() {
@@ -22,7 +27,11 @@ void WeChatQRCode_CStrings_Close(struct CStrings cstrs) {
 }
 
 void WeChatQRCode_Mats_to(struct Mats mats, int i, Mat dst) {
-    mats.mats[i]->copyTo(*dst);;
+    try {
+        mats.mats[i]->copyTo(*dst);;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void WeChatQRCode_Mats_Close(struct Mats mats) {
@@ -31,25 +40,29 @@ void WeChatQRCode_Mats_Close(struct Mats mats) {
 
 
 CStrings WeChatQRCode_DetectAndDecode(WeChatQRCode wq, Mat img, struct Mats *points, StringsVector codes) {
-    std::vector <cv::Mat> Points;
-    *codes = ((*wq)->detectAndDecode(*img, Points));
-    CStrings results;
-
-    points->mats = new Mat[Points.size()];
-
-    for (size_t i = 0; i < Points.size(); ++i) {
-        points->mats[i] = new cv::Mat(Points[i]);
+    try {
+        std::vector <cv::Mat> Points;
+        *codes = ((*wq)->detectAndDecode(*img, Points));
+        CStrings results;
+    
+        points->mats = new Mat[Points.size()];
+    
+        for (size_t i = 0; i < Points.size(); ++i) {
+            points->mats[i] = new cv::Mat(Points[i]);
+        }
+        points->length = (int) Points.size();
+    
+        const char **decodes = new const char *[codes->size()];
+    
+        for (size_t i = 0; i < codes->size(); ++i) {
+            decodes[i] = (*codes)[i].c_str();
+        }
+        (&results)->length = codes->size();
+        (&results)->strs = decodes;
+        return results;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        CStrings results;
+        return results;
     }
-    points->length = (int) Points.size();
-
-
-    const char **decodes = new const char *[codes->size()];
-
-
-    for (size_t i = 0; i < codes->size(); ++i) {
-        decodes[i] = (*codes)[i].c_str();
-    }
-    (&results)->length = codes->size();
-    (&results)->strs = decodes;
-    return results;
 }

--- a/contrib/xfeatures2d.cpp
+++ b/contrib/xfeatures2d.cpp
@@ -2,11 +2,21 @@
 
 
 SURF SURF_Create() {
-    return new cv::Ptr<cv::xfeatures2d::SURF>(cv::xfeatures2d::SURF::create());
+    try {
+        return new cv::Ptr<cv::xfeatures2d::SURF>(cv::xfeatures2d::SURF::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 SURF SURF_CreateWithParams(double hessianThreshold, int nOctaves, int nOctaveLayers, bool extended, bool upright) {
-    return new cv::Ptr<cv::xfeatures2d::SURF>(cv::xfeatures2d::SURF::create(hessianThreshold, nOctaves, nOctaveLayers, extended, upright));
+    try {
+        return new cv::Ptr<cv::xfeatures2d::SURF>(cv::xfeatures2d::SURF::create(hessianThreshold, nOctaves, nOctaveLayers, extended, upright));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void SURF_Close(SURF d) {
@@ -14,69 +24,97 @@ void SURF_Close(SURF d) {
 }
 
 struct KeyPoints SURF_Detect(SURF d, Mat src) {
-    std::vector<cv::KeyPoint> detected;
-    (*d)->detect(*src, detected);
-
-    KeyPoint* kps = new KeyPoint[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
-                      detected[i].response, detected[i].octave, detected[i].class_id
-                     };
-        kps[i] = k;
+    try {
+        std::vector<cv::KeyPoint> detected;
+        (*d)->detect(*src, detected);
+    
+        KeyPoint* kps = new KeyPoint[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
+                          detected[i].response, detected[i].octave, detected[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoints ret = {NULL, 0};
+        return ret;
     }
-
-    KeyPoints ret = {kps, (int)detected.size()};
-    return ret;
 }
 
 struct KeyPoints SURF_Compute(SURF d, Mat src, struct KeyPoints kp, Mat desc) {
-    std::vector<cv::KeyPoint> computed;
-    for (size_t i = 0; i < kp.length; i++) {
-        cv::KeyPoint k = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
-            kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
-            kp.keypoints[i].octave, kp.keypoints[i].classID);
-        computed.push_back(k);
+    try {
+        std::vector<cv::KeyPoint> computed;
+        for (size_t i = 0; i < kp.length; i++) {
+            cv::KeyPoint k = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
+                kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
+                kp.keypoints[i].octave, kp.keypoints[i].classID);
+            computed.push_back(k);
+        }
+    
+        (*d)->compute(*src, computed, *desc);
+    
+        KeyPoint* kps = new KeyPoint[computed.size()];
+    
+        for (size_t i = 0; i < computed.size(); ++i) {
+            KeyPoint k = {computed[i].pt.x, computed[i].pt.y, computed[i].size, computed[i].angle,
+                          computed[i].response, computed[i].octave, computed[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)computed.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoints ret = {NULL, 0};
+        return ret;
     }
-
-    (*d)->compute(*src, computed, *desc);
-
-    KeyPoint* kps = new KeyPoint[computed.size()];
-
-    for (size_t i = 0; i < computed.size(); ++i) {
-        KeyPoint k = {computed[i].pt.x, computed[i].pt.y, computed[i].size, computed[i].angle,
-                      computed[i].response, computed[i].octave, computed[i].class_id
-                     };
-        kps[i] = k;
-    }
-
-    KeyPoints ret = {kps, (int)computed.size()};
-    return ret;
 }
 
 struct KeyPoints SURF_DetectAndCompute(SURF d, Mat src, Mat mask, Mat desc) {
-    std::vector<cv::KeyPoint> detected;
-    (*d)->detectAndCompute(*src, *mask, detected, *desc);
-
-    KeyPoint* kps = new KeyPoint[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
-                      detected[i].response, detected[i].octave, detected[i].class_id
-                     };
-        kps[i] = k;
+    try {
+        std::vector<cv::KeyPoint> detected;
+        (*d)->detectAndCompute(*src, *mask, detected, *desc);
+    
+        KeyPoint* kps = new KeyPoint[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
+                          detected[i].response, detected[i].octave, detected[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoints ret = {NULL, 0};
+        return ret;
     }
-
-    KeyPoints ret = {kps, (int)detected.size()};
-    return ret;
 }
 
 BriefDescriptorExtractor BriefDescriptorExtractor_Create() {
-    return new cv::Ptr<cv::xfeatures2d::BriefDescriptorExtractor>(cv::xfeatures2d::BriefDescriptorExtractor::create());
+    try {
+        return new cv::Ptr<cv::xfeatures2d::BriefDescriptorExtractor>(cv::xfeatures2d::BriefDescriptorExtractor::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 BriefDescriptorExtractor BriefDescriptorExtractor_CreateWithParams(int bytes, bool useOrientation) {
-    return new cv::Ptr<cv::xfeatures2d::BriefDescriptorExtractor>(cv::xfeatures2d::BriefDescriptorExtractor::create(bytes, useOrientation));
+    try {
+        return new cv::Ptr<cv::xfeatures2d::BriefDescriptorExtractor>(cv::xfeatures2d::BriefDescriptorExtractor::create(bytes, useOrientation));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void BriefDescriptorExtractor_Close(BriefDescriptorExtractor b) {
@@ -84,16 +122,20 @@ void BriefDescriptorExtractor_Close(BriefDescriptorExtractor b) {
 }
 
 void BriefDescriptorExtractor_Compute(BriefDescriptorExtractor b, Mat src, struct KeyPoints kp, Mat desc) {
-    std::vector<cv::KeyPoint> keypts;
-    keypts.reserve(kp.length);
-    cv::KeyPoint keypt;
-
-    for (int i = 0; i < kp.length; ++i) {
-        keypt = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
-                        kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
-                        kp.keypoints[i].octave, kp.keypoints[i].classID);
-        keypts.push_back(keypt);
+    try {
+        std::vector<cv::KeyPoint> keypts;
+        keypts.reserve(kp.length);
+        cv::KeyPoint keypt;
+    
+        for (int i = 0; i < kp.length; ++i) {
+            keypt = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
+                            kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
+                            kp.keypoints[i].octave, kp.keypoints[i].classID);
+            keypts.push_back(keypt);
+        }
+    
+        (*b)->compute(*src, keypts, *desc);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    (*b)->compute(*src, keypts, *desc);
 }

--- a/contrib/ximgproc.cpp
+++ b/contrib/ximgproc.cpp
@@ -1,21 +1,41 @@
 #include "ximgproc.h"
 
 void anisotropicDiffusion(Mat src, Mat dst, float alpha, float K, int niters) {
-    cv::ximgproc::anisotropicDiffusion(*src, *dst, alpha, K, niters);	
+    try {
+        cv::ximgproc::anisotropicDiffusion(*src, *dst, alpha, K, niters);	
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void edgePreservingFilter(Mat src, Mat dst, int d, float threshold) {
-    cv::ximgproc::edgePreservingFilter(*src, *dst, d, threshold);
+    try {
+        cv::ximgproc::edgePreservingFilter(*src, *dst, d, threshold);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void niBlackThreshold(Mat src, Mat dst, float maxValue, int type, int blockSize, float k, int binarizationMethod, float r) {
-    cv::ximgproc::niBlackThreshold(*src, *dst, maxValue, type, blockSize, k, binarizationMethod, r);
+    try {
+        cv::ximgproc::niBlackThreshold(*src, *dst, maxValue, type, blockSize, k, binarizationMethod, r);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void PeiLinNormalization(Mat src, Mat dst) {
-    cv::ximgproc::PeiLinNormalization(*src, *dst);
+    try {
+        cv::ximgproc::PeiLinNormalization(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void thinning(Mat src, Mat dst, int typ) {
-    cv::ximgproc::thinning(*src, *dst, typ);
+    try {
+        cv::ximgproc::thinning(*src, *dst, typ);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }

--- a/contrib/ximgproc.cpp
+++ b/contrib/ximgproc.cpp
@@ -1,41 +1,46 @@
 #include "ximgproc.h"
 
-void anisotropicDiffusion(Mat src, Mat dst, float alpha, float K, int niters) {
+OpenCVResult anisotropicDiffusion(Mat src, Mat dst, float alpha, float K, int niters) {
     try {
         cv::ximgproc::anisotropicDiffusion(*src, *dst, alpha, K, niters);	
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void edgePreservingFilter(Mat src, Mat dst, int d, float threshold) {
+OpenCVResult edgePreservingFilter(Mat src, Mat dst, int d, float threshold) {
     try {
         cv::ximgproc::edgePreservingFilter(*src, *dst, d, threshold);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void niBlackThreshold(Mat src, Mat dst, float maxValue, int type, int blockSize, float k, int binarizationMethod, float r) {
+OpenCVResult niBlackThreshold(Mat src, Mat dst, float maxValue, int type, int blockSize, float k, int binarizationMethod, float r) {
     try {
         cv::ximgproc::niBlackThreshold(*src, *dst, maxValue, type, blockSize, k, binarizationMethod, r);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void PeiLinNormalization(Mat src, Mat dst) {
+OpenCVResult PeiLinNormalization(Mat src, Mat dst) {
     try {
         cv::ximgproc::PeiLinNormalization(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void thinning(Mat src, Mat dst, int typ) {
+OpenCVResult thinning(Mat src, Mat dst, int typ) {
     try {
         cv::ximgproc::thinning(*src, *dst, typ);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }

--- a/contrib/ximgproc.go
+++ b/contrib/ximgproc.go
@@ -15,16 +15,16 @@ import (
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/d2d/group__ximgproc.html#gaffedd976e0a8efb5938107acab185ec2
-func AnisotropicDiffusion(src gocv.Mat, dst *gocv.Mat, alpha float32, k float32, niters int) {
-	C.anisotropicDiffusion(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.float(alpha), C.float(k), C.int(niters))
+func AnisotropicDiffusion(src gocv.Mat, dst *gocv.Mat, alpha float32, k float32, niters int) error {
+	return OpenCVResult(C.anisotropicDiffusion(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.float(alpha), C.float(k), C.int(niters)))
 }
 
 // EdgePreservingFilter smoothes an image using the Edge-Preserving filter.
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/d2d/group__ximgproc.html#ga86fcda65ced0aafa2741088d82e9161c
-func EdgePreservingFilter(src gocv.Mat, dst *gocv.Mat, d int, threshold float32) {
-	C.edgePreservingFilter(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.int(d), C.float(threshold))
+func EdgePreservingFilter(src gocv.Mat, dst *gocv.Mat, d int, threshold float32) error {
+	return OpenCVResult(C.edgePreservingFilter(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.int(d), C.float(threshold)))
 }
 
 type BinarizationMethod int
@@ -42,9 +42,9 @@ const (
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/d2d/group__ximgproc.html#gab042a5032bbb85275f1fd3e04e7c7660
 func NiblackThreshold(src gocv.Mat, dst *gocv.Mat, maxValue float32,
-	typ gocv.ThresholdType, blockSize int, k float32, binarizationMethod BinarizationMethod, r float32) {
-	C.niBlackThreshold(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.float(maxValue), C.int(typ),
-		C.int(blockSize), C.float(k), C.int(binarizationMethod), C.float(r))
+	typ gocv.ThresholdType, blockSize int, k float32, binarizationMethod BinarizationMethod, r float32) error {
+	return OpenCVResult(C.niBlackThreshold(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.float(maxValue), C.int(typ),
+		C.int(blockSize), C.float(k), C.int(binarizationMethod), C.float(r)))
 }
 
 // PeiLinNormalization calculates an affine transformation that normalize
@@ -52,8 +52,8 @@ func NiblackThreshold(src gocv.Mat, dst *gocv.Mat, maxValue float32,
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/d2d/group__ximgproc.html#ga50d064b92f63916f4162474eea22d656
-func PeiLinNormalization(src gocv.Mat, dst *gocv.Mat) {
-	C.PeiLinNormalization(C.Mat(src.Ptr()), C.Mat(dst.Ptr()))
+func PeiLinNormalization(src gocv.Mat, dst *gocv.Mat) error {
+	return OpenCVResult(C.PeiLinNormalization(C.Mat(src.Ptr()), C.Mat(dst.Ptr())))
 }
 
 type ThinningType int
@@ -71,6 +71,6 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/d2d/group__ximgproc.html#ga37002c6ca80c978edb6ead5d6b39740c
-func Thinning(src gocv.Mat, dst *gocv.Mat, typ ThinningType) {
-	C.thinning(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.int(typ))
+func Thinning(src gocv.Mat, dst *gocv.Mat, typ ThinningType) error {
+	return OpenCVResult(C.thinning(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.int(typ)))
 }

--- a/contrib/ximgproc.h
+++ b/contrib/ximgproc.h
@@ -9,11 +9,11 @@ extern "C" {
 
 #include "../core.h"
 
-void anisotropicDiffusion(Mat src, Mat dst, float alpha, float K, int niters);
-void edgePreservingFilter(Mat src, Mat dst, int d, float threshold);
-void niBlackThreshold(Mat src, Mat dst, float maxValue, int type, int blockSize, float k, int binarizationMethod, float r);
-void PeiLinNormalization(Mat src, Mat dst);
-void thinning(Mat src, Mat dst, int typ);
+OpenCVResult anisotropicDiffusion(Mat src, Mat dst, float alpha, float K, int niters);
+OpenCVResult edgePreservingFilter(Mat src, Mat dst, int d, float threshold);
+OpenCVResult niBlackThreshold(Mat src, Mat dst, float maxValue, int type, int blockSize, float k, int binarizationMethod, float r);
+OpenCVResult PeiLinNormalization(Mat src, Mat dst);
+OpenCVResult thinning(Mat src, Mat dst, int typ);
 
 #ifdef __cplusplus
 }

--- a/contrib/ximgproc_test.go
+++ b/contrib/ximgproc_test.go
@@ -1,8 +1,9 @@
 package contrib
 
 import (
-	"gocv.io/x/gocv"
 	"testing"
+
+	"gocv.io/x/gocv"
 )
 
 func TestAnisotropicDiffusion(t *testing.T) {
@@ -15,6 +16,21 @@ func TestAnisotropicDiffusion(t *testing.T) {
 
 	if src.Empty() || dst.Rows() != src.Rows() {
 		t.Error("invalid AnisotropicDiffusion test")
+	}
+}
+
+func TestAnisotropicDiffusionException(t *testing.T) {
+	src := gocv.NewMat()
+	defer src.Close()
+	dst := gocv.NewMat()
+	defer dst.Close()
+
+	err := AnisotropicDiffusion(src, &dst, 0.5, 0.5, 100)
+	if err == nil {
+		t.Error("Expected exception in test")
+	}
+	if len(err.Error()) == 0 {
+		t.Error("Expected exception message in test")
 	}
 }
 

--- a/contrib/xobjdetect.cpp
+++ b/contrib/xobjdetect.cpp
@@ -1,7 +1,12 @@
 #include "xobjdetect.h"
 
 WBDetector WBDetector_Create(){
-    return new cv::Ptr<cv::xobjdetect::WBDetector>(cv::xobjdetect::WBDetector::create());
+    try {
+        return new cv::Ptr<cv::xobjdetect::WBDetector>(cv::xobjdetect::WBDetector::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void WBDetector_Close(WBDetector det){
@@ -9,43 +14,61 @@ void WBDetector_Close(WBDetector det){
 }
 
 WBDetector_detect_result WBDetector_Detect(WBDetector det, Mat img){
-    std::vector<cv::Rect> bb;
-    std::vector<double> conf;
-    WBDetector_detect_result result;
-
-    (*det)->detect(*img, bb, conf);
-
-    Rect* result_rects = (Rect*)malloc(bb.size()*sizeof(Rect));
-    float* result_confs = (float*)malloc(conf.size()*sizeof(float));
-
-    for(int i = 0; i < bb.size(); i ++) {
-        result_rects[i].x = bb[i].x;
-        result_rects[i].y = bb[i].y;
-        result_rects[i].width = bb[i].width;
-        result_rects[i].height = bb[i].height;
+    try {
+        std::vector<cv::Rect> bb;
+        std::vector<double> conf;
+        WBDetector_detect_result result;
+    
+        (*det)->detect(*img, bb, conf);
+    
+        Rect* result_rects = (Rect*)malloc(bb.size()*sizeof(Rect));
+        float* result_confs = (float*)malloc(conf.size()*sizeof(float));
+    
+        for(int i = 0; i < bb.size(); i ++) {
+            result_rects[i].x = bb[i].x;
+            result_rects[i].y = bb[i].y;
+            result_rects[i].width = bb[i].width;
+            result_rects[i].height = bb[i].height;
+        }
+    
+        for(int i = 0; i < conf.size(); i ++){
+            result_confs[i] = conf[i];
+        }
+    
+        result.bboxes.rects = result_rects;
+        result.bboxes.length = bb.size();
+    
+        result.confidences.val = result_confs;
+        result.confidences.length = conf.size();
+    
+        return result;    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        WBDetector_detect_result result;
+        return result;
     }
-
-    for(int i = 0; i < conf.size(); i ++){
-        result_confs[i] = conf[i];
-    }
-
-    result.bboxes.rects = result_rects;
-    result.bboxes.length = bb.size();
-
-    result.confidences.val = result_confs;
-    result.confidences.length = conf.size();
-
-    return result;
 }
 
 void WBDetector_Read(WBDetector det, FileNode node){
-    (*det)->read(*node);    
+    try {
+        (*det)->read(*node);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void WBDetector_Train(WBDetector det, const char* pos_samples, const char* neg_imgs){
-    (*det)->train(pos_samples, neg_imgs);
+    try {
+        (*det)->train(pos_samples, neg_imgs);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void WBDetector_Write(WBDetector det, FileStorage fs){
-    (*det)->write(*fs);
+    try {
+        (*det)->write(*fs);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }

--- a/contrib/xphoto.cpp
+++ b/contrib/xphoto.cpp
@@ -1,14 +1,15 @@
 #include "xphoto.h"
 
-void Xphoto_ApplyChannelGains(Mat src, Mat dst, float gainB, float gainG, float gainR) {
+OpenCVResult Xphoto_ApplyChannelGains(Mat src, Mat dst, float gainB, float gainG, float gainR) {
     try {
         cv::xphoto::applyChannelGains(*src, *dst, gainB, gainG, gainR);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Xphoto_Bm3dDenoising_Step(Mat src, Mat dststep1, Mat dststep2) {
+OpenCVResult Xphoto_Bm3dDenoising_Step(Mat src, Mat dststep1, Mat dststep2) {
     try {
         cv::xphoto::bm3dDenoising(
             *src, *dststep1, *dststep2,
@@ -19,13 +20,14 @@ void Xphoto_Bm3dDenoising_Step(Mat src, Mat dststep1, Mat dststep2) {
             cv::NORM_L2, cv::xphoto::BM3D_STEPALL,
             cv::xphoto::HAAR
         );
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
 
-void Xphoto_Bm3dDenoising_Step_WithParams(
+OpenCVResult Xphoto_Bm3dDenoising_Step_WithParams(
     Mat src, Mat dststep1, Mat dststep2,
     float h, int templateWindowSize,
     int searchWindowSize, int blockMatchingStep1,
@@ -44,12 +46,13 @@ void Xphoto_Bm3dDenoising_Step_WithParams(
             normType, step,
             transformType
         );    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Xphoto_Bm3dDenoising(Mat src, Mat dst) {
+OpenCVResult Xphoto_Bm3dDenoising(Mat src, Mat dst) {
     try {
         cv::xphoto::bm3dDenoising(*src, *dst,
             1, 4,
@@ -59,12 +62,15 @@ void Xphoto_Bm3dDenoising(Mat src, Mat dst) {
             cv::NORM_L2, cv::xphoto::BM3D_STEPALL,
             cv::xphoto::HAAR
            );
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+           OpenCVResult result = {0, NULL};
+           return result;
+    } catch(const cv::Exception& e) {
+        OpenCVResult result = {e.code, e.what()};
+        return result;
     }
 }
 
-void Xphoto_Bm3dDenoising_WithParams(
+OpenCVResult Xphoto_Bm3dDenoising_WithParams(
     Mat src, Mat dst, float h, int templateWindowSize,
     int searchWindowSize, int blockMatchingStep1,
     int blockMatchingStep2, int groupSize,
@@ -80,8 +86,11 @@ void Xphoto_Bm3dDenoising_WithParams(
             normType, step,
             transformType
            );
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+           OpenCVResult result = {0, NULL};
+           return result;
+    } catch(const cv::Exception& e) {
+        OpenCVResult result = {e.code, e.what()};
+        return result;
     }
 }
 
@@ -117,11 +126,12 @@ float GrayworldWB_GetSaturationThreshold(GrayworldWB b) {
     }
 }
 
-void GrayworldWB_BalanceWhite(GrayworldWB b, Mat src, Mat dst) {
+OpenCVResult GrayworldWB_BalanceWhite(GrayworldWB b, Mat src, Mat dst) {
     try {
         (*b)->balanceWhite(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -150,11 +160,12 @@ void LearningBasedWB_Close(LearningBasedWB b) {
     delete b;
 }
 
-void LearningBasedWB_ExtractSimpleFeatures(LearningBasedWB b, Mat src, Mat dst) {
+OpenCVResult LearningBasedWB_ExtractSimpleFeatures(LearningBasedWB b, Mat src, Mat dst) {
     try {
         (*b)->extractSimpleFeatures(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -209,11 +220,12 @@ void LearningBasedWB_SetSaturationThreshold(LearningBasedWB b, float val) {
     }
 }
 
-void LearningBasedWB_BalanceWhite(LearningBasedWB b, Mat src, Mat dst) {
+OpenCVResult LearningBasedWB_BalanceWhite(LearningBasedWB b, Mat src, Mat dst) {
     try {
         (*b)->balanceWhite(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -328,11 +340,12 @@ void SimpleWB_SetP(SimpleWB b, float val) {
     }
 }
 
-void SimpleWB_BalanceWhite(SimpleWB b, Mat src, Mat dst) {
+OpenCVResult SimpleWB_BalanceWhite(SimpleWB b, Mat src, Mat dst) {
     try {
         (*b)->balanceWhite(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -449,36 +462,40 @@ void TonemapDurand_SetGamma(TonemapDurand b, float gamma) {
     }
 }
 
-void TonemapDurand_Process(TonemapDurand b, Mat src, Mat dst) {
+OpenCVResult TonemapDurand_Process(TonemapDurand b, Mat src, Mat dst) {
     try {
         (*b)->process(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
 // -------------------- cv::xphoto::Inpaint --------------------
 
-void Inpaint(Mat src, Mat mask, Mat dst, int algorithmType) {
+OpenCVResult Inpaint(Mat src, Mat mask, Mat dst, int algorithmType) {
     try {
         cv::xphoto::inpaint(*src, *mask, *dst, algorithmType);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void OilPaintingWithParams(Mat src, Mat dst, int size, int dynRatio, int code) {
+OpenCVResult OilPaintingWithParams(Mat src, Mat dst, int size, int dynRatio, int code) {
     try {
         cv::xphoto::oilPainting(*src, *dst, size, dynRatio, code);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void OilPainting(Mat src, Mat dst, int size, int dynRatio) {
+OpenCVResult OilPainting(Mat src, Mat dst, int size, int dynRatio) {
     try {
         cv::xphoto::oilPainting(*src, *dst, size, dynRatio);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }

--- a/contrib/xphoto.cpp
+++ b/contrib/xphoto.cpp
@@ -1,20 +1,27 @@
 #include "xphoto.h"
 
 void Xphoto_ApplyChannelGains(Mat src, Mat dst, float gainB, float gainG, float gainR) {
-    cv::xphoto::applyChannelGains(*src, *dst, gainB, gainG, gainR);
+    try {
+        cv::xphoto::applyChannelGains(*src, *dst, gainB, gainG, gainR);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Xphoto_Bm3dDenoising_Step(Mat src, Mat dststep1, Mat dststep2) {
-
-    cv::xphoto::bm3dDenoising(
-        *src, *dststep1, *dststep2,
-        1, 4,
-        16, 2500,
-        400, 8,
-        1, 2.0f,
-        cv::NORM_L2, cv::xphoto::BM3D_STEPALL,
-        cv::xphoto::HAAR
-    );
+    try {
+        cv::xphoto::bm3dDenoising(
+            *src, *dststep1, *dststep2,
+            1, 4,
+            16, 2500,
+            400, 8,
+            1, 2.0f,
+            cv::NORM_L2, cv::xphoto::BM3D_STEPALL,
+            cv::xphoto::HAAR
+        );
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 
@@ -27,29 +34,34 @@ void Xphoto_Bm3dDenoising_Step_WithParams(
     int normType, int step,
     int transformType
 ) {
-
-    cv::xphoto::bm3dDenoising(
-        *src, *dststep1, *dststep2,
-        h, templateWindowSize,
-        searchWindowSize, blockMatchingStep1,
-        blockMatchingStep2, groupSize,
-        slidingStep, beta,
-        normType, step,
-        transformType
-    );
+    try {
+        cv::xphoto::bm3dDenoising(
+            *src, *dststep1, *dststep2,
+            h, templateWindowSize,
+            searchWindowSize, blockMatchingStep1,
+            blockMatchingStep2, groupSize,
+            slidingStep, beta,
+            normType, step,
+            transformType
+        );    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Xphoto_Bm3dDenoising(Mat src, Mat dst) {
-
-    cv::xphoto::bm3dDenoising(*src, *dst,
-                              1, 4,
-                              16, 2500,
-                              400, 8,
-                              1, 2.0f,
-                              cv::NORM_L2, cv::xphoto::BM3D_STEPALL,
-                              cv::xphoto::HAAR
-                             );
-
+    try {
+        cv::xphoto::bm3dDenoising(*src, *dst,
+            1, 4,
+            16, 2500,
+            400, 8,
+            1, 2.0f,
+            cv::NORM_L2, cv::xphoto::BM3D_STEPALL,
+            cv::xphoto::HAAR
+           );
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Xphoto_Bm3dDenoising_WithParams(
@@ -60,24 +72,28 @@ void Xphoto_Bm3dDenoising_WithParams(
     int normType, int step,
     int transformType
 ) {
-
-    cv::xphoto::bm3dDenoising(*src, *dst, h, templateWindowSize,
-                              searchWindowSize, blockMatchingStep1,
-                              blockMatchingStep2, groupSize,
-                              slidingStep, beta,
-                              normType, step,
-                              transformType
-                             );
-
+    try {
+        cv::xphoto::bm3dDenoising(*src, *dst, h, templateWindowSize,
+            searchWindowSize, blockMatchingStep1,
+            blockMatchingStep2, groupSize,
+            slidingStep, beta,
+            normType, step,
+            transformType
+           );
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
-
-
-
 
 // ----------------------- GrayworldWB -----------------------
 
 GrayworldWB GrayworldWB_Create() {
-    return new cv::Ptr<cv::xphoto::GrayworldWB>(cv::xphoto::createGrayworldWB());
+    try {
+        return new cv::Ptr<cv::xphoto::GrayworldWB>(cv::xphoto::createGrayworldWB());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void GrayworldWB_Close(GrayworldWB b) {
@@ -85,26 +101,49 @@ void GrayworldWB_Close(GrayworldWB b) {
 }
 
 void GrayworldWB_SetSaturationThreshold(GrayworldWB b, float saturationThreshold) {
-    (*b)->setSaturationThreshold(saturationThreshold);
+    try {
+        (*b)->setSaturationThreshold(saturationThreshold);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 float GrayworldWB_GetSaturationThreshold(GrayworldWB b) {
-    return (*b)->getSaturationThreshold();
+    try {
+        return (*b)->getSaturationThreshold();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void GrayworldWB_BalanceWhite(GrayworldWB b, Mat src, Mat dst) {
-    (*b)->balanceWhite(*src, *dst);
+    try {
+        (*b)->balanceWhite(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 // ----------------------- LearningBasedWB -----------------------
 
 LearningBasedWB LearningBasedWB_Create() {
-    return new cv::Ptr<cv::xphoto::LearningBasedWB>(cv::xphoto::createLearningBasedWB());
+    try {
+        return new cv::Ptr<cv::xphoto::LearningBasedWB>(cv::xphoto::createLearningBasedWB());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 LearningBasedWB LearningBasedWB_CreateWithParams(const char* pathmodel) {
-    cv::String path(pathmodel);
-    return new cv::Ptr<cv::xphoto::LearningBasedWB>(cv::xphoto::createLearningBasedWB(path));
+    try {
+        cv::String path(pathmodel);
+        return new cv::Ptr<cv::xphoto::LearningBasedWB>(cv::xphoto::createLearningBasedWB(path));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void LearningBasedWB_Close(LearningBasedWB b) {
@@ -112,42 +151,82 @@ void LearningBasedWB_Close(LearningBasedWB b) {
 }
 
 void LearningBasedWB_ExtractSimpleFeatures(LearningBasedWB b, Mat src, Mat dst) {
-    (*b)->extractSimpleFeatures(*src, *dst);
+    try {
+        (*b)->extractSimpleFeatures(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 int LearningBasedWB_GetHistBinNum(LearningBasedWB b)  {
-    return (*b)->getHistBinNum();
+    try {
+        return (*b)->getHistBinNum();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 int LearningBasedWB_GetRangeMaxVal(LearningBasedWB b)  {
-    return (*b)->getRangeMaxVal();
+    try {
+        return (*b)->getRangeMaxVal();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 float LearningBasedWB_GetSaturationThreshold(LearningBasedWB b)  {
-    return (*b)->getSaturationThreshold();
+    try {
+        return (*b)->getSaturationThreshold();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void LearningBasedWB_SetHistBinNum(LearningBasedWB b, int val)  {
-    (*b)->setHistBinNum(val);
+    try {
+        (*b)->setHistBinNum(val);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void LearningBasedWB_SetRangeMaxVal(LearningBasedWB b, int val) {
-    (*b)->setRangeMaxVal(val);
+    try {
+        (*b)->setRangeMaxVal(val);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void LearningBasedWB_SetSaturationThreshold(LearningBasedWB b, float val) {
-    (*b)->setSaturationThreshold(val);
+    try {
+        (*b)->setSaturationThreshold(val);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void LearningBasedWB_BalanceWhite(LearningBasedWB b, Mat src, Mat dst) {
-    (*b)->balanceWhite(*src, *dst);
+    try {
+        (*b)->balanceWhite(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 // ----------------------- SimpleWB -----------------------
 
 
 SimpleWB SimpleWB_Create() {
-    return new cv::Ptr<cv::xphoto::SimpleWB>(cv::xphoto::createSimpleWB());
+    try {
+        return new cv::Ptr<cv::xphoto::SimpleWB>(cv::xphoto::createSimpleWB());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void SimpleWB_Close(SimpleWB b) {
@@ -156,71 +235,129 @@ void SimpleWB_Close(SimpleWB b) {
 
 //  Input image range maximum value.
 float SimpleWB_GetInputMax(SimpleWB b) {
-    return (*b)->getInputMax();
+    try {
+        return (*b)->getInputMax();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 //  Input image range minimum value.
 float SimpleWB_GetInputMin(SimpleWB b) {
-    return (*b)->getInputMin();
+    try {
+        return (*b)->getInputMin();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 //  Output image range maximum value.
 float SimpleWB_GetOutputMax(SimpleWB b) {
-    return (*b)->getOutputMax();
+    try {
+        return (*b)->getOutputMax();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 //  Output image range minimum value.
 float SimpleWB_GetOutputMin(SimpleWB b) {
-    return (*b)->getOutputMin();
+    try {
+        return (*b)->getOutputMin();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 //  Percent of top/bottom values to ignore.
 float SimpleWB_GetP(SimpleWB b) {
-    return (*b)->getP();
+    try {
+        return (*b)->getP();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 //  Input image range maximum value.
 void SimpleWB_SetInputMax(SimpleWB b, float val) {
-    return (*b)->setInputMax(val);
+    try {
+        (*b)->setInputMax(val);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 //  Input image range minimum value.
 void SimpleWB_SetInputMin(SimpleWB b, float val) {
-    return (*b)->setInputMin(val);
+    try {
+        (*b)->setInputMin(val);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 //  Output image range maximum value.
 void SimpleWB_SetOutputMax(SimpleWB b, float val) {
-    return (*b)->setOutputMax(val);
+    try {
+        (*b)->setOutputMax(val);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 //  Output image range minimum value.
 void SimpleWB_SetOutputMin(SimpleWB b, float val) {
-    return (*b)->setOutputMin(val);
+    try {
+        (*b)->setOutputMin(val);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 //  Percent of top/bottom values to ignore.
 void SimpleWB_SetP(SimpleWB b, float val) {
-    return (*b)->setP(val);
+    try {
+        (*b)->setP(val);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void SimpleWB_BalanceWhite(SimpleWB b, Mat src, Mat dst) {
-    (*b)->balanceWhite(*src, *dst);
+    try {
+        (*b)->balanceWhite(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
-
 
 // -------------------- TonemapDurand --------------------
 
 // Creates TonemapDurand object. More...
 TonemapDurand TonemapDurand_Create() {
-    return new cv::Ptr<cv::xphoto::TonemapDurand>(cv::xphoto::createTonemapDurand(1.0f, 4.0f, 1.0f,
-            2.0f, 2.0f));
+    try {
+        return new cv::Ptr<cv::xphoto::TonemapDurand>(cv::xphoto::createTonemapDurand(1.0f, 4.0f, 1.0f, 2.0f, 2.0f));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 TonemapDurand TonemapDurand_CreateWithParams(float gamma, float contrast, float saturation,
         float sigma_color, float sigma_space) {
-    return new cv::Ptr<cv::xphoto::TonemapDurand>(cv::xphoto::createTonemapDurand(gamma, contrast,
+
+    try {
+        return new cv::Ptr<cv::xphoto::TonemapDurand>(cv::xphoto::createTonemapDurand(gamma, contrast,
             saturation, sigma_color, sigma_space));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void TonemapDurand_Close(TonemapDurand b) {
@@ -228,53 +365,120 @@ void TonemapDurand_Close(TonemapDurand b) {
 }
 
 float TonemapDurand_GetContrast(TonemapDurand b) {
-    return (*b)->getContrast();
+    try {
+        return (*b)->getContrast();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
+
 float TonemapDurand_GetSaturation(TonemapDurand b) {
-    return (*b)->getSaturation();
+    try {
+        return (*b)->getSaturation();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
+
 float TonemapDurand_GetSigmaColor(TonemapDurand b) {
-    return (*b)->getSigmaColor();
+    try {
+        return (*b)->getSigmaColor();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
+
 float TonemapDurand_GetSigmaSpace(TonemapDurand b) {
-    return (*b)->getSigmaSpace();
+    try {
+        return (*b)->getSigmaSpace();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void TonemapDurand_SetContrast(TonemapDurand b, float contrast) {
-    return (*b)->setContrast(contrast);
+    try {
+        (*b)->setContrast(contrast);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
+
 void TonemapDurand_SetSaturation(TonemapDurand b, float saturation) {
-    return (*b)->setSaturation(saturation);
+    try {
+        (*b)->setSaturation(saturation);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
+
 void TonemapDurand_SetSigmaColor(TonemapDurand b, float sigma_color) {
-    return (*b)->setSigmaColor(sigma_color);
+    try {
+        (*b)->setSigmaColor(sigma_color);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
+
 void TonemapDurand_SetSigmaSpace(TonemapDurand b, float sigma_space) {
-    return (*b)->setSigmaSpace(sigma_space);
+    try {
+        (*b)->setSigmaSpace(sigma_space);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 float TonemapDurand_GetGamma(TonemapDurand b) {
-    return (*b)->getGamma();
+    try {
+        return (*b)->getGamma();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void TonemapDurand_SetGamma(TonemapDurand b, float gamma) {
-    (*b)->setGamma(gamma);
+    try {
+        (*b)->setGamma(gamma);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void TonemapDurand_Process(TonemapDurand b, Mat src, Mat dst) {
-    (*b)->process(*src, *dst);
+    try {
+        (*b)->process(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 // -------------------- cv::xphoto::Inpaint --------------------
 
 void Inpaint(Mat src, Mat mask, Mat dst, int algorithmType) {
-    cv::xphoto::inpaint(*src, *mask, *dst, algorithmType);
+    try {
+        cv::xphoto::inpaint(*src, *mask, *dst, algorithmType);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void OilPaintingWithParams(Mat src, Mat dst, int size, int dynRatio, int code) {
-    cv::xphoto::oilPainting(*src, *dst, size, dynRatio, code);
+    try {
+        cv::xphoto::oilPainting(*src, *dst, size, dynRatio, code);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void OilPainting(Mat src, Mat dst, int size, int dynRatio) {
-    cv::xphoto::oilPainting(*src, *dst, size, dynRatio);
+    try {
+        cv::xphoto::oilPainting(*src, *dst, size, dynRatio);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }

--- a/contrib/xphoto.go
+++ b/contrib/xphoto.go
@@ -6,8 +6,9 @@ package contrib
 */
 import "C"
 import (
-	"gocv.io/x/gocv"
 	"unsafe"
+
+	"gocv.io/x/gocv"
 )
 
 // GrayworldWB is a wrapper around the cv::xphoto::GrayworldWB.
@@ -61,15 +62,13 @@ const (
 // ----------------------- Bm3dDenoising -------------------------
 // ----------------------- ---------------------------------------
 
-func ApplyChannelGains(src gocv.Mat, dst *gocv.Mat, gainB float32, gainG float32, gainR float32) {
-	C.Xphoto_ApplyChannelGains(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.float(gainB), C.float(gainG), C.float(gainR))
-	return
+func ApplyChannelGains(src gocv.Mat, dst *gocv.Mat, gainB float32, gainG float32, gainR float32) error {
+	return OpenCVResult(C.Xphoto_ApplyChannelGains(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.float(gainB), C.float(gainG), C.float(gainR)))
 }
 
 // src = Input 8-bit or 16-bit 1-channel image.
-func Bm3dDenoisingStep(src gocv.Mat, dststep1 *gocv.Mat, dststep2 *gocv.Mat) {
-	C.Xphoto_Bm3dDenoising_Step(C.Mat(src.Ptr()), C.Mat(dststep1.Ptr()), C.Mat(dststep2.Ptr()))
-	return
+func Bm3dDenoisingStep(src gocv.Mat, dststep1 *gocv.Mat, dststep2 *gocv.Mat) error {
+	return OpenCVResult(C.Xphoto_Bm3dDenoising_Step(C.Mat(src.Ptr()), C.Mat(dststep1.Ptr()), C.Mat(dststep2.Ptr())))
 }
 
 // src = Input 8-bit or 16-bit 1-channel image.
@@ -79,20 +78,19 @@ func Bm3dDenoisingStepWithParams(src gocv.Mat, dststep1 *gocv.Mat, dststep2 *goc
 	blockMatchingStep2 int, groupSize int,
 	slidingStep int, beta float32,
 	normType gocv.NormType, step Bm3dSteps,
-	transformType TransformTypes) {
-	C.Xphoto_Bm3dDenoising_Step_WithParams(C.Mat(src.Ptr()), C.Mat(dststep1.Ptr()), C.Mat(dststep2.Ptr()),
+	transformType TransformTypes) error {
+	return OpenCVResult(C.Xphoto_Bm3dDenoising_Step_WithParams(C.Mat(src.Ptr()), C.Mat(dststep1.Ptr()), C.Mat(dststep2.Ptr()),
 		C.float(h), C.int(templateWindowSize),
 		C.int(searchWindowSize), C.int(blockMatchingStep1),
 		C.int(blockMatchingStep2), C.int(groupSize),
 		C.int(slidingStep), C.float(beta),
 		C.int(normType), C.int(step),
-		C.int(transformType))
-	return
+		C.int(transformType)))
 }
 
 // src = Input 8-bit or 16-bit 1-channel image.
-func Bm3dDenoising(src gocv.Mat, dst *gocv.Mat) {
-	C.Xphoto_Bm3dDenoising(C.Mat(src.Ptr()), C.Mat(dst.Ptr()))
+func Bm3dDenoising(src gocv.Mat, dst *gocv.Mat) error {
+	return OpenCVResult(C.Xphoto_Bm3dDenoising(C.Mat(src.Ptr()), C.Mat(dst.Ptr())))
 }
 
 // src = Input 8-bit or 16-bit 1-channel image.
@@ -102,16 +100,15 @@ func Bm3dDenoisingWithParams(src gocv.Mat, dst *gocv.Mat,
 	blockMatchingStep2 int, groupSize int,
 	slidingStep int, beta float32,
 	normType gocv.NormType, step Bm3dSteps,
-	transformType TransformTypes) {
+	transformType TransformTypes) error {
 
-	C.Xphoto_Bm3dDenoising_WithParams(C.Mat(src.Ptr()), C.Mat(dst.Ptr()),
+	return OpenCVResult(C.Xphoto_Bm3dDenoising_WithParams(C.Mat(src.Ptr()), C.Mat(dst.Ptr()),
 		C.float(h), C.int(templateWindowSize),
 		C.int(searchWindowSize), C.int(blockMatchingStep1),
 		C.int(blockMatchingStep2), C.int(groupSize),
 		C.int(slidingStep), C.float(beta),
 		C.int(normType), C.int(step),
-		C.int(transformType))
-	return
+		C.int(transformType)))
 }
 
 // ----------------------- ---------------------------------------
@@ -162,9 +159,8 @@ func (b *GrayworldWB) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/d71/classcv_1_1xphoto_1_1GrayworldWB.html#details
-func (b *GrayworldWB) BalanceWhite(src gocv.Mat, dst *gocv.Mat) {
-	C.GrayworldWB_BalanceWhite((C.GrayworldWB)(b.p), C.Mat(src.Ptr()), C.Mat(dst.Ptr()))
-	return
+func (b *GrayworldWB) BalanceWhite(src gocv.Mat, dst *gocv.Mat) error {
+	return OpenCVResult(C.GrayworldWB_BalanceWhite((C.GrayworldWB)(b.p), C.Mat(src.Ptr()), C.Mat(dst.Ptr())))
 }
 
 // ----------------------- ---------------------------------------
@@ -208,9 +204,8 @@ func (b *LearningBasedWB) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d3b/classcv_1_1xphoto_1_1LearningBasedWB.html#aeeaca052262a01d0feed6312ccb9a76e
-func (b *LearningBasedWB) ExtractSimpleFeatures(src gocv.Mat, dst *gocv.Mat) {
-	C.LearningBasedWB_ExtractSimpleFeatures((C.LearningBasedWB)(b.p), C.Mat(src.Ptr()), C.Mat(dst.Ptr()))
-	return
+func (b *LearningBasedWB) ExtractSimpleFeatures(src gocv.Mat, dst *gocv.Mat) error {
+	return OpenCVResult(C.LearningBasedWB_ExtractSimpleFeatures((C.LearningBasedWB)(b.p), C.Mat(src.Ptr()), C.Mat(dst.Ptr())))
 }
 
 // GetHistBinNum
@@ -274,9 +269,8 @@ func (b *LearningBasedWB) SetSaturationThreshold(val float32) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d7a/classcv_1_1xphoto_1_1WhiteBalancer.html#ae23838a1a54f101b255bca1a97418aa3
-func (b *LearningBasedWB) BalanceWhite(src gocv.Mat, dst *gocv.Mat) {
-	C.LearningBasedWB_BalanceWhite((C.LearningBasedWB)(b.p), C.Mat(src.Ptr()), C.Mat(dst.Ptr()))
-	return
+func (b *LearningBasedWB) BalanceWhite(src gocv.Mat, dst *gocv.Mat) error {
+	return OpenCVResult(C.LearningBasedWB_BalanceWhite((C.LearningBasedWB)(b.p), C.Mat(src.Ptr()), C.Mat(dst.Ptr())))
 }
 
 // ----------------------- ---------------------------------------
@@ -401,9 +395,8 @@ func (b *SimpleWB) SetP(val float32) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d9/d7a/classcv_1_1xphoto_1_1WhiteBalancer.html#ae23838a1a54f101b255bca1a97418aa3
-func (b *SimpleWB) BalanceWhite(src gocv.Mat, dst *gocv.Mat) {
-	C.SimpleWB_BalanceWhite((C.SimpleWB)(b.p), C.Mat(src.Ptr()), C.Mat(dst.Ptr()))
-	return
+func (b *SimpleWB) BalanceWhite(src gocv.Mat, dst *gocv.Mat) error {
+	return OpenCVResult(C.SimpleWB_BalanceWhite((C.SimpleWB)(b.p), C.Mat(src.Ptr()), C.Mat(dst.Ptr())))
 }
 
 // ----------------------- ---------------------------------------
@@ -532,9 +525,8 @@ func (b *TonemapDurand) SetGamma(val float32) {
 // Tonemaps image with gocv.MatTypeCV32FC3 type image
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d5e/classcv_1_1Tonemap.html#aa705c3b7226f7028a5c117dffab60fe4
-func (b *TonemapDurand) Process(src gocv.Mat, dst *gocv.Mat) {
-	C.TonemapDurand_Process((C.TonemapDurand)(b.p), C.Mat(src.Ptr()), C.Mat(dst.Ptr()))
-	return
+func (b *TonemapDurand) Process(src gocv.Mat, dst *gocv.Mat) error {
+	return OpenCVResult(C.TonemapDurand_Process((C.TonemapDurand)(b.p), C.Mat(src.Ptr()), C.Mat(dst.Ptr())))
 }
 
 // ----------------------- ---------------------------------------
@@ -545,8 +537,8 @@ func (b *TonemapDurand) Process(src gocv.Mat, dst *gocv.Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#gab4febba6be53e5fddc480b8cedf51eee
-func Inpaint(src *gocv.Mat, mask *gocv.Mat, dst *gocv.Mat, algorithmType InpaintTypes) {
-	C.Inpaint(C.Mat(src.Ptr()), C.Mat(mask.Ptr()), C.Mat(dst.Ptr()), C.int(algorithmType))
+func Inpaint(src *gocv.Mat, mask *gocv.Mat, dst *gocv.Mat, algorithmType InpaintTypes) error {
+	return OpenCVResult(C.Inpaint(C.Mat(src.Ptr()), C.Mat(mask.Ptr()), C.Mat(dst.Ptr()), C.int(algorithmType)))
 }
 
 // oilPainting, See the book for details :
@@ -554,8 +546,8 @@ func Inpaint(src *gocv.Mat, mask *gocv.Mat, dst *gocv.Mat, algorithmType Inpaint
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#gac050a6e876298cb9713cd2c09db9a027
-func OilPaintingWithParams(src gocv.Mat, dst gocv.Mat, size int, dynRatio int, code gocv.ColorConversionCode) {
-	C.OilPaintingWithParams(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.int(size), C.int(dynRatio), C.int(code))
+func OilPaintingWithParams(src gocv.Mat, dst gocv.Mat, size int, dynRatio int, code gocv.ColorConversionCode) error {
+	return OpenCVResult(C.OilPaintingWithParams(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.int(size), C.int(dynRatio), C.int(code)))
 }
 
 // oilPainting, See the book for details :
@@ -563,6 +555,6 @@ func OilPaintingWithParams(src gocv.Mat, dst gocv.Mat, size int, dynRatio int, c
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/daa/group__xphoto.html#gac18ef93a7b1e65f703f7dc3b1e8e5235
-func OilPainting(src gocv.Mat, dst *gocv.Mat, size int, dynRatio int) {
-	C.OilPainting(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.int(size), C.int(dynRatio))
+func OilPainting(src gocv.Mat, dst *gocv.Mat, size int, dynRatio int) error {
+	return OpenCVResult(C.OilPainting(C.Mat(src.Ptr()), C.Mat(dst.Ptr()), C.int(size), C.int(dynRatio)))
 }

--- a/contrib/xphoto.h
+++ b/contrib/xphoto.h
@@ -28,10 +28,10 @@ typedef void* TonemapDurand;
 
 // ----------------------- bm3d_image_denoising -----------------------
 
-void Xphoto_ApplyChannelGains(Mat src, Mat dst, float gainB, float gainG, float gainR) ;
+OpenCVResult Xphoto_ApplyChannelGains(Mat src, Mat dst, float gainB, float gainG, float gainR);
 
-void Xphoto_Bm3dDenoising_Step(Mat src, Mat dststep1, Mat dststep2) ;
-void Xphoto_Bm3dDenoising_Step_WithParams(
+OpenCVResult Xphoto_Bm3dDenoising_Step(Mat src, Mat dststep1, Mat dststep2);
+OpenCVResult Xphoto_Bm3dDenoising_Step_WithParams(
     Mat src, Mat dststep1, Mat dststep2,
     float h, int templateWindowSize,
     int searchWindowSize, int blockMatchingStep1,
@@ -39,10 +39,10 @@ void Xphoto_Bm3dDenoising_Step_WithParams(
     int slidingStep, float beta,
     int normType, int step,
     int transformType
-) ;
+);
 
-void Xphoto_Bm3dDenoising(Mat src, Mat dst) ;
-void Xphoto_Bm3dDenoising_WithParams(
+OpenCVResult Xphoto_Bm3dDenoising(Mat src, Mat dst);
+OpenCVResult Xphoto_Bm3dDenoising_WithParams(
     Mat src, Mat dst,
     float h, int templateWindowSize,
     int searchWindowSize, int blockMatchingStep1,
@@ -50,7 +50,7 @@ void Xphoto_Bm3dDenoising_WithParams(
     int slidingStep, float beta,
     int normType, int step,
     int transformType
-) ;
+);
 
 
 // ----------------------- GrayworldWB -----------------------
@@ -59,21 +59,21 @@ GrayworldWB GrayworldWB_Create();
 void GrayworldWB_Close(GrayworldWB b);
 void GrayworldWB_SetSaturationThreshold(GrayworldWB b, float saturationThreshold);
 float GrayworldWB_GetSaturationThreshold(GrayworldWB b);
-void GrayworldWB_BalanceWhite(GrayworldWB b, Mat src, Mat dst);
+OpenCVResult GrayworldWB_BalanceWhite(GrayworldWB b, Mat src, Mat dst);
 
 // ----------------------- LearningBasedWB -----------------------
 
 LearningBasedWB LearningBasedWB_Create();
 LearningBasedWB LearningBasedWB_CreateWithParams(const char* pathmodel);
 void LearningBasedWB_Close(LearningBasedWB b);
-void LearningBasedWB_ExtractSimpleFeatures(LearningBasedWB b, Mat src, Mat dst);
+OpenCVResult LearningBasedWB_ExtractSimpleFeatures(LearningBasedWB b, Mat src, Mat dst);
 int LearningBasedWB_GetHistBinNum(LearningBasedWB b) ;
 int LearningBasedWB_GetRangeMaxVal(LearningBasedWB b) ;
 float LearningBasedWB_GetSaturationThreshold(LearningBasedWB b) ;
 void LearningBasedWB_SetHistBinNum(LearningBasedWB b, int val);
 void LearningBasedWB_SetRangeMaxVal(LearningBasedWB b, int val);
 void LearningBasedWB_SetSaturationThreshold(LearningBasedWB b, float val);
-void LearningBasedWB_BalanceWhite(LearningBasedWB b, Mat src, Mat dst);
+OpenCVResult LearningBasedWB_BalanceWhite(LearningBasedWB b, Mat src, Mat dst);
 
 // ----------------------- SimpleWB -----------------------
 
@@ -89,7 +89,7 @@ void SimpleWB_SetInputMin(SimpleWB b, float val);
 void SimpleWB_SetOutputMax(SimpleWB b, float val);
 void SimpleWB_SetOutputMin(SimpleWB b, float val);
 void SimpleWB_SetP(SimpleWB b, float val);
-void SimpleWB_BalanceWhite(SimpleWB b, Mat src, Mat dst);
+OpenCVResult SimpleWB_BalanceWhite(SimpleWB b, Mat src, Mat dst);
 
 
 // -------------------- TonemapDurand --------------------
@@ -109,15 +109,15 @@ void TonemapDurand_SetSigmaColor(TonemapDurand b, float sigma_color);
 void TonemapDurand_SetSigmaSpace(TonemapDurand b, float sigma_space);
 
 float TonemapDurand_GetGamma(TonemapDurand b);
-void TonemapDurand_Process(TonemapDurand b, Mat src, Mat dst);
+OpenCVResult TonemapDurand_Process(TonemapDurand b, Mat src, Mat dst);
 void TonemapDurand_SetGamma(TonemapDurand b, float gamma);
 
 
 // ------------------------ Inpaint -----------------------
 
-void Inpaint(Mat src, Mat mask, Mat dst, int algorithmType);
-void OilPaintingWithParams(Mat src, Mat dst, int size, int dynRatio, int code);
-void OilPainting(Mat src, Mat dst, int size, int dynRatio);
+OpenCVResult Inpaint(Mat src, Mat mask, Mat dst, int algorithmType);
+OpenCVResult OilPaintingWithParams(Mat src, Mat dst, int size, int dynRatio, int code);
+OpenCVResult OilPainting(Mat src, Mat dst, int size, int dynRatio);
 
 #ifdef __cplusplus
 }

--- a/core.cpp
+++ b/core.cpp
@@ -1,6 +1,27 @@
 #include "core.h"
 #include <string.h>
 
+int lastException = 0;
+char lastExceptionMessage[1024];
+
+int GetOpenCVException() {
+    return lastException;
+}
+
+const char* GetOpenCVExceptionMessage() {
+    return lastExceptionMessage;
+}
+
+void ClearOpenCVException() {
+    lastException = 0;
+    strncpy(lastExceptionMessage, "", 1024);
+}
+
+void setExceptionInfo(int code, const char* message) {
+    lastException = code;
+    strncpy(lastExceptionMessage, message, 1024);
+}
+
 // Mat_New creates a new empty Mat
 Mat Mat_New() {
     return new cv::Mat();
@@ -67,21 +88,36 @@ Mat Mat_NewFromPointVector(PointVector pv, bool copy_data) {
 }
 
 Mat Eye(int rows, int cols, int type) {
-    cv::Mat* mat = new cv::Mat(rows, cols, type);
-    *mat = cv::Mat::eye(rows, cols, type);
-    return mat;
+    try {
+        cv::Mat* mat = new cv::Mat(rows, cols, type);
+        *mat = cv::Mat::eye(rows, cols, type);
+        return mat;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 Mat Zeros(int rows, int cols, int type) {
-    cv::Mat* mat = new cv::Mat(rows, cols, type);
-    *mat = cv::Mat::zeros(rows, cols, type);
-    return mat;
+    try {
+        cv::Mat* mat = new cv::Mat(rows, cols, type);
+        *mat = cv::Mat::zeros(rows, cols, type);
+        return mat;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 Mat Ones(int rows, int cols, int type) {
-    cv::Mat* mat = new cv::Mat(rows, cols, type);
-    *mat = cv::Mat::ones(rows, cols, type);
-    return mat;
+    try {
+        cv::Mat* mat = new cv::Mat(rows, cols, type);
+        *mat = cv::Mat::ones(rows, cols, type);
+        return mat;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 Mat Mat_FromPtr(Mat m, int rows, int cols, int type, int prow, int pcol) {
@@ -122,20 +158,36 @@ Mat Mat_Clone(Mat m) {
 
 // Mat_CopyTo copies this Mat to another Mat.
 void Mat_CopyTo(Mat m, Mat dst) {
-    m->copyTo(*dst);
+    try {
+        m->copyTo(*dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 // Mat_CopyToWithMask copies this Mat to another Mat while applying the mask
 void Mat_CopyToWithMask(Mat m, Mat dst, Mat mask) {
-    m->copyTo(*dst, *mask);
+    try {
+        m->copyTo(*dst, *mask);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_ConvertTo(Mat m, Mat dst, int type) {
-    m->convertTo(*dst, type);
+    try {
+        m->convertTo(*dst, type);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_ConvertToWithParams(Mat m, Mat dst, int type, float alpha, float beta) {
-    m->convertTo(*dst, type, alpha, beta);
+    try {
+        m->convertTo(*dst, type, alpha, beta);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 // Mat_ToBytes returns the bytes representation of the underlying data.
@@ -153,23 +205,42 @@ Mat Mat_Region(Mat m, Rect r) {
 }
 
 Mat Mat_Reshape(Mat m, int cn, int rows) {
-    return new cv::Mat(m->reshape(cn, rows));
+    try {
+        return new cv::Mat(m->reshape(cn, rows));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 void Mat_PatchNaNs(Mat m) {
-    cv::patchNaNs(*m);
+    try {
+        cv::patchNaNs(*m);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 Mat Mat_ConvertFp16(Mat m) {
-    Mat dst = new cv::Mat();
-    cv::convertFp16(*m, *dst);
-    return dst;
+    try {
+        Mat dst = new cv::Mat();
+        cv::convertFp16(*m, *dst);
+        return dst;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 Mat Mat_Sqrt(Mat m) {
-    Mat dst = new cv::Mat();
-    cv::sqrt(*m, *dst);
-    return dst;
+    try {
+        Mat dst = new cv::Mat();
+        cv::sqrt(*m, *dst);
+        return dst;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 // Mat_Mean calculates the mean value M of array elements, independently for each channel, and return it as Scalar vector
@@ -198,7 +269,11 @@ Scalar Mat_MeanWithMask(Mat m, Mat mask){
 }
 
 void LUT(Mat src, Mat lut, Mat dst) {
-    cv::LUT(*src, *lut, *dst);
+    try {
+        cv::LUT(*src, *lut, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 // Mat_Rows returns how many rows in this Mat.
@@ -409,448 +484,830 @@ Mat Mat_MultiplyMatrix(Mat x, Mat y) {
 }
 
 Mat Mat_T(Mat x) {
-    return new cv::Mat(x->t());
+    try {
+        return new cv::Mat(x->t());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 void Mat_AbsDiff(Mat src1, Mat src2, Mat dst) {
-    cv::absdiff(*src1, *src2, *dst);
+    try {
+        cv::absdiff(*src1, *src2, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Add(Mat src1, Mat src2, Mat dst) {
-    cv::add(*src1, *src2, *dst);
+    try {
+        cv::add(*src1, *src2, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_AddWeighted(Mat src1, double alpha, Mat src2, double beta, double gamma, Mat dst) {
-    cv::addWeighted(*src1, alpha, *src2, beta, gamma, *dst);
+    try {
+        cv::addWeighted(*src1, alpha, *src2, beta, gamma, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_BitwiseAnd(Mat src1, Mat src2, Mat dst) {
-    cv::bitwise_and(*src1, *src2, *dst);
+    try {
+        cv::bitwise_and(*src1, *src2, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_BitwiseAndWithMask(Mat src1, Mat src2, Mat dst, Mat mask){
-    cv::bitwise_and(*src1, *src2, *dst, *mask);
+    try {
+        cv::bitwise_and(*src1, *src2, *dst, *mask);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_BitwiseNot(Mat src1, Mat dst) {
-    cv::bitwise_not(*src1, *dst);
+    try {
+        cv::bitwise_not(*src1, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_BitwiseNotWithMask(Mat src1, Mat dst, Mat mask) {
-    cv::bitwise_not(*src1, *dst, *mask);
+    try {
+        cv::bitwise_not(*src1, *dst, *mask);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_BitwiseOr(Mat src1, Mat src2, Mat dst) {
-    cv::bitwise_or(*src1, *src2, *dst);
+    try {
+        cv::bitwise_or(*src1, *src2, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_BitwiseOrWithMask(Mat src1, Mat src2, Mat dst, Mat mask) {
-    cv::bitwise_or(*src1, *src2, *dst, *mask);
+    try {
+        cv::bitwise_or(*src1, *src2, *dst, *mask);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_BitwiseXor(Mat src1, Mat src2, Mat dst) {
-    cv::bitwise_xor(*src1, *src2, *dst);
+    try {
+        cv::bitwise_xor(*src1, *src2, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_BitwiseXorWithMask(Mat src1, Mat src2, Mat dst, Mat mask) {
-    cv::bitwise_xor(*src1, *src2, *dst, *mask);
+    try {
+        cv::bitwise_xor(*src1, *src2, *dst, *mask);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_BatchDistance(Mat src1, Mat src2, Mat dist, int dtype, Mat nidx, int normType, int K,
                        Mat mask, int update, bool crosscheck) {
-    cv::batchDistance(*src1, *src2, *dist, dtype, *nidx, normType, K, *mask, update, crosscheck);
+    try {
+        cv::batchDistance(*src1, *src2, *dist, dtype, *nidx, normType, K, *mask, update, crosscheck);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 int Mat_BorderInterpolate(int p, int len, int borderType) {
-    return cv::borderInterpolate(p, len, borderType);
+    try {
+        return cv::borderInterpolate(p, len, borderType);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
-void  Mat_CalcCovarMatrix(Mat samples, Mat covar, Mat mean, int flags, int ctype) {
-    cv::calcCovarMatrix(*samples, *covar, *mean, flags, ctype);
+void Mat_CalcCovarMatrix(Mat samples, Mat covar, Mat mean, int flags, int ctype) {
+    try {
+        cv::calcCovarMatrix(*samples, *covar, *mean, flags, ctype);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
-void  Mat_CartToPolar(Mat x, Mat y, Mat magnitude, Mat angle, bool angleInDegrees) {
-    cv::cartToPolar(*x, *y, *magnitude, *angle, angleInDegrees);
+void Mat_CartToPolar(Mat x, Mat y, Mat magnitude, Mat angle, bool angleInDegrees) {
+    try {
+        cv::cartToPolar(*x, *y, *magnitude, *angle, angleInDegrees);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 bool Mat_CheckRange(Mat m) {
-    return cv::checkRange(*m);
+    try {
+        return cv::checkRange(*m);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 void Mat_Compare(Mat src1, Mat src2, Mat dst, int ct) {
-    cv::compare(*src1, *src2, *dst, ct);
+    try {
+        cv::compare(*src1, *src2, *dst, ct);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 int Mat_CountNonZero(Mat src) {
-    return cv::countNonZero(*src);
+    try {
+        return cv::countNonZero(*src);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
-
 void Mat_CompleteSymm(Mat m, bool lowerToUpper) {
-    cv::completeSymm(*m, lowerToUpper);
+    try {
+        cv::completeSymm(*m, lowerToUpper);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_ConvertScaleAbs(Mat src, Mat dst, double alpha, double beta) {
-    cv::convertScaleAbs(*src, *dst, alpha, beta);
+    try {
+        cv::convertScaleAbs(*src, *dst, alpha, beta);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_CopyMakeBorder(Mat src, Mat dst, int top, int bottom, int left, int right, int borderType,
                         Scalar value) {
-    cv::Scalar c_value(value.val1, value.val2, value.val3, value.val4);
-    cv::copyMakeBorder(*src, *dst, top, bottom, left, right, borderType, c_value);
+    try {
+        cv::Scalar c_value(value.val1, value.val2, value.val3, value.val4);
+        cv::copyMakeBorder(*src, *dst, top, bottom, left, right, borderType, c_value);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_DCT(Mat src, Mat dst, int flags) {
-    cv::dct(*src, *dst, flags);
+    try {
+        cv::dct(*src, *dst, flags);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 double Mat_Determinant(Mat m) {
-    return cv::determinant(*m);
+    try {
+        return cv::determinant(*m);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void Mat_DFT(Mat m, Mat dst, int flags) {
-    cv::dft(*m, *dst, flags);
+    try {
+        cv::dft(*m, *dst, flags);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Divide(Mat src1, Mat src2, Mat dst) {
-    cv::divide(*src1, *src2, *dst);
+    try {
+        cv::divide(*src1, *src2, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 bool Mat_Eigen(Mat src, Mat eigenvalues, Mat eigenvectors) {
-    return cv::eigen(*src, *eigenvalues, *eigenvectors);
+    try {
+        return cv::eigen(*src, *eigenvalues, *eigenvectors);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 void Mat_EigenNonSymmetric(Mat src, Mat eigenvalues, Mat eigenvectors) {
-    cv::eigenNonSymmetric(*src, *eigenvalues, *eigenvectors);
+    try {
+        cv::eigenNonSymmetric(*src, *eigenvalues, *eigenvectors);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_PCABackProject(Mat data, Mat mean, Mat eigenvectors, Mat result) {
-    cv::PCABackProject(*data, *mean, *eigenvectors, *result);
+    try {
+        cv::PCABackProject(*data, *mean, *eigenvectors, *result);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_PCACompute(Mat src, Mat mean, Mat eigenvectors, Mat eigenvalues, int maxComponents) {
-    cv::PCACompute(*src, *mean, *eigenvectors, *eigenvalues, maxComponents);
+    try {
+        cv::PCACompute(*src, *mean, *eigenvectors, *eigenvalues, maxComponents);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_PCAProject(Mat data, Mat mean, Mat eigenvectors, Mat result) {
-    cv::PCAProject(*data, *mean, *eigenvectors, *result);
+    try {
+        cv::PCAProject(*data, *mean, *eigenvectors, *result);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 double PSNR(Mat src1, Mat src2) {
-    return cv::PSNR(*src1, *src2);
+    try {
+        return cv::PSNR(*src1, *src2);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void SVBackSubst(Mat w, Mat u, Mat vt, Mat rhs, Mat dst) {
-    cv::SVBackSubst(*w, *u, *vt, *rhs, *dst);
+    try {
+        cv::SVBackSubst(*w, *u, *vt, *rhs, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void SVDecomp(Mat src, Mat w, Mat u, Mat vt) {
-    cv::SVDecomp(*src, *w, *u, *vt);
+    try {
+        cv::SVDecomp(*src, *w, *u, *vt);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Exp(Mat src, Mat dst) {
-    cv::exp(*src, *dst);
+    try {
+        cv::exp(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_ExtractChannel(Mat src, Mat dst, int coi) {
-    cv::extractChannel(*src, *dst, coi);
+    try {
+        cv::extractChannel(*src, *dst, coi);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_FindNonZero(Mat src, Mat idx) {
-    cv::findNonZero(*src, *idx);
+    try {
+        cv::findNonZero(*src, *idx);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Flip(Mat src, Mat dst, int flipCode) {
-    cv::flip(*src, *dst, flipCode);
+    try {
+        cv::flip(*src, *dst, flipCode);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Gemm(Mat src1, Mat src2, double alpha, Mat src3, double beta, Mat dst, int flags) {
-    cv::gemm(*src1, *src2, alpha, *src3, beta, *dst, flags);
+    try {
+        cv::gemm(*src1, *src2, alpha, *src3, beta, *dst, flags);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 int Mat_GetOptimalDFTSize(int vecsize) {
-    return cv::getOptimalDFTSize(vecsize);
+    try {
+        return cv::getOptimalDFTSize(vecsize);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 void Mat_Hconcat(Mat src1, Mat src2, Mat dst) {
-    cv::hconcat(*src1, *src2, *dst);
+    try {
+        cv::hconcat(*src1, *src2, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Vconcat(Mat src1, Mat src2, Mat dst) {
-    cv::vconcat(*src1, *src2, *dst);
+    try {
+        cv::vconcat(*src1, *src2, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Rotate(Mat src, Mat dst, int rotateCode) {
-    cv::rotate(*src, *dst, rotateCode);
+    try {
+        cv::rotate(*src, *dst, rotateCode);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Idct(Mat src, Mat dst, int flags) {
-    cv::idct(*src, *dst, flags);
+    try {
+        cv::idct(*src, *dst, flags);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Idft(Mat src, Mat dst, int flags, int nonzeroRows) {
-    cv::idft(*src, *dst, flags, nonzeroRows);
+    try {
+        cv::idft(*src, *dst, flags, nonzeroRows);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_InRange(Mat src, Mat lowerb, Mat upperb, Mat dst) {
-    cv::inRange(*src, *lowerb, *upperb, *dst);
+    try {
+        cv::inRange(*src, *lowerb, *upperb, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_InRangeWithScalar(Mat src, Scalar lowerb, Scalar upperb, Mat dst) {
-    cv::Scalar lb = cv::Scalar(lowerb.val1, lowerb.val2, lowerb.val3, lowerb.val4);
-    cv::Scalar ub = cv::Scalar(upperb.val1, upperb.val2, upperb.val3, upperb.val4);
-    cv::inRange(*src, lb, ub, *dst);
+    try {
+        cv::Scalar lb = cv::Scalar(lowerb.val1, lowerb.val2, lowerb.val3, lowerb.val4);
+        cv::Scalar ub = cv::Scalar(upperb.val1, upperb.val2, upperb.val3, upperb.val4);
+        cv::inRange(*src, lb, ub, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_InsertChannel(Mat src, Mat dst, int coi) {
-    cv::insertChannel(*src, *dst, coi);
+    try {
+        cv::insertChannel(*src, *dst, coi);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 double Mat_Invert(Mat src, Mat dst, int flags) {
-    double ret = cv::invert(*src, *dst, flags);
-    return ret;
+    try {
+        return cv::invert(*src, *dst, flags);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 double KMeans(Mat data, int k, Mat bestLabels, TermCriteria criteria, int attempts, int flags, Mat centers) {
-    double ret = cv::kmeans(*data, k, *bestLabels, *criteria, attempts, flags, *centers);
-    return ret;
+    try {
+        return cv::kmeans(*data, k, *bestLabels, *criteria, attempts, flags, *centers);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 double KMeansPoints(PointVector points, int k, Mat bestLabels, TermCriteria criteria, int attempts, int flags, Mat centers) {
-    std::vector<cv::Point2f> pts;
-    copyPointVectorToPoint2fVector(points, &pts);
-    double ret = cv::kmeans(pts, k, *bestLabels, *criteria, attempts, flags, *centers);
-    return ret;
+    try {
+        std::vector<cv::Point2f> pts;
+        copyPointVectorToPoint2fVector(points, &pts);
+        return cv::kmeans(pts, k, *bestLabels, *criteria, attempts, flags, *centers);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void Mat_Log(Mat src, Mat dst) {
-    cv::log(*src, *dst);
+    try {
+        cv::log(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Magnitude(Mat x, Mat y, Mat magnitude) {
-    cv::magnitude(*x, *y, *magnitude);
+    try {
+        cv::magnitude(*x, *y, *magnitude);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 double Mat_Mahalanobis(Mat v1, Mat v2, Mat icovar) {
-    return cv::Mahalanobis(*v1, *v2, *icovar);
+    try {
+        return cv::Mahalanobis(*v1, *v2, *icovar);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void MulTransposed(Mat src, Mat dest, bool ata) {
-    cv::mulTransposed(*src, *dest, ata);
+    try {
+        cv::mulTransposed(*src, *dest, ata);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Max(Mat src1, Mat src2, Mat dst) {
-    cv::max(*src1, *src2, *dst);
+    try {
+        cv::max(*src1, *src2, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_MeanStdDev(Mat src, Mat dstMean, Mat dstStdDev) {
-    cv::meanStdDev(*src, *dstMean, *dstStdDev);
+    try {
+        cv::meanStdDev(*src, *dstMean, *dstStdDev);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Merge(struct Mats mats, Mat dst) {
-    std::vector<cv::Mat> images;
+    try {
+        std::vector<cv::Mat> images;
 
-    for (int i = 0; i < mats.length; ++i) {
-        images.push_back(*mats.mats[i]);
+        for (int i = 0; i < mats.length; ++i) {
+            images.push_back(*mats.mats[i]);
+        }
+
+        cv::merge(images, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    cv::merge(images, *dst);
 }
 
 void Mat_Min(Mat src1, Mat src2, Mat dst) {
-    cv::min(*src1, *src2, *dst);
+    try {
+        cv::min(*src1, *src2, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_MinMaxIdx(Mat m, double* minVal, double* maxVal, int* minIdx, int* maxIdx) {
-    cv::minMaxIdx(*m, minVal, maxVal, minIdx, maxIdx);
+    try {
+        cv::minMaxIdx(*m, minVal, maxVal, minIdx, maxIdx);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_MinMaxLoc(Mat m, double* minVal, double* maxVal, Point* minLoc, Point* maxLoc) {
-    cv::Point cMinLoc;
-    cv::Point cMaxLoc;
-    cv::minMaxLoc(*m, minVal, maxVal, &cMinLoc, &cMaxLoc);
+    try {
+        cv::Point cMinLoc;
+        cv::Point cMaxLoc;
+        cv::minMaxLoc(*m, minVal, maxVal, &cMinLoc, &cMaxLoc);
 
-    minLoc->x = cMinLoc.x;
-    minLoc->y = cMinLoc.y;
-    maxLoc->x = cMaxLoc.x;
-    maxLoc->y = cMaxLoc.y;
+        minLoc->x = cMinLoc.x;
+        minLoc->y = cMinLoc.y;
+        maxLoc->x = cMaxLoc.x;
+        maxLoc->y = cMaxLoc.y;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_MinMaxLocWithMask(Mat m, double* minVal, double* maxVal, Point* minLoc, Point* maxLoc, Mat mask) {
-    cv::Point cMinLoc;
-    cv::Point cMaxLoc;
-    cv::minMaxLoc(*m, minVal, maxVal, &cMinLoc, &cMaxLoc, *mask);
+    try {
+        cv::Point cMinLoc;
+        cv::Point cMaxLoc;
+        cv::minMaxLoc(*m, minVal, maxVal, &cMinLoc, &cMaxLoc, *mask);
 
-    minLoc->x = cMinLoc.x;
-    minLoc->y = cMinLoc.y;
-    maxLoc->x = cMaxLoc.x;
-    maxLoc->y = cMaxLoc.y;
+        minLoc->x = cMinLoc.x;
+        minLoc->y = cMinLoc.y;
+        maxLoc->x = cMaxLoc.x;
+        maxLoc->y = cMaxLoc.y;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_MixChannels(struct Mats src, struct Mats dst, struct IntVector fromTo) {
-    std::vector<cv::Mat> srcMats;
+    try {
+        std::vector<cv::Mat> srcMats;
 
-    for (int i = 0; i < src.length; ++i) {
-        srcMats.push_back(*src.mats[i]);
+        for (int i = 0; i < src.length; ++i) {
+            srcMats.push_back(*src.mats[i]);
+        }
+
+        std::vector<cv::Mat> dstMats;
+
+        for (int i = 0; i < dst.length; ++i) {
+            dstMats.push_back(*dst.mats[i]);
+        }
+
+        std::vector<int> fromTos;
+
+        for (int i = 0; i < fromTo.length; ++i) {
+            fromTos.push_back(fromTo.val[i]);
+        }
+
+        cv::mixChannels(srcMats, dstMats, fromTos);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    std::vector<cv::Mat> dstMats;
-
-    for (int i = 0; i < dst.length; ++i) {
-        dstMats.push_back(*dst.mats[i]);
-    }
-
-    std::vector<int> fromTos;
-
-    for (int i = 0; i < fromTo.length; ++i) {
-        fromTos.push_back(fromTo.val[i]);
-    }
-
-    cv::mixChannels(srcMats, dstMats, fromTos);
 }
 
 void Mat_MulSpectrums(Mat a, Mat b, Mat c, int flags) {
-    cv::mulSpectrums(*a, *b, *c, flags);
+    try {
+        cv::mulSpectrums(*a, *b, *c, flags);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Multiply(Mat src1, Mat src2, Mat dst) {
-    cv::multiply(*src1, *src2, *dst);
+    try {
+        cv::multiply(*src1, *src2, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_MultiplyWithParams(Mat src1, Mat src2, Mat dst, double scale, int dtype) {
-    cv::multiply(*src1, *src2, *dst, scale, dtype);
+    try {
+        cv::multiply(*src1, *src2, *dst, scale, dtype);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Normalize(Mat src, Mat dst, double alpha, double beta, int typ) {
-    cv::normalize(*src, *dst, alpha, beta, typ);
+    try {
+        cv::normalize(*src, *dst, alpha, beta, typ);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 double Norm(Mat src1, int normType) {
-    return cv::norm(*src1, normType);
+    try {
+        return cv::norm(*src1, normType);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 double NormWithMats(Mat src1, Mat src2, int normType) {
-    return cv::norm(*src1, *src2, normType);
+    try {
+        return cv::norm(*src1, *src2, normType);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void Mat_PerspectiveTransform(Mat src, Mat dst, Mat tm) {
-    cv::perspectiveTransform(*src, *dst, *tm);
+    try {
+        cv::perspectiveTransform(*src, *dst, *tm);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 bool Mat_Solve(Mat src1, Mat src2, Mat dst, int flags) {
-    return cv::solve(*src1, *src2, *dst, flags);
+    try {
+        return cv::solve(*src1, *src2, *dst, flags);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 int Mat_SolveCubic(Mat coeffs, Mat roots) {
-    return cv::solveCubic(*coeffs, *roots);
+    try {
+        return cv::solveCubic(*coeffs, *roots);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 double Mat_SolvePoly(Mat coeffs, Mat roots, int maxIters) {
-    return cv::solvePoly(*coeffs, *roots, maxIters);
+    try {
+        return cv::solvePoly(*coeffs, *roots, maxIters);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void Mat_Reduce(Mat src, Mat dst, int dim, int rType, int dType) {
-    cv::reduce(*src, *dst, dim, rType, dType);
+    try {
+        cv::reduce(*src, *dst, dim, rType, dType);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_ReduceArgMax(Mat src, Mat dst, int axis, bool lastIndex) {
-    cv::reduceArgMax(*src, *dst, axis, lastIndex);
+    try {
+        cv::reduceArgMax(*src, *dst, axis, lastIndex);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_ReduceArgMin(Mat src, Mat dst, int axis, bool lastIndex) {
-    cv::reduceArgMin(*src, *dst, axis, lastIndex);
+    try {
+        cv::reduceArgMin(*src, *dst, axis, lastIndex);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
-
 void Mat_Repeat(Mat src, int nY, int nX, Mat dst) {
-    cv::repeat(*src, nY, nX, *dst);
+    try {
+        cv::repeat(*src, nY, nX, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_ScaleAdd(Mat src1, double alpha, Mat src2, Mat dst) {
-    cv::scaleAdd(*src1, alpha, *src2, *dst);
+    try {
+        cv::scaleAdd(*src1, alpha, *src2, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_SetIdentity(Mat src, double scalar) {
-    cv::setIdentity(*src, scalar);
+    try {
+        cv::setIdentity(*src, scalar);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Sort(Mat src, Mat dst, int flags) {
-    cv::sort(*src, *dst, flags);
+    try {
+        cv::sort(*src, *dst, flags);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_SortIdx(Mat src, Mat dst, int flags) {
-    cv::sortIdx(*src, *dst, flags);
+    try {
+        cv::sortIdx(*src, *dst, flags);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Split(Mat src, struct Mats* mats) {
-    std::vector<cv::Mat> channels;
-    cv::split(*src, channels);
-    mats->mats = new Mat[channels.size()];
+    try {
+        std::vector<cv::Mat> channels;
+        cv::split(*src, channels);
+        mats->mats = new Mat[channels.size()];
 
-    for (size_t i = 0; i < channels.size(); ++i) {
-        mats->mats[i] = new cv::Mat(channels[i]);
+        for (size_t i = 0; i < channels.size(); ++i) {
+            mats->mats[i] = new cv::Mat(channels[i]);
+        }
+
+        mats->length = (int)channels.size();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    mats->length = (int)channels.size();
 }
 
 void Mat_Subtract(Mat src1, Mat src2, Mat dst) {
-    cv::subtract(*src1, *src2, *dst);
+    try {
+        cv::subtract(*src1, *src2, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 Scalar Mat_Trace(Mat src) {
-    cv::Scalar c = cv::trace(*src);
-    Scalar scal = Scalar();
-    scal.val1 = c.val[0];
-    scal.val2 = c.val[1];
-    scal.val3 = c.val[2];
-    scal.val4 = c.val[3];
-    return scal;
+    try {
+        cv::Scalar c = cv::trace(*src);
+        Scalar scal = Scalar();
+        scal.val1 = c.val[0];
+        scal.val2 = c.val[1];
+        scal.val3 = c.val[2];
+        scal.val4 = c.val[3];
+        return scal;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return Scalar();
+    }
 }
 
 void Mat_Transform(Mat src, Mat dst, Mat tm) {
-    cv::transform(*src, *dst, *tm);
+    try {
+        cv::transform(*src, *dst, *tm);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Transpose(Mat src, Mat dst) {
-    cv::transpose(*src, *dst);
+    try {
+        cv::transpose(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_TransposeND(Mat src, struct IntVector order, Mat dst) {
-    std::vector<int> _order;
-    for (int i = 0, *v = order.val; i < order.length; ++v, ++i) {
-        _order.push_back(*v);
-    }
+    try {
+        std::vector<int> _order;
+        for (int i = 0, *v = order.val; i < order.length; ++v, ++i) {
+            _order.push_back(*v);
+        }
 
-    cv::transposeND(*src, _order, *dst);
+        cv::transposeND(*src, _order, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_PolarToCart(Mat magnitude, Mat degree, Mat x, Mat y, bool angleInDegrees) {
-    cv::polarToCart(*magnitude, *degree, *x, *y, angleInDegrees);
+    try {
+        cv::polarToCart(*magnitude, *degree, *x, *y, angleInDegrees);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Pow(Mat src, double power, Mat dst) {
-    cv::pow(*src, power, *dst);
+    try {
+        cv::pow(*src, power, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Phase(Mat x, Mat y, Mat angle, bool angleInDegrees) {
-	cv::phase(*x, *y, *angle, angleInDegrees);
+    try {
+        cv::phase(*x, *y, *angle, angleInDegrees);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
-
 Scalar Mat_Sum(Mat src) {
-    cv::Scalar c = cv::sum(*src);
-    Scalar scal = Scalar();
-    scal.val1 = c.val[0];
-    scal.val2 = c.val[1];
-    scal.val3 = c.val[2];
-    scal.val4 = c.val[3];
-    return scal;
+    try {
+        cv::Scalar c = cv::sum(*src);
+        Scalar scal = Scalar();
+        scal.val1 = c.val[0];
+        scal.val2 = c.val[1];
+        scal.val3 = c.val[2];
+        scal.val4 = c.val[3];
+        return scal;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return Scalar();
+    }
 }
 
 // TermCriteria_New creates a new TermCriteria
 TermCriteria TermCriteria_New(int typ, int maxCount, double epsilon) {
-    return new cv::TermCriteria(typ, maxCount, epsilon);
+    try {
+        return new cv::TermCriteria(typ, maxCount, epsilon);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void Contours_Close(struct Contours cs) {
@@ -932,19 +1389,39 @@ struct ByteArray toByteArray(const char* buf, int len) {
 }
 
 int64 GetCVTickCount() {
-    return cv::getTickCount();
+    try {
+        return cv::getTickCount();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 double GetTickFrequency() {
-    return cv::getTickFrequency();
+    try {
+        return cv::getTickFrequency();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 Mat Mat_rowRange(Mat m,int startrow,int endrow) {
-    return new cv::Mat(m->rowRange(startrow,endrow));
+    try {
+        return new cv::Mat(m->rowRange(startrow,endrow));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 Mat Mat_colRange(Mat m,int startrow,int endrow) {
-    return new cv::Mat(m->colRange(startrow,endrow));
+    try {
+        return new cv::Mat(m->colRange(startrow,endrow));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 PointVector PointVector_New() {
@@ -1073,35 +1550,65 @@ void SetRNGSeed(int seed) {
 }
 
 void RNG_Fill(RNG rng, Mat mat, int distType, double a, double b, bool saturateRange) {
-    rng->fill(*mat, distType, a, b, saturateRange);
+    try {
+        rng->fill(*mat, distType, a, b, saturateRange);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 double RNG_Gaussian(RNG rng, double sigma) {
-    return rng->gaussian(sigma);
+    try {
+        return rng->gaussian(sigma);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 unsigned int RNG_Next(RNG rng) {
-    return rng->next();
+    try {
+        return rng->next();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 void RandN(Mat mat, Scalar mean, Scalar stddev) {
-    cv::Scalar m = cv::Scalar(mean.val1, mean.val2, mean.val3, mean.val4);
-    cv::Scalar s = cv::Scalar(stddev.val1, stddev.val2, stddev.val3, stddev.val4);
-    cv::randn(*mat, m, s);
+    try {
+        cv::Scalar m = cv::Scalar(mean.val1, mean.val2, mean.val3, mean.val4);
+        cv::Scalar s = cv::Scalar(stddev.val1, stddev.val2, stddev.val3, stddev.val4);
+        cv::randn(*mat, m, s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void RandShuffle(Mat mat) {
-    cv::randShuffle(*mat);
+    try {
+        cv::randShuffle(*mat);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void RandShuffleWithParams(Mat mat, double iterFactor, RNG rng) {
-    cv::randShuffle(*mat, iterFactor, rng);
+    try {
+        cv::randShuffle(*mat, iterFactor, rng);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void RandU(Mat mat, Scalar low, Scalar high) {
-    cv::Scalar l = cv::Scalar(low.val1, low.val2, low.val3, low.val4);
-    cv::Scalar h = cv::Scalar(high.val1, high.val2, high.val3, high.val4);
-    cv::randn(*mat, l, h);
+    try {
+        cv::Scalar l = cv::Scalar(low.val1, low.val2, low.val3, low.val4);
+        cv::Scalar h = cv::Scalar(high.val1, high.val2, high.val3, high.val4);
+        cv::randn(*mat, l, h);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void copyPointVectorToPoint2fVector(PointVector src, Point2fVector dest) {

--- a/core.cpp
+++ b/core.cpp
@@ -22,6 +22,23 @@ void setExceptionInfo(int code, const char* message) {
     strncpy(lastExceptionMessage, message, 1024);
 }
 
+OpenCVResult successResult() {
+    OpenCVResult ri = {0, "", 0};
+    return ri;
+}
+
+OpenCVResult errorResult(int code, const char* message) {
+    OpenCVResult ri;
+    ri.Code = code;
+
+    auto res = (char*)malloc(strlen(message)+1);
+    memset(res, 0, strlen(message)+1);
+    memcpy(res, message, strlen(message));
+    ri.Message = res;
+    ri.Length = strlen(message);
+    return ri;
+}
+
 // Mat_New creates a new empty Mat
 Mat Mat_New() {
     return new cv::Mat();
@@ -157,36 +174,40 @@ Mat Mat_Clone(Mat m) {
 }
 
 // Mat_CopyTo copies this Mat to another Mat.
-void Mat_CopyTo(Mat m, Mat dst) {
+OpenCVResult Mat_CopyTo(Mat m, Mat dst) {
     try {
         m->copyTo(*dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
 // Mat_CopyToWithMask copies this Mat to another Mat while applying the mask
-void Mat_CopyToWithMask(Mat m, Mat dst, Mat mask) {
+OpenCVResult Mat_CopyToWithMask(Mat m, Mat dst, Mat mask) {
     try {
         m->copyTo(*dst, *mask);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_ConvertTo(Mat m, Mat dst, int type) {
+OpenCVResult Mat_ConvertTo(Mat m, Mat dst, int type) {
     try {
         m->convertTo(*dst, type);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_ConvertToWithParams(Mat m, Mat dst, int type, float alpha, float beta) {
+OpenCVResult Mat_ConvertToWithParams(Mat m, Mat dst, int type, float alpha, float beta) {
     try {
         m->convertTo(*dst, type, alpha, beta);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -213,11 +234,12 @@ Mat Mat_Reshape(Mat m, int cn, int rows) {
     }
 }
 
-void Mat_PatchNaNs(Mat m) {
+OpenCVResult Mat_PatchNaNs(Mat m) {
     try {
         cv::patchNaNs(*m);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -268,11 +290,12 @@ Scalar Mat_MeanWithMask(Mat m, Mat mask){
     return scal;
 }
 
-void LUT(Mat src, Mat lut, Mat dst) {
+OpenCVResult LUT(Mat src, Mat lut, Mat dst) {
     try {
         cv::LUT(*src, *lut, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -492,100 +515,112 @@ Mat Mat_T(Mat x) {
     }
 }
 
-void Mat_AbsDiff(Mat src1, Mat src2, Mat dst) {
+OpenCVResult Mat_AbsDiff(Mat src1, Mat src2, Mat dst) {
     try {
         cv::absdiff(*src1, *src2, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Add(Mat src1, Mat src2, Mat dst) {
+OpenCVResult Mat_Add(Mat src1, Mat src2, Mat dst) {
     try {
         cv::add(*src1, *src2, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_AddWeighted(Mat src1, double alpha, Mat src2, double beta, double gamma, Mat dst) {
+OpenCVResult Mat_AddWeighted(Mat src1, double alpha, Mat src2, double beta, double gamma, Mat dst) {
     try {
         cv::addWeighted(*src1, alpha, *src2, beta, gamma, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_BitwiseAnd(Mat src1, Mat src2, Mat dst) {
+OpenCVResult Mat_BitwiseAnd(Mat src1, Mat src2, Mat dst) {
     try {
         cv::bitwise_and(*src1, *src2, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_BitwiseAndWithMask(Mat src1, Mat src2, Mat dst, Mat mask){
+OpenCVResult Mat_BitwiseAndWithMask(Mat src1, Mat src2, Mat dst, Mat mask){
     try {
         cv::bitwise_and(*src1, *src2, *dst, *mask);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_BitwiseNot(Mat src1, Mat dst) {
+OpenCVResult Mat_BitwiseNot(Mat src1, Mat dst) {
     try {
         cv::bitwise_not(*src1, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_BitwiseNotWithMask(Mat src1, Mat dst, Mat mask) {
+OpenCVResult Mat_BitwiseNotWithMask(Mat src1, Mat dst, Mat mask) {
     try {
         cv::bitwise_not(*src1, *dst, *mask);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_BitwiseOr(Mat src1, Mat src2, Mat dst) {
+OpenCVResult Mat_BitwiseOr(Mat src1, Mat src2, Mat dst) {
     try {
         cv::bitwise_or(*src1, *src2, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_BitwiseOrWithMask(Mat src1, Mat src2, Mat dst, Mat mask) {
+OpenCVResult Mat_BitwiseOrWithMask(Mat src1, Mat src2, Mat dst, Mat mask) {
     try {
         cv::bitwise_or(*src1, *src2, *dst, *mask);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_BitwiseXor(Mat src1, Mat src2, Mat dst) {
+OpenCVResult Mat_BitwiseXor(Mat src1, Mat src2, Mat dst) {
     try {
         cv::bitwise_xor(*src1, *src2, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_BitwiseXorWithMask(Mat src1, Mat src2, Mat dst, Mat mask) {
+OpenCVResult Mat_BitwiseXorWithMask(Mat src1, Mat src2, Mat dst, Mat mask) {
     try {
         cv::bitwise_xor(*src1, *src2, *dst, *mask);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_BatchDistance(Mat src1, Mat src2, Mat dist, int dtype, Mat nidx, int normType, int K,
+OpenCVResult Mat_BatchDistance(Mat src1, Mat src2, Mat dist, int dtype, Mat nidx, int normType, int K,
                        Mat mask, int update, bool crosscheck) {
     try {
         cv::batchDistance(*src1, *src2, *dist, dtype, *nidx, normType, K, *mask, update, crosscheck);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -598,19 +633,21 @@ int Mat_BorderInterpolate(int p, int len, int borderType) {
     }
 }
 
-void Mat_CalcCovarMatrix(Mat samples, Mat covar, Mat mean, int flags, int ctype) {
+OpenCVResult Mat_CalcCovarMatrix(Mat samples, Mat covar, Mat mean, int flags, int ctype) {
     try {
         cv::calcCovarMatrix(*samples, *covar, *mean, flags, ctype);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_CartToPolar(Mat x, Mat y, Mat magnitude, Mat angle, bool angleInDegrees) {
+OpenCVResult Mat_CartToPolar(Mat x, Mat y, Mat magnitude, Mat angle, bool angleInDegrees) {
     try {
         cv::cartToPolar(*x, *y, *magnitude, *angle, angleInDegrees);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -623,11 +660,12 @@ bool Mat_CheckRange(Mat m) {
     }
 }
 
-void Mat_Compare(Mat src1, Mat src2, Mat dst, int ct) {
+OpenCVResult Mat_Compare(Mat src1, Mat src2, Mat dst, int ct) {
     try {
         cv::compare(*src1, *src2, *dst, ct);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -640,37 +678,41 @@ int Mat_CountNonZero(Mat src) {
     }
 }
 
-void Mat_CompleteSymm(Mat m, bool lowerToUpper) {
+OpenCVResult Mat_CompleteSymm(Mat m, bool lowerToUpper) {
     try {
         cv::completeSymm(*m, lowerToUpper);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_ConvertScaleAbs(Mat src, Mat dst, double alpha, double beta) {
+OpenCVResult Mat_ConvertScaleAbs(Mat src, Mat dst, double alpha, double beta) {
     try {
         cv::convertScaleAbs(*src, *dst, alpha, beta);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_CopyMakeBorder(Mat src, Mat dst, int top, int bottom, int left, int right, int borderType,
+OpenCVResult Mat_CopyMakeBorder(Mat src, Mat dst, int top, int bottom, int left, int right, int borderType,
                         Scalar value) {
     try {
         cv::Scalar c_value(value.val1, value.val2, value.val3, value.val4);
         cv::copyMakeBorder(*src, *dst, top, bottom, left, right, borderType, c_value);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_DCT(Mat src, Mat dst, int flags) {
+OpenCVResult Mat_DCT(Mat src, Mat dst, int flags) {
     try {
         cv::dct(*src, *dst, flags);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -683,19 +725,21 @@ double Mat_Determinant(Mat m) {
     }
 }
 
-void Mat_DFT(Mat m, Mat dst, int flags) {
+OpenCVResult Mat_DFT(Mat m, Mat dst, int flags) {
     try {
         cv::dft(*m, *dst, flags);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Divide(Mat src1, Mat src2, Mat dst) {
+OpenCVResult Mat_Divide(Mat src1, Mat src2, Mat dst) {
     try {
         cv::divide(*src1, *src2, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -708,35 +752,39 @@ bool Mat_Eigen(Mat src, Mat eigenvalues, Mat eigenvectors) {
     }
 }
 
-void Mat_EigenNonSymmetric(Mat src, Mat eigenvalues, Mat eigenvectors) {
+OpenCVResult Mat_EigenNonSymmetric(Mat src, Mat eigenvalues, Mat eigenvectors) {
     try {
         cv::eigenNonSymmetric(*src, *eigenvalues, *eigenvectors);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_PCABackProject(Mat data, Mat mean, Mat eigenvectors, Mat result) {
+OpenCVResult Mat_PCABackProject(Mat data, Mat mean, Mat eigenvectors, Mat result) {
     try {
         cv::PCABackProject(*data, *mean, *eigenvectors, *result);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_PCACompute(Mat src, Mat mean, Mat eigenvectors, Mat eigenvalues, int maxComponents) {
+OpenCVResult Mat_PCACompute(Mat src, Mat mean, Mat eigenvectors, Mat eigenvalues, int maxComponents) {
     try {
         cv::PCACompute(*src, *mean, *eigenvectors, *eigenvalues, maxComponents);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_PCAProject(Mat data, Mat mean, Mat eigenvectors, Mat result) {
+OpenCVResult Mat_PCAProject(Mat data, Mat mean, Mat eigenvectors, Mat result) {
     try {
         cv::PCAProject(*data, *mean, *eigenvectors, *result);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -749,59 +797,66 @@ double PSNR(Mat src1, Mat src2) {
     }
 }
 
-void SVBackSubst(Mat w, Mat u, Mat vt, Mat rhs, Mat dst) {
+OpenCVResult SVBackSubst(Mat w, Mat u, Mat vt, Mat rhs, Mat dst) {
     try {
         cv::SVBackSubst(*w, *u, *vt, *rhs, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void SVDecomp(Mat src, Mat w, Mat u, Mat vt) {
+OpenCVResult SVDecomp(Mat src, Mat w, Mat u, Mat vt) {
     try {
         cv::SVDecomp(*src, *w, *u, *vt);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Exp(Mat src, Mat dst) {
+OpenCVResult Mat_Exp(Mat src, Mat dst) {
     try {
         cv::exp(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_ExtractChannel(Mat src, Mat dst, int coi) {
+OpenCVResult Mat_ExtractChannel(Mat src, Mat dst, int coi) {
     try {
         cv::extractChannel(*src, *dst, coi);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_FindNonZero(Mat src, Mat idx) {
+OpenCVResult Mat_FindNonZero(Mat src, Mat idx) {
     try {
         cv::findNonZero(*src, *idx);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Flip(Mat src, Mat dst, int flipCode) {
+OpenCVResult Mat_Flip(Mat src, Mat dst, int flipCode) {
     try {
         cv::flip(*src, *dst, flipCode);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Gemm(Mat src1, Mat src2, double alpha, Mat src3, double beta, Mat dst, int flags) {
+OpenCVResult Mat_Gemm(Mat src1, Mat src2, double alpha, Mat src3, double beta, Mat dst, int flags) {
     try {
         cv::gemm(*src1, *src2, alpha, *src3, beta, *dst, flags);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -814,69 +869,77 @@ int Mat_GetOptimalDFTSize(int vecsize) {
     }
 }
 
-void Mat_Hconcat(Mat src1, Mat src2, Mat dst) {
+OpenCVResult Mat_Hconcat(Mat src1, Mat src2, Mat dst) {
     try {
         cv::hconcat(*src1, *src2, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Vconcat(Mat src1, Mat src2, Mat dst) {
+OpenCVResult Mat_Vconcat(Mat src1, Mat src2, Mat dst) {
     try {
         cv::vconcat(*src1, *src2, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Rotate(Mat src, Mat dst, int rotateCode) {
+OpenCVResult Rotate(Mat src, Mat dst, int rotateCode) {
     try {
         cv::rotate(*src, *dst, rotateCode);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Idct(Mat src, Mat dst, int flags) {
+OpenCVResult Mat_Idct(Mat src, Mat dst, int flags) {
     try {
         cv::idct(*src, *dst, flags);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Idft(Mat src, Mat dst, int flags, int nonzeroRows) {
+OpenCVResult Mat_Idft(Mat src, Mat dst, int flags, int nonzeroRows) {
     try {
         cv::idft(*src, *dst, flags, nonzeroRows);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_InRange(Mat src, Mat lowerb, Mat upperb, Mat dst) {
+OpenCVResult Mat_InRange(Mat src, Mat lowerb, Mat upperb, Mat dst) {
     try {
         cv::inRange(*src, *lowerb, *upperb, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_InRangeWithScalar(Mat src, Scalar lowerb, Scalar upperb, Mat dst) {
+OpenCVResult Mat_InRangeWithScalar(Mat src, Scalar lowerb, Scalar upperb, Mat dst) {
     try {
         cv::Scalar lb = cv::Scalar(lowerb.val1, lowerb.val2, lowerb.val3, lowerb.val4);
         cv::Scalar ub = cv::Scalar(upperb.val1, upperb.val2, upperb.val3, upperb.val4);
         cv::inRange(*src, lb, ub, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_InsertChannel(Mat src, Mat dst, int coi) {
+OpenCVResult Mat_InsertChannel(Mat src, Mat dst, int coi) {
     try {
         cv::insertChannel(*src, *dst, coi);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -909,19 +972,21 @@ double KMeansPoints(PointVector points, int k, Mat bestLabels, TermCriteria crit
     }
 }
 
-void Mat_Log(Mat src, Mat dst) {
+OpenCVResult Mat_Log(Mat src, Mat dst) {
     try {
         cv::log(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Magnitude(Mat x, Mat y, Mat magnitude) {
+OpenCVResult Mat_Magnitude(Mat x, Mat y, Mat magnitude) {
     try {
         cv::magnitude(*x, *y, *magnitude);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -934,31 +999,34 @@ double Mat_Mahalanobis(Mat v1, Mat v2, Mat icovar) {
     }
 }
 
-void MulTransposed(Mat src, Mat dest, bool ata) {
+OpenCVResult MulTransposed(Mat src, Mat dest, bool ata) {
     try {
         cv::mulTransposed(*src, *dest, ata);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Max(Mat src1, Mat src2, Mat dst) {
+OpenCVResult Mat_Max(Mat src1, Mat src2, Mat dst) {
     try {
         cv::max(*src1, *src2, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_MeanStdDev(Mat src, Mat dstMean, Mat dstStdDev) {
+OpenCVResult Mat_MeanStdDev(Mat src, Mat dstMean, Mat dstStdDev) {
     try {
         cv::meanStdDev(*src, *dstMean, *dstStdDev);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Merge(struct Mats mats, Mat dst) {
+OpenCVResult Mat_Merge(struct Mats mats, Mat dst) {
     try {
         std::vector<cv::Mat> images;
 
@@ -967,28 +1035,31 @@ void Mat_Merge(struct Mats mats, Mat dst) {
         }
 
         cv::merge(images, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Min(Mat src1, Mat src2, Mat dst) {
+OpenCVResult Mat_Min(Mat src1, Mat src2, Mat dst) {
     try {
         cv::min(*src1, *src2, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_MinMaxIdx(Mat m, double* minVal, double* maxVal, int* minIdx, int* maxIdx) {
+OpenCVResult Mat_MinMaxIdx(Mat m, double* minVal, double* maxVal, int* minIdx, int* maxIdx) {
     try {
         cv::minMaxIdx(*m, minVal, maxVal, minIdx, maxIdx);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_MinMaxLoc(Mat m, double* minVal, double* maxVal, Point* minLoc, Point* maxLoc) {
+OpenCVResult Mat_MinMaxLoc(Mat m, double* minVal, double* maxVal, Point* minLoc, Point* maxLoc) {
     try {
         cv::Point cMinLoc;
         cv::Point cMaxLoc;
@@ -998,12 +1069,13 @@ void Mat_MinMaxLoc(Mat m, double* minVal, double* maxVal, Point* minLoc, Point* 
         minLoc->y = cMinLoc.y;
         maxLoc->x = cMaxLoc.x;
         maxLoc->y = cMaxLoc.y;
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_MinMaxLocWithMask(Mat m, double* minVal, double* maxVal, Point* minLoc, Point* maxLoc, Mat mask) {
+OpenCVResult Mat_MinMaxLocWithMask(Mat m, double* minVal, double* maxVal, Point* minLoc, Point* maxLoc, Mat mask) {
     try {
         cv::Point cMinLoc;
         cv::Point cMaxLoc;
@@ -1013,12 +1085,13 @@ void Mat_MinMaxLocWithMask(Mat m, double* minVal, double* maxVal, Point* minLoc,
         minLoc->y = cMinLoc.y;
         maxLoc->x = cMaxLoc.x;
         maxLoc->y = cMaxLoc.y;
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_MixChannels(struct Mats src, struct Mats dst, struct IntVector fromTo) {
+OpenCVResult Mat_MixChannels(struct Mats src, struct Mats dst, struct IntVector fromTo) {
     try {
         std::vector<cv::Mat> srcMats;
 
@@ -1039,40 +1112,45 @@ void Mat_MixChannels(struct Mats src, struct Mats dst, struct IntVector fromTo) 
         }
 
         cv::mixChannels(srcMats, dstMats, fromTos);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_MulSpectrums(Mat a, Mat b, Mat c, int flags) {
+OpenCVResult Mat_MulSpectrums(Mat a, Mat b, Mat c, int flags) {
     try {
         cv::mulSpectrums(*a, *b, *c, flags);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Multiply(Mat src1, Mat src2, Mat dst) {
+OpenCVResult Mat_Multiply(Mat src1, Mat src2, Mat dst) {
     try {
         cv::multiply(*src1, *src2, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_MultiplyWithParams(Mat src1, Mat src2, Mat dst, double scale, int dtype) {
+OpenCVResult Mat_MultiplyWithParams(Mat src1, Mat src2, Mat dst, double scale, int dtype) {
     try {
         cv::multiply(*src1, *src2, *dst, scale, dtype);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Normalize(Mat src, Mat dst, double alpha, double beta, int typ) {
+OpenCVResult Mat_Normalize(Mat src, Mat dst, double alpha, double beta, int typ) {
     try {
         cv::normalize(*src, *dst, alpha, beta, typ);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -1094,11 +1172,12 @@ double NormWithMats(Mat src1, Mat src2, int normType) {
     }
 }
 
-void Mat_PerspectiveTransform(Mat src, Mat dst, Mat tm) {
+OpenCVResult Mat_PerspectiveTransform(Mat src, Mat dst, Mat tm) {
     try {
         cv::perspectiveTransform(*src, *dst, *tm);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -1129,71 +1208,79 @@ double Mat_SolvePoly(Mat coeffs, Mat roots, int maxIters) {
     }
 }
 
-void Mat_Reduce(Mat src, Mat dst, int dim, int rType, int dType) {
+OpenCVResult Mat_Reduce(Mat src, Mat dst, int dim, int rType, int dType) {
     try {
         cv::reduce(*src, *dst, dim, rType, dType);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_ReduceArgMax(Mat src, Mat dst, int axis, bool lastIndex) {
+OpenCVResult Mat_ReduceArgMax(Mat src, Mat dst, int axis, bool lastIndex) {
     try {
         cv::reduceArgMax(*src, *dst, axis, lastIndex);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_ReduceArgMin(Mat src, Mat dst, int axis, bool lastIndex) {
+OpenCVResult Mat_ReduceArgMin(Mat src, Mat dst, int axis, bool lastIndex) {
     try {
         cv::reduceArgMin(*src, *dst, axis, lastIndex);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Repeat(Mat src, int nY, int nX, Mat dst) {
+OpenCVResult Mat_Repeat(Mat src, int nY, int nX, Mat dst) {
     try {
         cv::repeat(*src, nY, nX, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_ScaleAdd(Mat src1, double alpha, Mat src2, Mat dst) {
+OpenCVResult Mat_ScaleAdd(Mat src1, double alpha, Mat src2, Mat dst) {
     try {
         cv::scaleAdd(*src1, alpha, *src2, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_SetIdentity(Mat src, double scalar) {
+OpenCVResult Mat_SetIdentity(Mat src, double scalar) {
     try {
         cv::setIdentity(*src, scalar);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Sort(Mat src, Mat dst, int flags) {
+OpenCVResult Mat_Sort(Mat src, Mat dst, int flags) {
     try {
         cv::sort(*src, *dst, flags);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_SortIdx(Mat src, Mat dst, int flags) {
+OpenCVResult Mat_SortIdx(Mat src, Mat dst, int flags) {
     try {
         cv::sortIdx(*src, *dst, flags);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Split(Mat src, struct Mats* mats) {
+OpenCVResult Mat_Split(Mat src, struct Mats* mats) {
     try {
         std::vector<cv::Mat> channels;
         cv::split(*src, channels);
@@ -1204,16 +1291,18 @@ void Mat_Split(Mat src, struct Mats* mats) {
         }
 
         mats->length = (int)channels.size();
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Subtract(Mat src1, Mat src2, Mat dst) {
+OpenCVResult Mat_Subtract(Mat src1, Mat src2, Mat dst) {
     try {
         cv::subtract(*src1, *src2, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -1232,23 +1321,25 @@ Scalar Mat_Trace(Mat src) {
     }
 }
 
-void Mat_Transform(Mat src, Mat dst, Mat tm) {
+OpenCVResult Mat_Transform(Mat src, Mat dst, Mat tm) {
     try {
         cv::transform(*src, *dst, *tm);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Transpose(Mat src, Mat dst) {
+OpenCVResult Mat_Transpose(Mat src, Mat dst) {
     try {
         cv::transpose(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_TransposeND(Mat src, struct IntVector order, Mat dst) {
+OpenCVResult Mat_TransposeND(Mat src, struct IntVector order, Mat dst) {
     try {
         std::vector<int> _order;
         for (int i = 0, *v = order.val; i < order.length; ++v, ++i) {
@@ -1256,32 +1347,36 @@ void Mat_TransposeND(Mat src, struct IntVector order, Mat dst) {
         }
 
         cv::transposeND(*src, _order, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_PolarToCart(Mat magnitude, Mat degree, Mat x, Mat y, bool angleInDegrees) {
+OpenCVResult Mat_PolarToCart(Mat magnitude, Mat degree, Mat x, Mat y, bool angleInDegrees) {
     try {
         cv::polarToCart(*magnitude, *degree, *x, *y, angleInDegrees);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Pow(Mat src, double power, Mat dst) {
+OpenCVResult Mat_Pow(Mat src, double power, Mat dst) {
     try {
         cv::pow(*src, power, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Phase(Mat x, Mat y, Mat angle, bool angleInDegrees) {
+OpenCVResult Mat_Phase(Mat x, Mat y, Mat angle, bool angleInDegrees) {
     try {
         cv::phase(*x, *y, *angle, angleInDegrees);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 

--- a/core.go
+++ b/core.go
@@ -13,6 +13,21 @@ import (
 	"unsafe"
 )
 
+// GetLastException returns the last exception code from the OpenCV library.
+func GetLastException() int {
+	return int(C.GetOpenCVException())
+}
+
+// GetLastExceptionMessage returns the last exception message from the OpenCV library.
+func GetLastExceptionMessage() string {
+	return C.GoString(C.GetOpenCVExceptionMessage())
+}
+
+// ClearLastException clears the last exception from the OpenCV library.
+func ClearLastException() {
+	C.ClearOpenCVException()
+}
+
 const (
 	// MatChannels1 is a single channel Mat.
 	MatChannels1 = 0

--- a/core.h
+++ b/core.h
@@ -260,6 +260,17 @@ typedef struct Moment {
     double nu03;
 } Moment;
 
+// OpenCVResult is a struct that contains the result of an OpenCV operation.
+// It contains a code and a message. The code of 0 mean success, while a non-zero
+// code means an error occurred.
+// This is needed to wrap the result of an OpenCV operation, since Go does not
+// have exceptions.
+typedef struct OpenCVResult {
+    int Code;
+    const char* Message;
+    int Length;
+} OpenCVResult;
+
 int GetOpenCVException();
 const char* GetOpenCVExceptionMessage();
 void ClearOpenCVException();
@@ -289,6 +300,8 @@ typedef void* RotatedRectT;
 #endif
 
 void setExceptionInfo(int code, const char* message);
+OpenCVResult successResult();
+OpenCVResult errorResult(int code, const char* message);
 
 // Wrapper for the vector of Mat aka std::vector<Mat>
 typedef struct Mats {
@@ -331,17 +344,17 @@ void Mat_Inv(Mat m);
 Mat Mat_Col(Mat m, int c);
 Mat Mat_Row(Mat m, int r);
 Mat Mat_Clone(Mat m);
-void Mat_CopyTo(Mat m, Mat dst);
+OpenCVResult Mat_CopyTo(Mat m, Mat dst);
 int Mat_Total(Mat m);
 void Mat_Size(Mat m, IntVector* res);
-void Mat_CopyToWithMask(Mat m, Mat dst, Mat mask);
-void Mat_ConvertTo(Mat m, Mat dst, int type);
-void Mat_ConvertToWithParams(Mat m, Mat dst, int type, float alpha, float beta);
+OpenCVResult Mat_CopyToWithMask(Mat m, Mat dst, Mat mask);
+OpenCVResult Mat_ConvertTo(Mat m, Mat dst, int type);
+OpenCVResult Mat_ConvertToWithParams(Mat m, Mat dst, int type, float alpha, float beta);
 struct ByteArray Mat_ToBytes(Mat m);
 struct ByteArray Mat_DataPtr(Mat m);
 Mat Mat_Region(Mat m, Rect r);
 Mat Mat_Reshape(Mat m, int cn, int rows);
-void Mat_PatchNaNs(Mat m);
+OpenCVResult Mat_PatchNaNs(Mat m);
 Mat Mat_ConvertFp16(Mat m);
 Scalar Mat_Mean(Mat m);
 Scalar Mat_MeanWithMask(Mat m, Mat mask);
@@ -395,100 +408,100 @@ Mat Mat_MultiplyMatrix(Mat x, Mat y);
 
 Mat Mat_T(Mat x);
 
-void LUT(Mat src, Mat lut, Mat dst);
+OpenCVResult LUT(Mat src, Mat lut, Mat dst);
 
-void Mat_AbsDiff(Mat src1, Mat src2, Mat dst);
-void Mat_Add(Mat src1, Mat src2, Mat dst);
-void Mat_AddWeighted(Mat src1, double alpha, Mat src2, double beta, double gamma, Mat dst);
-void Mat_BitwiseAnd(Mat src1, Mat src2, Mat dst);
-void Mat_BitwiseAndWithMask(Mat src1, Mat src2, Mat dst, Mat mask);
-void Mat_BitwiseNot(Mat src1, Mat dst);
-void Mat_BitwiseNotWithMask(Mat src1, Mat dst, Mat mask);
-void Mat_BitwiseOr(Mat src1, Mat src2, Mat dst);
-void Mat_BitwiseOrWithMask(Mat src1, Mat src2, Mat dst, Mat mask);
-void Mat_BitwiseXor(Mat src1, Mat src2, Mat dst);
-void Mat_BitwiseXorWithMask(Mat src1, Mat src2, Mat dst, Mat mask);
-void Mat_Compare(Mat src1, Mat src2, Mat dst, int ct);
-void Mat_BatchDistance(Mat src1, Mat src2, Mat dist, int dtype, Mat nidx, int normType, int K,
+OpenCVResult Mat_AbsDiff(Mat src1, Mat src2, Mat dst);
+OpenCVResult Mat_Add(Mat src1, Mat src2, Mat dst);
+OpenCVResult Mat_AddWeighted(Mat src1, double alpha, Mat src2, double beta, double gamma, Mat dst);
+OpenCVResult Mat_BitwiseAnd(Mat src1, Mat src2, Mat dst);
+OpenCVResult Mat_BitwiseAndWithMask(Mat src1, Mat src2, Mat dst, Mat mask);
+OpenCVResult Mat_BitwiseNot(Mat src1, Mat dst);
+OpenCVResult Mat_BitwiseNotWithMask(Mat src1, Mat dst, Mat mask);
+OpenCVResult Mat_BitwiseOr(Mat src1, Mat src2, Mat dst);
+OpenCVResult Mat_BitwiseOrWithMask(Mat src1, Mat src2, Mat dst, Mat mask);
+OpenCVResult Mat_BitwiseXor(Mat src1, Mat src2, Mat dst);
+OpenCVResult Mat_BitwiseXorWithMask(Mat src1, Mat src2, Mat dst, Mat mask);
+OpenCVResult Mat_Compare(Mat src1, Mat src2, Mat dst, int ct);
+OpenCVResult Mat_BatchDistance(Mat src1, Mat src2, Mat dist, int dtype, Mat nidx, int normType, int K,
                        Mat mask, int update, bool crosscheck);
 int Mat_BorderInterpolate(int p, int len, int borderType);
-void Mat_CalcCovarMatrix(Mat samples, Mat covar, Mat mean, int flags, int ctype);
-void Mat_CartToPolar(Mat x, Mat y, Mat magnitude, Mat angle, bool angleInDegrees);
+OpenCVResult Mat_CalcCovarMatrix(Mat samples, Mat covar, Mat mean, int flags, int ctype);
+OpenCVResult Mat_CartToPolar(Mat x, Mat y, Mat magnitude, Mat angle, bool angleInDegrees);
 bool Mat_CheckRange(Mat m);
-void Mat_CompleteSymm(Mat m, bool lowerToUpper);
-void Mat_ConvertScaleAbs(Mat src, Mat dst, double alpha, double beta);
-void Mat_CopyMakeBorder(Mat src, Mat dst, int top, int bottom, int left, int right, int borderType,
+OpenCVResult Mat_CompleteSymm(Mat m, bool lowerToUpper);
+OpenCVResult Mat_ConvertScaleAbs(Mat src, Mat dst, double alpha, double beta);
+OpenCVResult Mat_CopyMakeBorder(Mat src, Mat dst, int top, int bottom, int left, int right, int borderType,
                         Scalar value);
 int Mat_CountNonZero(Mat src);
-void Mat_DCT(Mat src, Mat dst, int flags);
+OpenCVResult Mat_DCT(Mat src, Mat dst, int flags);
 double Mat_Determinant(Mat m);
-void Mat_DFT(Mat m, Mat dst, int flags);
-void Mat_Divide(Mat src1, Mat src2, Mat dst);
+OpenCVResult Mat_DFT(Mat m, Mat dst, int flags);
+OpenCVResult Mat_Divide(Mat src1, Mat src2, Mat dst);
 bool Mat_Eigen(Mat src, Mat eigenvalues, Mat eigenvectors);
-void Mat_EigenNonSymmetric(Mat src, Mat eigenvalues, Mat eigenvectors);
-void Mat_PCABackProject(Mat data, Mat mean, Mat eigenvectors, Mat result);
-void Mat_PCACompute(Mat src, Mat mean, Mat eigenvectors, Mat eigenvalues, int maxComponents);
-void Mat_PCAProject(Mat data, Mat mean, Mat eigenvectors, Mat result);
+OpenCVResult Mat_EigenNonSymmetric(Mat src, Mat eigenvalues, Mat eigenvectors);
+OpenCVResult Mat_PCABackProject(Mat data, Mat mean, Mat eigenvectors, Mat result);
+OpenCVResult Mat_PCACompute(Mat src, Mat mean, Mat eigenvectors, Mat eigenvalues, int maxComponents);
+OpenCVResult Mat_PCAProject(Mat data, Mat mean, Mat eigenvectors, Mat result);
 double PSNR(Mat src1, Mat src2);
-void SVBackSubst(Mat w, Mat u, Mat vt, Mat rhs, Mat dst);
-void SVDecomp(Mat src, Mat w, Mat u, Mat vt);
-void Mat_Exp(Mat src, Mat dst);
-void Mat_ExtractChannel(Mat src, Mat dst, int coi);
-void Mat_FindNonZero(Mat src, Mat idx);
-void Mat_Flip(Mat src, Mat dst, int flipCode);
-void Mat_Gemm(Mat src1, Mat src2, double alpha, Mat src3, double beta, Mat dst, int flags);
+OpenCVResult SVBackSubst(Mat w, Mat u, Mat vt, Mat rhs, Mat dst);
+OpenCVResult SVDecomp(Mat src, Mat w, Mat u, Mat vt);
+OpenCVResult Mat_Exp(Mat src, Mat dst);
+OpenCVResult Mat_ExtractChannel(Mat src, Mat dst, int coi);
+OpenCVResult Mat_FindNonZero(Mat src, Mat idx);
+OpenCVResult Mat_Flip(Mat src, Mat dst, int flipCode);
+OpenCVResult Mat_Gemm(Mat src1, Mat src2, double alpha, Mat src3, double beta, Mat dst, int flags);
 int Mat_GetOptimalDFTSize(int vecsize);
-void Mat_Hconcat(Mat src1, Mat src2, Mat dst);
-void Mat_Vconcat(Mat src1, Mat src2, Mat dst);
-void Rotate(Mat src, Mat dst, int rotationCode);
-void Mat_Idct(Mat src, Mat dst, int flags);
-void Mat_Idft(Mat src, Mat dst, int flags, int nonzeroRows);
-void Mat_InRange(Mat src, Mat lowerb, Mat upperb, Mat dst);
-void Mat_InRangeWithScalar(Mat src, const Scalar lowerb, const Scalar upperb, Mat dst);
-void Mat_InsertChannel(Mat src, Mat dst, int coi);
+OpenCVResult Mat_Hconcat(Mat src1, Mat src2, Mat dst);
+OpenCVResult Mat_Vconcat(Mat src1, Mat src2, Mat dst);
+OpenCVResult Rotate(Mat src, Mat dst, int rotationCode);
+OpenCVResult Mat_Idct(Mat src, Mat dst, int flags);
+OpenCVResult Mat_Idft(Mat src, Mat dst, int flags, int nonzeroRows);
+OpenCVResult Mat_InRange(Mat src, Mat lowerb, Mat upperb, Mat dst);
+OpenCVResult Mat_InRangeWithScalar(Mat src, const Scalar lowerb, const Scalar upperb, Mat dst);
+OpenCVResult Mat_InsertChannel(Mat src, Mat dst, int coi);
 double Mat_Invert(Mat src, Mat dst, int flags);
 double KMeans(Mat data, int k, Mat bestLabels, TermCriteria criteria, int attempts, int flags, Mat centers);
 double KMeansPoints(PointVector pts, int k, Mat bestLabels, TermCriteria criteria, int attempts, int flags, Mat centers);
-void Mat_Log(Mat src, Mat dst);
-void Mat_Magnitude(Mat x, Mat y, Mat magnitude);
+OpenCVResult Mat_Log(Mat src, Mat dst);
+OpenCVResult Mat_Magnitude(Mat x, Mat y, Mat magnitude);
 double Mat_Mahalanobis(Mat v1, Mat v2, Mat icovar);
-void MulTransposed(Mat src, Mat dest, bool ata);
-void Mat_Max(Mat src1, Mat src2, Mat dst);
-void Mat_MeanStdDev(Mat src, Mat dstMean, Mat dstStdDev);
-void Mat_Merge(struct Mats mats, Mat dst);
-void Mat_Min(Mat src1, Mat src2, Mat dst);
-void Mat_MinMaxIdx(Mat m, double* minVal, double* maxVal, int* minIdx, int* maxIdx);
-void Mat_MinMaxLoc(Mat m, double* minVal, double* maxVal, Point* minLoc, Point* maxLoc);
-void Mat_MinMaxLocWithMask(Mat m, double* minVal, double* maxVal, Point* minLoc, Point* maxLoc, Mat mask);
-void Mat_MixChannels(struct Mats src, struct Mats dst, struct IntVector fromTo);
-void Mat_MulSpectrums(Mat a, Mat b, Mat c, int flags);
-void Mat_Multiply(Mat src1, Mat src2, Mat dst);
-void Mat_MultiplyWithParams(Mat src1, Mat src2, Mat dst, double scale, int dtype);
-void Mat_Subtract(Mat src1, Mat src2, Mat dst);
-void Mat_Normalize(Mat src, Mat dst, double alpha, double beta, int typ);
+OpenCVResult MulTransposed(Mat src, Mat dest, bool ata);
+OpenCVResult Mat_Max(Mat src1, Mat src2, Mat dst);
+OpenCVResult Mat_MeanStdDev(Mat src, Mat dstMean, Mat dstStdDev);
+OpenCVResult Mat_Merge(struct Mats mats, Mat dst);
+OpenCVResult Mat_Min(Mat src1, Mat src2, Mat dst);
+OpenCVResult Mat_MinMaxIdx(Mat m, double* minVal, double* maxVal, int* minIdx, int* maxIdx);
+OpenCVResult Mat_MinMaxLoc(Mat m, double* minVal, double* maxVal, Point* minLoc, Point* maxLoc);
+OpenCVResult Mat_MinMaxLocWithMask(Mat m, double* minVal, double* maxVal, Point* minLoc, Point* maxLoc, Mat mask);
+OpenCVResult Mat_MixChannels(struct Mats src, struct Mats dst, struct IntVector fromTo);
+OpenCVResult Mat_MulSpectrums(Mat a, Mat b, Mat c, int flags);
+OpenCVResult Mat_Multiply(Mat src1, Mat src2, Mat dst);
+OpenCVResult Mat_MultiplyWithParams(Mat src1, Mat src2, Mat dst, double scale, int dtype);
+OpenCVResult Mat_Subtract(Mat src1, Mat src2, Mat dst);
+OpenCVResult Mat_Normalize(Mat src, Mat dst, double alpha, double beta, int typ);
 double Norm(Mat src1, int normType);
 double NormWithMats(Mat src1, Mat src2, int normType);
-void Mat_PerspectiveTransform(Mat src, Mat dst, Mat tm);
+OpenCVResult Mat_PerspectiveTransform(Mat src, Mat dst, Mat tm);
 bool Mat_Solve(Mat src1, Mat src2, Mat dst, int flags);
 int Mat_SolveCubic(Mat coeffs, Mat roots);
 double Mat_SolvePoly(Mat coeffs, Mat roots, int maxIters);
-void Mat_Reduce(Mat src, Mat dst, int dim, int rType, int dType);
-void Mat_ReduceArgMax(Mat src, Mat dst, int axis, bool lastIndex);
-void Mat_ReduceArgMin(Mat src, Mat dst, int axis, bool lastIndex);
-void Mat_Repeat(Mat src, int nY, int nX, Mat dst);
-void Mat_ScaleAdd(Mat src1, double alpha, Mat src2, Mat dst);
-void Mat_SetIdentity(Mat src, double scalar);
-void Mat_Sort(Mat src, Mat dst, int flags);
-void Mat_SortIdx(Mat src, Mat dst, int flags);
-void Mat_Split(Mat src, struct Mats* mats);
-void Mat_Subtract(Mat src1, Mat src2, Mat dst);
+OpenCVResult Mat_Reduce(Mat src, Mat dst, int dim, int rType, int dType);
+OpenCVResult Mat_ReduceArgMax(Mat src, Mat dst, int axis, bool lastIndex);
+OpenCVResult Mat_ReduceArgMin(Mat src, Mat dst, int axis, bool lastIndex);
+OpenCVResult Mat_Repeat(Mat src, int nY, int nX, Mat dst);
+OpenCVResult Mat_ScaleAdd(Mat src1, double alpha, Mat src2, Mat dst);
+OpenCVResult Mat_SetIdentity(Mat src, double scalar);
+OpenCVResult Mat_Sort(Mat src, Mat dst, int flags);
+OpenCVResult Mat_SortIdx(Mat src, Mat dst, int flags);
+OpenCVResult Mat_Split(Mat src, struct Mats* mats);
+OpenCVResult Mat_Subtract(Mat src1, Mat src2, Mat dst);
 Scalar Mat_Trace(Mat src);
-void Mat_Transform(Mat src, Mat dst, Mat tm);
-void Mat_Transpose(Mat src, Mat dst);
-void Mat_TransposeND(Mat src, struct IntVector order, Mat dst);
-void Mat_PolarToCart(Mat magnitude, Mat degree, Mat x, Mat y, bool angleInDegrees);
-void Mat_Pow(Mat src, double power, Mat dst);
-void Mat_Phase(Mat x, Mat y, Mat angle, bool angleInDegrees);
+OpenCVResult Mat_Transform(Mat src, Mat dst, Mat tm);
+OpenCVResult Mat_Transpose(Mat src, Mat dst);
+OpenCVResult Mat_TransposeND(Mat src, struct IntVector order, Mat dst);
+OpenCVResult Mat_PolarToCart(Mat magnitude, Mat degree, Mat x, Mat y, bool angleInDegrees);
+OpenCVResult Mat_Pow(Mat src, double power, Mat dst);
+OpenCVResult Mat_Phase(Mat x, Mat y, Mat angle, bool angleInDegrees);
 Scalar Mat_Sum(Mat src1);
 
 TermCriteria TermCriteria_New(int typ, int maxCount, double epsilon);

--- a/core.h
+++ b/core.h
@@ -260,6 +260,10 @@ typedef struct Moment {
     double nu03;
 } Moment;
 
+int GetOpenCVException();
+const char* GetOpenCVExceptionMessage();
+void ClearOpenCVException();
+
 #ifdef __cplusplus
 typedef cv::Mat* Mat;
 typedef cv::TermCriteria* TermCriteria;
@@ -283,6 +287,8 @@ typedef void* Point3fVector;
 typedef void* Points3fVector;
 typedef void* RotatedRectT;
 #endif
+
+void setExceptionInfo(int code, const char* message);
 
 // Wrapper for the vector of Mat aka std::vector<Mat>
 typedef struct Mats {

--- a/cuda/arithm.cpp
+++ b/cuda/arithm.cpp
@@ -3,193 +3,286 @@
 #include <string.h>
 
 void GpuAbs(GpuMat src, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::abs(*src, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::abs(*src, *dst);
+            return;
+        }
+        cv::cuda::abs(*src, *dst, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::abs(*src, *dst, *s);
 }
 
 void GpuAbsDiff(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::absdiff(*src1, *src2, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::absdiff(*src1, *src2, *dst);
+            return;
+        }
+        cv::cuda::absdiff(*src1, *src2, *dst, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::absdiff(*src1, *src2, *dst, *s);
 }
 
 void GpuAdd(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::add(*src1, *src2, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::add(*src1, *src2, *dst);
+            return;
+        }
+        cv::cuda::add(*src1, *src2, *dst, cv::noArray(), -1, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::add(*src1, *src2, *dst, cv::noArray(), -1, *s);
 }
 
 void GpuBitwiseAnd(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::bitwise_and(*src1, *src2, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::bitwise_and(*src1, *src2, *dst);
+            return;
+        }
+        cv::cuda::bitwise_and(*src1, *src2, *dst, cv::noArray(), *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::bitwise_and(*src1, *src2, *dst, cv::noArray(), *s);
 }
 
 void GpuBitwiseNot(GpuMat src, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::bitwise_not(*src, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::bitwise_not(*src, *dst);
+            return;
+        }
+        cv::cuda::bitwise_not(*src, *dst, cv::noArray(), *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::bitwise_not(*src, *dst, cv::noArray(), *s);
 }
 
 void GpuBitwiseOr(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::bitwise_or(*src1, *src2, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::bitwise_or(*src1, *src2, *dst);
+            return;
+        }
+        cv::cuda::bitwise_or(*src1, *src2, *dst, cv::noArray(), *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::bitwise_or(*src1, *src2, *dst, cv::noArray(), *s);
 }
 
 void GpuBitwiseXor(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::bitwise_xor(*src1, *src2, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::bitwise_xor(*src1, *src2, *dst);
+            return;
+        }
+        cv::cuda::bitwise_xor(*src1, *src2, *dst, cv::noArray(), *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::bitwise_xor(*src1, *src2, *dst, cv::noArray(), *s);
 }
 
 void GpuDivide(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::divide(*src1, *src2, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::divide(*src1, *src2, *dst);
+            return;
+        }
+        cv::cuda::divide(*src1, *src2, *dst, 1, -1, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::divide(*src1, *src2, *dst, 1, -1, *s);
 }
 
 void GpuExp(GpuMat src, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::exp(*src, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::exp(*src, *dst);
+            return;
+        }
+        cv::cuda::exp(*src, *dst, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::exp(*src, *dst, *s);
 }
 
 void GpuLog(GpuMat src, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::log(*src, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::log(*src, *dst);
+            return;
+        }
+        cv::cuda::log(*src, *dst, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::log(*src, *dst, *s);
 }
 
 void GpuMax(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::max(*src1, *src2, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::max(*src1, *src2, *dst);
+            return;
+        }
+        cv::cuda::max(*src1, *src2, *dst, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::max(*src1, *src2, *dst, *s);
 }
 
 void GpuMin(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::min(*src1, *src2, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::min(*src1, *src2, *dst);
+            return;
+        }
+        cv::cuda::min(*src1, *src2, *dst, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::min(*src1, *src2, *dst, *s);
 }
 
 void GpuMultiply(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::multiply(*src1, *src2, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::multiply(*src1, *src2, *dst);
+            return;
+        }
+        cv::cuda::multiply(*src1, *src2, *dst, 1, -1, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::multiply(*src1, *src2, *dst, 1, -1, *s);
 }
 
 void GpuSqr(GpuMat src, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::sqr(*src, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::sqr(*src, *dst);
+            return;
+        }
+        cv::cuda::sqr(*src, *dst, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::sqr(*src, *dst, *s);
 }
 
 void GpuSqrt(GpuMat src, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::sqrt(*src, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::sqrt(*src, *dst);
+            return;
+        }
+        cv::cuda::sqrt(*src, *dst, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::sqrt(*src, *dst, *s);
 }
 
 void GpuSubtract(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::subtract(*src1, *src2, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::subtract(*src1, *src2, *dst);
+            return;
+        }
+        cv::cuda::subtract(*src1, *src2, *dst, cv::noArray(), -1, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::subtract(*src1, *src2, *dst, cv::noArray(), -1, *s);
 }
 
 void GpuThreshold(GpuMat src, GpuMat dst, double thresh, double maxval, int typ, Stream s) {
-    if (s == NULL) {
-        cv::cuda::threshold(*src, *dst, thresh, maxval, typ);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::threshold(*src, *dst, thresh, maxval, typ);
+            return;
+        }
+    
+        cv::cuda::threshold(*src, *dst, thresh, maxval, typ, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    cv::cuda::threshold(*src, *dst, thresh, maxval, typ, *s);
 }
 
 void GpuFlip(GpuMat src, GpuMat dst, int flipCode, Stream s) {
-    if (s == NULL) {
-        cv::cuda::flip(*src, *dst, flipCode);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::flip(*src, *dst, flipCode);
+            return;
+        }
+        cv::cuda::flip(*src, *dst, flipCode, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::flip(*src, *dst, flipCode, *s);
 }
 
 void GpuMerge(struct GpuMats mats, GpuMat dst, Stream s) {
-    std::vector<cv::cuda::GpuMat> images;
+    try {
+        std::vector<cv::cuda::GpuMat> images;
 
-    for (int i = 0; i < mats.length; ++i) {
-        images.push_back(*mats.mats[i]);
+        for (int i = 0; i < mats.length; ++i) {
+            images.push_back(*mats.mats[i]);
+        }
+    
+        if (s == NULL) {
+            cv::cuda::merge(images, *dst);
+            return;
+        }
+        cv::cuda::merge(images, *dst, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    if (s == NULL) {
-        cv::cuda::merge(images, *dst);
-        return;
-    }
-    cv::cuda::merge(images, *dst, *s);
 }
 
 void GpuTranspose(GpuMat src, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::transpose(*src, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::transpose(*src, *dst);
+            return;
+        }
+        cv::cuda::transpose(*src, *dst, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::transpose(*src, *dst, *s);
 }
 
 void GpuAddWeighted(GpuMat src1, double alpha, GpuMat src2, double beta, double gamma, GpuMat dst, int dType, Stream s) {
-    if (s == NULL) {
-        cv::cuda::addWeighted(*src1, alpha, *src2, beta, gamma, *dst, dType);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::addWeighted(*src1, alpha, *src2, beta, gamma, *dst, dType);
+            return;
+        }
+    
+        cv::cuda::addWeighted(*src1, alpha, *src2, beta, gamma, *dst, dType, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    cv::cuda::addWeighted(*src1, alpha, *src2, beta, gamma, *dst, dType, *s);
 }
 
 void GpuCopyMakeBorder(GpuMat src, GpuMat dst, int top, int bottom, int left, int right, int borderType, Scalar value, Stream s) {
-    cv::Scalar cValue = cv::Scalar(value.val1, value.val2, value.val3, value.val4);
+    try {
+        cv::Scalar cValue = cv::Scalar(value.val1, value.val2, value.val3, value.val4);
 
-    if (s == NULL) {
-        cv::cuda::copyMakeBorder(*src, *dst, top, bottom, left, right, borderType, cValue);
-        return;
+        if (s == NULL) {
+            cv::cuda::copyMakeBorder(*src, *dst, top, bottom, left, right, borderType, cValue);
+            return;
+        }
+        cv::cuda::copyMakeBorder(*src, *dst, top, bottom, left, right, borderType, cValue, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::copyMakeBorder(*src, *dst, top, bottom, left, right, borderType, cValue, *s);
 }
 
 LookUpTable Cuda_Create_LookUpTable(GpuMat lut){
-    return new cv::Ptr<cv::cuda::LookUpTable>(cv::cuda::createLookUpTable(*lut));
+    try {
+        return new cv::Ptr<cv::cuda::LookUpTable>(cv::cuda::createLookUpTable(*lut));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void Cuda_LookUpTable_Close(LookUpTable lt) {
@@ -197,30 +290,42 @@ void Cuda_LookUpTable_Close(LookUpTable lt) {
 }
 
 bool Cuda_LookUpTable_Empty(LookUpTable lut) {
-    return lut->empty();
+    try {
+        return lut->empty();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return true;
+    }
 }
 
 void Cuda_LookUpTable_Transform(LookUpTable lt, GpuMat src, GpuMat dst, Stream s) {
-    cv::Ptr< cv::cuda::LookUpTable> p = cv::Ptr< cv::cuda::LookUpTable>(*lt);
+    try {
+        cv::Ptr< cv::cuda::LookUpTable> p = cv::Ptr< cv::cuda::LookUpTable>(*lt);
 
-    if(s == NULL) {
-        p->transform(*src, *dst);
-    } else {
-        p->transform(*src, *dst, *s);
+        if(s == NULL) {
+            p->transform(*src, *dst);
+        } else {
+            p->transform(*src, *dst, *s);
+        }    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
 }
 
 void Cuda_Split(GpuMat src, GpuMats dst, Stream s) {
-    std::vector< cv::cuda::GpuMat > dstv;
+    try {
+        std::vector< cv::cuda::GpuMat > dstv;
 
-    for(int i = 0; i < dst.length; i++) {
-        dstv.push_back(*(dst.mats[i]));
+        for(int i = 0; i < dst.length; i++) {
+            dstv.push_back(*(dst.mats[i]));
+        }
+    
+        if(s == NULL){
+            cv::cuda::split(*src, dstv);
+        } else {
+            cv::cuda::split(*src, dstv, *s);
+        }    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    if(s == NULL){
-        cv::cuda::split(*src, dstv);
-    } else {
-        cv::cuda::split(*src, dstv, *s);
-    }
-
 }

--- a/cuda/arithm.cpp
+++ b/cuda/arithm.cpp
@@ -2,224 +2,241 @@
 #include "arithm.h"
 #include <string.h>
 
-void GpuAbs(GpuMat src, GpuMat dst, Stream s) {
+OpenCVResult GpuAbs(GpuMat src, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::abs(*src, *dst);
-            return;
+        } else {
+            cv::cuda::abs(*src, *dst, *s);
         }
-        cv::cuda::abs(*src, *dst, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuAbsDiff(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
+OpenCVResult GpuAbsDiff(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::absdiff(*src1, *src2, *dst);
-            return;
+        } else {
+            cv::cuda::absdiff(*src1, *src2, *dst, *s);
         }
-        cv::cuda::absdiff(*src1, *src2, *dst, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuAdd(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
+OpenCVResult GpuAdd(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::add(*src1, *src2, *dst);
-            return;
+        } else {
+            cv::cuda::add(*src1, *src2, *dst, cv::noArray(), -1, *s);
         }
-        cv::cuda::add(*src1, *src2, *dst, cv::noArray(), -1, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuBitwiseAnd(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
+OpenCVResult GpuBitwiseAnd(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::bitwise_and(*src1, *src2, *dst);
-            return;
+        } else {
+            cv::cuda::bitwise_and(*src1, *src2, *dst, cv::noArray(), *s);
         }
-        cv::cuda::bitwise_and(*src1, *src2, *dst, cv::noArray(), *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuBitwiseNot(GpuMat src, GpuMat dst, Stream s) {
+OpenCVResult GpuBitwiseNot(GpuMat src, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::bitwise_not(*src, *dst);
-            return;
+        } else {
+            cv::cuda::bitwise_not(*src, *dst, cv::noArray(), *s);
         }
-        cv::cuda::bitwise_not(*src, *dst, cv::noArray(), *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuBitwiseOr(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
+OpenCVResult GpuBitwiseOr(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::bitwise_or(*src1, *src2, *dst);
-            return;
+        } else {
+            cv::cuda::bitwise_or(*src1, *src2, *dst, cv::noArray(), *s);
         }
-        cv::cuda::bitwise_or(*src1, *src2, *dst, cv::noArray(), *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuBitwiseXor(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
+OpenCVResult GpuBitwiseXor(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::bitwise_xor(*src1, *src2, *dst);
-            return;
+        } else {
+            cv::cuda::bitwise_xor(*src1, *src2, *dst, cv::noArray(), *s);
         }
-        cv::cuda::bitwise_xor(*src1, *src2, *dst, cv::noArray(), *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuDivide(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
+OpenCVResult GpuDivide(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::divide(*src1, *src2, *dst);
-            return;
+        } else {
+            cv::cuda::divide(*src1, *src2, *dst, 1, -1, *s);
         }
-        cv::cuda::divide(*src1, *src2, *dst, 1, -1, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuExp(GpuMat src, GpuMat dst, Stream s) {
+OpenCVResult GpuExp(GpuMat src, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::exp(*src, *dst);
-            return;
+        } else {
+            cv::cuda::exp(*src, *dst, *s);
         }
-        cv::cuda::exp(*src, *dst, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuLog(GpuMat src, GpuMat dst, Stream s) {
+OpenCVResult GpuLog(GpuMat src, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::log(*src, *dst);
-            return;
+        } else {
+            cv::cuda::log(*src, *dst, *s);
         }
-        cv::cuda::log(*src, *dst, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuMax(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
+OpenCVResult GpuMax(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::max(*src1, *src2, *dst);
-            return;
+        } else {
+            cv::cuda::max(*src1, *src2, *dst, *s);
         }
-        cv::cuda::max(*src1, *src2, *dst, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuMin(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
+OpenCVResult GpuMin(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::min(*src1, *src2, *dst);
-            return;
+        } else {
+            cv::cuda::min(*src1, *src2, *dst, *s);
         }
-        cv::cuda::min(*src1, *src2, *dst, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuMultiply(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
+OpenCVResult GpuMultiply(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::multiply(*src1, *src2, *dst);
-            return;
+        } else {
+            cv::cuda::multiply(*src1, *src2, *dst, 1, -1, *s);
         }
-        cv::cuda::multiply(*src1, *src2, *dst, 1, -1, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuSqr(GpuMat src, GpuMat dst, Stream s) {
+OpenCVResult GpuSqr(GpuMat src, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::sqr(*src, *dst);
-            return;
+        } else {
+            cv::cuda::sqr(*src, *dst, *s);
         }
-        cv::cuda::sqr(*src, *dst, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuSqrt(GpuMat src, GpuMat dst, Stream s) {
+OpenCVResult GpuSqrt(GpuMat src, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::sqrt(*src, *dst);
-            return;
+        } else {
+            cv::cuda::sqrt(*src, *dst, *s);
         }
-        cv::cuda::sqrt(*src, *dst, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuSubtract(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
+OpenCVResult GpuSubtract(GpuMat src1, GpuMat src2, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::subtract(*src1, *src2, *dst);
-            return;
+        } else {
+            cv::cuda::subtract(*src1, *src2, *dst, cv::noArray(), -1, *s);
         }
-        cv::cuda::subtract(*src1, *src2, *dst, cv::noArray(), -1, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuThreshold(GpuMat src, GpuMat dst, double thresh, double maxval, int typ, Stream s) {
+OpenCVResult GpuThreshold(GpuMat src, GpuMat dst, double thresh, double maxval, int typ, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::threshold(*src, *dst, thresh, maxval, typ);
-            return;
+        } else {
+            cv::cuda::threshold(*src, *dst, thresh, maxval, typ, *s);
         }
-    
-        cv::cuda::threshold(*src, *dst, thresh, maxval, typ, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuFlip(GpuMat src, GpuMat dst, int flipCode, Stream s) {
+OpenCVResult GpuFlip(GpuMat src, GpuMat dst, int flipCode, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::flip(*src, *dst, flipCode);
-            return;
+        } else {
+            cv::cuda::flip(*src, *dst, flipCode, *s);
         }
-        cv::cuda::flip(*src, *dst, flipCode, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuMerge(struct GpuMats mats, GpuMat dst, Stream s) {
+OpenCVResult GpuMerge(struct GpuMats mats, GpuMat dst, Stream s) {
     try {
         std::vector<cv::cuda::GpuMat> images;
 
@@ -229,50 +246,53 @@ void GpuMerge(struct GpuMats mats, GpuMat dst, Stream s) {
     
         if (s == NULL) {
             cv::cuda::merge(images, *dst);
-            return;
+        } else {
+            cv::cuda::merge(images, *dst, *s);
         }
-        cv::cuda::merge(images, *dst, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuTranspose(GpuMat src, GpuMat dst, Stream s) {
+OpenCVResult GpuTranspose(GpuMat src, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::transpose(*src, *dst);
-            return;
+        } else {
+            cv::cuda::transpose(*src, *dst, *s);
         }
-        cv::cuda::transpose(*src, *dst, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuAddWeighted(GpuMat src1, double alpha, GpuMat src2, double beta, double gamma, GpuMat dst, int dType, Stream s) {
+OpenCVResult GpuAddWeighted(GpuMat src1, double alpha, GpuMat src2, double beta, double gamma, GpuMat dst, int dType, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::addWeighted(*src1, alpha, *src2, beta, gamma, *dst, dType);
-            return;
+        } else {    
+            cv::cuda::addWeighted(*src1, alpha, *src2, beta, gamma, *dst, dType, *s);
         }
-    
-        cv::cuda::addWeighted(*src1, alpha, *src2, beta, gamma, *dst, dType, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuCopyMakeBorder(GpuMat src, GpuMat dst, int top, int bottom, int left, int right, int borderType, Scalar value, Stream s) {
+OpenCVResult GpuCopyMakeBorder(GpuMat src, GpuMat dst, int top, int bottom, int left, int right, int borderType, Scalar value, Stream s) {
     try {
         cv::Scalar cValue = cv::Scalar(value.val1, value.val2, value.val3, value.val4);
 
         if (s == NULL) {
             cv::cuda::copyMakeBorder(*src, *dst, top, bottom, left, right, borderType, cValue);
-            return;
+        } else {
+            cv::cuda::copyMakeBorder(*src, *dst, top, bottom, left, right, borderType, cValue, *s);
         }
-        cv::cuda::copyMakeBorder(*src, *dst, top, bottom, left, right, borderType, cValue, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -298,7 +318,7 @@ bool Cuda_LookUpTable_Empty(LookUpTable lut) {
     }
 }
 
-void Cuda_LookUpTable_Transform(LookUpTable lt, GpuMat src, GpuMat dst, Stream s) {
+OpenCVResult Cuda_LookUpTable_Transform(LookUpTable lt, GpuMat src, GpuMat dst, Stream s) {
     try {
         cv::Ptr< cv::cuda::LookUpTable> p = cv::Ptr< cv::cuda::LookUpTable>(*lt);
 
@@ -307,12 +327,13 @@ void Cuda_LookUpTable_Transform(LookUpTable lt, GpuMat src, GpuMat dst, Stream s
         } else {
             p->transform(*src, *dst, *s);
         }    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Cuda_Split(GpuMat src, GpuMats dst, Stream s) {
+OpenCVResult Cuda_Split(GpuMat src, GpuMats dst, Stream s) {
     try {
         std::vector< cv::cuda::GpuMat > dstv;
 
@@ -325,7 +346,8 @@ void Cuda_Split(GpuMat src, GpuMats dst, Stream s) {
         } else {
             cv::cuda::split(*src, dstv, *s);
         }    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }

--- a/cuda/arithm.go
+++ b/cuda/arithm.go
@@ -18,8 +18,8 @@ import (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga54a72bd772494ab34d05406fd76df2b6
-func Abs(src GpuMat, dst *GpuMat) {
-	C.GpuAbs(src.p, dst.p, nil)
+func Abs(src GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.GpuAbs(src.p, dst.p, nil))
 }
 
 // AbsWithStream computes an absolute value of each matrix element
@@ -27,8 +27,8 @@ func Abs(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga54a72bd772494ab34d05406fd76df2b6
-func AbsWithStream(src GpuMat, dst *GpuMat, stream Stream) {
-	C.GpuAbs(src.p, dst.p, stream.p)
+func AbsWithStream(src GpuMat, dst *GpuMat, stream Stream) error {
+	return OpenCVResult(C.GpuAbs(src.p, dst.p, stream.p))
 }
 
 // AbsDiff computes per-element absolute difference of two matrices
@@ -36,8 +36,8 @@ func AbsWithStream(src GpuMat, dst *GpuMat, stream Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gac062b283cf46ee90f74a773d3382ab54
-func AbsDiff(src1, src2 GpuMat, dst *GpuMat) {
-	C.GpuAbsDiff(src1.p, src2.p, dst.p, nil)
+func AbsDiff(src1, src2 GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.GpuAbsDiff(src1.p, src2.p, dst.p, nil))
 }
 
 // AbsDiffWithStream computes an absolute value of each matrix element
@@ -45,16 +45,16 @@ func AbsDiff(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gac062b283cf46ee90f74a773d3382ab54
-func AbsDiffWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
-	C.GpuAbsDiff(src1.p, src2.p, dst.p, s.p)
+func AbsDiffWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.GpuAbsDiff(src1.p, src2.p, dst.p, s.p))
 }
 
 // Add computes a matrix-matrix or matrix-scalar sum.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga5d9794bde97ed23d1c1485249074a8b1
-func Add(src1, src2 GpuMat, dst *GpuMat) {
-	C.GpuAdd(src1.p, src2.p, dst.p, nil)
+func Add(src1, src2 GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.GpuAdd(src1.p, src2.p, dst.p, nil))
 }
 
 // AddWithStream computes a matrix-matrix or matrix-scalar sum
@@ -62,8 +62,8 @@ func Add(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga5d9794bde97ed23d1c1485249074a8b1
-func AddWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
-	C.GpuAdd(src1.p, src2.p, dst.p, s.p)
+func AddWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.GpuAdd(src1.p, src2.p, dst.p, s.p))
 }
 
 // BitwiseAnd performs a per-element bitwise conjunction of two matrices
@@ -71,8 +71,8 @@ func AddWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga78d7c1a013877abd4237fbfc4e13bd76
-func BitwiseAnd(src1, src2 GpuMat, dst *GpuMat) {
-	C.GpuBitwiseAnd(src1.p, src2.p, dst.p, nil)
+func BitwiseAnd(src1, src2 GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.GpuBitwiseAnd(src1.p, src2.p, dst.p, nil))
 }
 
 // BitwiseAndWithStream performs a per-element bitwise conjunction of two matrices
@@ -80,16 +80,16 @@ func BitwiseAnd(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga78d7c1a013877abd4237fbfc4e13bd76
-func BitwiseAndWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
-	C.GpuBitwiseAnd(src1.p, src2.p, dst.p, s.p)
+func BitwiseAndWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.GpuBitwiseAnd(src1.p, src2.p, dst.p, s.p))
 }
 
 // BitwiseNot performs a per-element bitwise inversion.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gae58159a2259ae1acc76b531c171cf06a
-func BitwiseNot(src GpuMat, dst *GpuMat) {
-	C.GpuBitwiseNot(src.p, dst.p, nil)
+func BitwiseNot(src GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.GpuBitwiseNot(src.p, dst.p, nil))
 }
 
 // BitwiseNotWithStream performs a per-element bitwise inversion
@@ -97,8 +97,8 @@ func BitwiseNot(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gae58159a2259ae1acc76b531c171cf06a
-func BitwiseNotWithStream(src GpuMat, dst *GpuMat, s Stream) {
-	C.GpuBitwiseNot(src.p, dst.p, s.p)
+func BitwiseNotWithStream(src GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.GpuBitwiseNot(src.p, dst.p, s.p))
 }
 
 // BitwiseOr performs a per-element bitwise disjunction of two matrices
@@ -106,8 +106,8 @@ func BitwiseNotWithStream(src GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gafd098ee3e51c68daa793999c1da3dfb7
-func BitwiseOr(src1, src2 GpuMat, dst *GpuMat) {
-	C.GpuBitwiseOr(src1.p, src2.p, dst.p, nil)
+func BitwiseOr(src1, src2 GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.GpuBitwiseOr(src1.p, src2.p, dst.p, nil))
 }
 
 // BitwiseOrWithStream performs a per-element bitwise disjunction of two matrices
@@ -115,8 +115,8 @@ func BitwiseOr(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gafd098ee3e51c68daa793999c1da3dfb7
-func BitwiseOrWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
-	C.GpuBitwiseXor(src1.p, src2.p, dst.p, s.p)
+func BitwiseOrWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.GpuBitwiseXor(src1.p, src2.p, dst.p, s.p))
 }
 
 // BitwiseXor performs a per-element exclusive or of two matrices
@@ -124,8 +124,8 @@ func BitwiseOrWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga3d95d4faafb099aacf18e8b915a4ad8d
-func BitwiseXor(src1, src2 GpuMat, dst *GpuMat) {
-	C.GpuBitwiseXor(src1.p, src2.p, dst.p, nil)
+func BitwiseXor(src1, src2 GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.GpuBitwiseXor(src1.p, src2.p, dst.p, nil))
 }
 
 // BitwiseXorWithStream performs a per-element exclusive or of two matrices
@@ -133,16 +133,16 @@ func BitwiseXor(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga3d95d4faafb099aacf18e8b915a4ad8d
-func BitwiseXorWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
-	C.GpuBitwiseXor(src1.p, src2.p, dst.p, s.p)
+func BitwiseXorWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.GpuBitwiseXor(src1.p, src2.p, dst.p, s.p))
 }
 
 // Divide computes a matrix-matrix or matrix-scalar division.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga124315aa226260841e25cc0b9ea99dc3
-func Divide(src1, src2 GpuMat, dst *GpuMat) {
-	C.GpuDivide(src1.p, src2.p, dst.p, nil)
+func Divide(src1, src2 GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.GpuDivide(src1.p, src2.p, dst.p, nil))
 }
 
 // DivideWithStream computes a matrix-matrix or matrix-scalar division
@@ -150,16 +150,16 @@ func Divide(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga124315aa226260841e25cc0b9ea99dc3
-func DivideWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
-	C.GpuDivide(src1.p, src2.p, dst.p, s.p)
+func DivideWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.GpuDivide(src1.p, src2.p, dst.p, s.p))
 }
 
 // Exp computes an exponent of each matrix element.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gac6e51541d3bb0a7a396128e4d5919b61
-func Exp(src GpuMat, dst *GpuMat) {
-	C.GpuExp(src.p, dst.p, nil)
+func Exp(src GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.GpuExp(src.p, dst.p, nil))
 }
 
 // ExpWithStream computes an exponent of each matrix element
@@ -167,16 +167,16 @@ func Exp(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gac6e51541d3bb0a7a396128e4d5919b61
-func ExpWithStream(src GpuMat, dst *GpuMat, s Stream) {
-	C.GpuExp(src.p, dst.p, s.p)
+func ExpWithStream(src GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.GpuExp(src.p, dst.p, s.p))
 }
 
 // Log computes natural logarithm of absolute value of each matrix element.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gac6e51541d3bb0a7a396128e4d5919b61
-func Log(src GpuMat, dst *GpuMat) {
-	C.GpuLog(src.p, dst.p, nil)
+func Log(src GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.GpuLog(src.p, dst.p, nil))
 }
 
 // LogWithStream computes natural logarithm of absolute value of each matrix element
@@ -184,16 +184,16 @@ func Log(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gac6e51541d3bb0a7a396128e4d5919b61
-func LogWithStream(src GpuMat, dst *GpuMat, s Stream) {
-	C.GpuLog(src.p, dst.p, s.p)
+func LogWithStream(src GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.GpuLog(src.p, dst.p, s.p))
 }
 
 // Max computes the per-element maximum of two matrices (or a matrix and a scalar).
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gadb5dd3d870f10c0866035755b929b1e7
-func Max(src1, src2 GpuMat, dst *GpuMat) {
-	C.GpuMax(src1.p, src2.p, dst.p, nil)
+func Max(src1, src2 GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.GpuMax(src1.p, src2.p, dst.p, nil))
 }
 
 // MaxWithStream computes the per-element maximum of two matrices (or a matrix and a scalar).
@@ -201,16 +201,16 @@ func Max(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#gadb5dd3d870f10c0866035755b929b1e7
-func MaxWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
-	C.GpuMax(src1.p, src2.p, dst.p, s.p)
+func MaxWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.GpuMax(src1.p, src2.p, dst.p, s.p))
 }
 
 // Min computes the per-element minimum of two matrices (or a matrix and a scalar).
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga74f0b05a65b3d949c237abb5e6c60867
-func Min(src1, src2 GpuMat, dst *GpuMat) {
-	C.GpuMin(src1.p, src2.p, dst.p, nil)
+func Min(src1, src2 GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.GpuMin(src1.p, src2.p, dst.p, nil))
 }
 
 // MinWithStream computes the per-element minimum of two matrices (or a matrix and a scalar).
@@ -218,32 +218,32 @@ func Min(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga74f0b05a65b3d949c237abb5e6c60867
-func MinWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
-	C.GpuMin(src1.p, src2.p, dst.p, s.p)
+func MinWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.GpuMin(src1.p, src2.p, dst.p, s.p))
 }
 
 // Multiply computes a matrix-matrix or matrix-scalar multiplication.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga497cc0615bf717e1e615143b56f00591
-func Multiply(src1, src2 GpuMat, dst *GpuMat) {
-	C.GpuMultiply(src1.p, src2.p, dst.p, nil)
+func Multiply(src1, src2 GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.GpuMultiply(src1.p, src2.p, dst.p, nil))
 }
 
 // MultiplyWithStream computes a matrix-matrix or matrix-scalar multiplication.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga497cc0615bf717e1e615143b56f00591
-func MultiplyWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
-	C.GpuMultiply(src1.p, src2.p, dst.p, s.p)
+func MultiplyWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.GpuMultiply(src1.p, src2.p, dst.p, s.p))
 }
 
 // Sqr computes a square value of each matrix element.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga8aae233da90ce0ffe309ab8004342acb
-func Sqr(src GpuMat, dst *GpuMat) {
-	C.GpuSqr(src.p, dst.p, nil)
+func Sqr(src GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.GpuSqr(src.p, dst.p, nil))
 }
 
 // SqrWithStream computes a square value of each matrix element
@@ -251,16 +251,16 @@ func Sqr(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga8aae233da90ce0ffe309ab8004342acb
-func SqrWithStream(src GpuMat, dst *GpuMat, s Stream) {
-	C.GpuSqr(src.p, dst.p, s.p)
+func SqrWithStream(src GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.GpuSqr(src.p, dst.p, s.p))
 }
 
 // Sqrt computes a square root of each matrix element.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga09303680cb1a5521a922b6d392028d8c
-func Sqrt(src GpuMat, dst *GpuMat) {
-	C.GpuSqrt(src.p, dst.p, nil)
+func Sqrt(src GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.GpuSqrt(src.p, dst.p, nil))
 }
 
 // SqrtWithStream computes a square root of each matrix element.
@@ -268,16 +268,16 @@ func Sqrt(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga09303680cb1a5521a922b6d392028d8c
-func SqrtWithStream(src GpuMat, dst *GpuMat, s Stream) {
-	C.GpuSqrt(src.p, dst.p, s.p)
+func SqrtWithStream(src GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.GpuSqrt(src.p, dst.p, s.p))
 }
 
 // Subtract computes a matrix-matrix or matrix-scalar difference.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga6eab60fc250059e2fda79c5636bd067f
-func Subtract(src1, src2 GpuMat, dst *GpuMat) {
-	C.GpuSubtract(src1.p, src2.p, dst.p, nil)
+func Subtract(src1, src2 GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.GpuSubtract(src1.p, src2.p, dst.p, nil))
 }
 
 // SubtractWithStream computes a matrix-matrix or matrix-scalar difference
@@ -285,16 +285,16 @@ func Subtract(src1, src2 GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga6eab60fc250059e2fda79c5636bd067f
-func SubtractWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) {
-	C.GpuSubtract(src1.p, src2.p, dst.p, s.p)
+func SubtractWithStream(src1, src2 GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.GpuSubtract(src1.p, src2.p, dst.p, s.p))
 }
 
 // Threshold applies a fixed-level threshold to each array element.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga40f1c94ae9a9456df3cad48e3cb008e1
-func Threshold(src GpuMat, dst *GpuMat, thresh, maxval float64, typ gocv.ThresholdType) {
-	C.GpuThreshold(src.p, dst.p, C.double(thresh), C.double(maxval), C.int(typ), nil)
+func Threshold(src GpuMat, dst *GpuMat, thresh, maxval float64, typ gocv.ThresholdType) error {
+	return OpenCVResult(C.GpuThreshold(src.p, dst.p, C.double(thresh), C.double(maxval), C.int(typ), nil))
 }
 
 // ThresholdWithStream applies a fixed-level threshold to each array element
@@ -302,16 +302,16 @@ func Threshold(src GpuMat, dst *GpuMat, thresh, maxval float64, typ gocv.Thresho
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d8/d34/group__cudaarithm__elem.html#ga40f1c94ae9a9456df3cad48e3cb008e1
-func ThresholdWithStream(src GpuMat, dst *GpuMat, thresh, maxval float64, typ gocv.ThresholdType, s Stream) {
-	C.GpuThreshold(src.p, dst.p, C.double(thresh), C.double(maxval), C.int(typ), s.p)
+func ThresholdWithStream(src GpuMat, dst *GpuMat, thresh, maxval float64, typ gocv.ThresholdType, s Stream) error {
+	return OpenCVResult(C.GpuThreshold(src.p, dst.p, C.double(thresh), C.double(maxval), C.int(typ), s.p))
 }
 
 // Flip flips a 2D matrix around vertical, horizontal, or both axes.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/d09/group__cudaarithm__core.html#ga4d0a3f2b46e8f0f1ec2b5ac178dcd871
-func Flip(src GpuMat, dst *GpuMat, flipCode int) {
-	C.GpuFlip(src.p, dst.p, C.int(flipCode), nil)
+func Flip(src GpuMat, dst *GpuMat, flipCode int) error {
+	return OpenCVResult(C.GpuFlip(src.p, dst.p, C.int(flipCode), nil))
 }
 
 // FlipWithStream flips a 2D matrix around vertical, horizontal, or both axes
@@ -319,15 +319,15 @@ func Flip(src GpuMat, dst *GpuMat, flipCode int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/d09/group__cudaarithm__core.html#ga4d0a3f2b46e8f0f1ec2b5ac178dcd871
-func FlipWithStream(src GpuMat, dst *GpuMat, flipCode int, stream Stream) {
-	C.GpuFlip(src.p, dst.p, C.int(flipCode), stream.p)
+func FlipWithStream(src GpuMat, dst *GpuMat, flipCode int, stream Stream) error {
+	return OpenCVResult(C.GpuFlip(src.p, dst.p, C.int(flipCode), stream.p))
 }
 
 // Merge makes a multi-channel matrix out of several single-channel matrices.
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/de/d09/group__cudaarithm__core.html#gafce19eb0fcad23f67ab45d544992436d
-func Merge(mv []GpuMat, dst *GpuMat) {
+func Merge(mv []GpuMat, dst *GpuMat) error {
 	cMatArray := make([]C.GpuMat, len(mv))
 	for i, r := range mv {
 		cMatArray[i] = r.p
@@ -337,7 +337,7 @@ func Merge(mv []GpuMat, dst *GpuMat) {
 		length: C.int(len(mv)),
 	}
 
-	C.GpuMerge(cMats, dst.p, nil)
+	return OpenCVResult(C.GpuMerge(cMats, dst.p, nil))
 }
 
 // MergeWithStream makes a multi-channel matrix out of several single-channel matrices
@@ -345,7 +345,7 @@ func Merge(mv []GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/de/d09/group__cudaarithm__core.html#gafce19eb0fcad23f67ab45d544992436d
-func MergeWithStream(mv []GpuMat, dst *GpuMat, s Stream) {
+func MergeWithStream(mv []GpuMat, dst *GpuMat, s Stream) error {
 	cMatArray := make([]C.GpuMat, len(mv))
 	for i, r := range mv {
 		cMatArray[i] = r.p
@@ -355,46 +355,46 @@ func MergeWithStream(mv []GpuMat, dst *GpuMat, s Stream) {
 		length: C.int(len(mv)),
 	}
 
-	C.GpuMerge(cMats, dst.p, s.p)
+	return OpenCVResult(C.GpuMerge(cMats, dst.p, s.p))
 }
 
 // Transpose transposes a matrix.
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/de/d09/group__cudaarithm__core.html#ga327b71c3cb811a904ccf5fba37fc29f2
-func Transpose(src GpuMat, dst *GpuMat) {
-	C.GpuTranspose(src.p, dst.p, nil)
+func Transpose(src GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.GpuTranspose(src.p, dst.p, nil))
 }
 
 // Transpose transposes a matrix using a Stream for concurrency.
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/de/d09/group__cudaarithm__core.html#ga327b71c3cb811a904ccf5fba37fc29f2
-func TransposeWithStream(src GpuMat, dst *GpuMat, s Stream) {
-	C.GpuTranspose(src.p, dst.p, s.p)
+func TransposeWithStream(src GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.GpuTranspose(src.p, dst.p, s.p))
 }
 
 // AddWeighted computes a weighted sum of two matrices.
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d8/d34/group__cudaarithm__elem.html#ga2cd14a684ea70c6ab2a63ee90ffe6201
-func AddWeighted(src1 GpuMat, alpha float64, src2 GpuMat, beta float64, gamma float64, dst *GpuMat, dType int) {
-	C.GpuAddWeighted(src1.p, C.double(alpha), src2.p, C.double(beta), C.double(gamma), dst.p, C.int(dType), nil)
+func AddWeighted(src1 GpuMat, alpha float64, src2 GpuMat, beta float64, gamma float64, dst *GpuMat, dType int) error {
+	return OpenCVResult(C.GpuAddWeighted(src1.p, C.double(alpha), src2.p, C.double(beta), C.double(gamma), dst.p, C.int(dType), nil))
 }
 
 // AddWeightedWithStream computes a weighted sum of two matrices using a Stream for concurrency.
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d8/d34/group__cudaarithm__elem.html#ga2cd14a684ea70c6ab2a63ee90ffe6201
-func AddWeightedWithStream(src1 GpuMat, alpha float64, src2 GpuMat, beta float64, gamma float64, dst *GpuMat, dType int, s Stream) {
-	C.GpuAddWeighted(src1.p, C.double(alpha), src2.p, C.double(beta), C.double(gamma), dst.p, C.int(dType), s.p)
+func AddWeightedWithStream(src1 GpuMat, alpha float64, src2 GpuMat, beta float64, gamma float64, dst *GpuMat, dType int, s Stream) error {
+	return OpenCVResult(C.GpuAddWeighted(src1.p, C.double(alpha), src2.p, C.double(beta), C.double(gamma), dst.p, C.int(dType), s.p))
 }
 
 // CopyMakeBorder forms a border around an image.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/d09/group__cudaarithm__core.html#ga5368db7656eacf846b40089c98053a49
-func CopyMakeBorder(src GpuMat, dst *GpuMat, top, bottom, left, right int, borderType gocv.BorderType, value gocv.Scalar) {
+func CopyMakeBorder(src GpuMat, dst *GpuMat, top, bottom, left, right int, borderType gocv.BorderType, value gocv.Scalar) error {
 	bv := C.struct_Scalar{
 		val1: C.double(value.Val1),
 		val2: C.double(value.Val2),
@@ -402,14 +402,14 @@ func CopyMakeBorder(src GpuMat, dst *GpuMat, top, bottom, left, right int, borde
 		val4: C.double(value.Val4),
 	}
 
-	C.GpuCopyMakeBorder(src.p, dst.p, C.int(top), C.int(bottom), C.int(left), C.int(right), C.int(borderType), bv, nil)
+	return OpenCVResult(C.GpuCopyMakeBorder(src.p, dst.p, C.int(top), C.int(bottom), C.int(left), C.int(right), C.int(borderType), bv, nil))
 }
 
 // CopyMakeBorderWithStream forms a border around an image using a Stream for concurrency.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/de/d09/group__cudaarithm__core.html#ga5368db7656eacf846b40089c98053a49
-func CopyMakeBorderWithStream(src GpuMat, dst *GpuMat, top, bottom, left, right int, borderType gocv.BorderType, value gocv.Scalar, s Stream) {
+func CopyMakeBorderWithStream(src GpuMat, dst *GpuMat, top, bottom, left, right int, borderType gocv.BorderType, value gocv.Scalar, s Stream) error {
 	bv := C.struct_Scalar{
 		val1: C.double(value.Val1),
 		val2: C.double(value.Val2),
@@ -417,7 +417,7 @@ func CopyMakeBorderWithStream(src GpuMat, dst *GpuMat, top, bottom, left, right 
 		val4: C.double(value.Val4),
 	}
 
-	C.GpuCopyMakeBorder(src.p, dst.p, C.int(top), C.int(bottom), C.int(left), C.int(right), C.int(borderType), bv, s.p)
+	return OpenCVResult(C.GpuCopyMakeBorder(src.p, dst.p, C.int(top), C.int(bottom), C.int(left), C.int(right), C.int(borderType), bv, s.p))
 }
 
 type LookUpTable struct {
@@ -448,8 +448,8 @@ func (lt *LookUpTable) Close() {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/d29/classcv_1_1cuda_1_1LookUpTable.html#afdbcbd3047f847451892f3b18cd018de
-func (lt *LookUpTable) Transform(src GpuMat, dst *GpuMat) {
-	C.Cuda_LookUpTable_Transform(lt.p, src.p, dst.p, nil)
+func (lt *LookUpTable) Transform(src GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.Cuda_LookUpTable_Transform(lt.p, src.p, dst.p, nil))
 }
 
 // Empty Returns true if the Algorithm is empty
@@ -474,8 +474,8 @@ func (lt *LookUpTable) Empty() bool {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/d29/classcv_1_1cuda_1_1LookUpTable.html#afdbcbd3047f847451892f3b18cd018de
-func (lt *LookUpTable) TransformWithStream(src GpuMat, dst *GpuMat, s Stream) {
-	C.Cuda_LookUpTable_Transform(lt.p, src.p, dst.p, s.p)
+func (lt *LookUpTable) TransformWithStream(src GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.Cuda_LookUpTable_Transform(lt.p, src.p, dst.p, s.p))
 }
 
 // Split Copies each plane of a multi-channel matrix into an array.
@@ -486,7 +486,7 @@ func (lt *LookUpTable) TransformWithStream(src GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/de/d09/group__cudaarithm__core.html#gaf1714e7a9ea0719c29bf378beaf5f99d
-func Split(src GpuMat, dst []GpuMat) {
+func Split(src GpuMat, dst []GpuMat) error {
 
 	dstv := make([]C.GpuMat, len(dst))
 
@@ -499,7 +499,7 @@ func Split(src GpuMat, dst []GpuMat) {
 		length: C.int(len(dstv)),
 	}
 
-	C.Cuda_Split(src.p, c_dstv, nil)
+	return OpenCVResult(C.Cuda_Split(src.p, c_dstv, nil))
 }
 
 // SplitWithStream Copies each plane of a multi-channel matrix into an array.
@@ -512,7 +512,7 @@ func Split(src GpuMat, dst []GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/de/d09/group__cudaarithm__core.html#gaf1714e7a9ea0719c29bf378beaf5f99d
-func SplitWithStream(src GpuMat, dst []GpuMat, s Stream) {
+func SplitWithStream(src GpuMat, dst []GpuMat, s Stream) error {
 
 	dstv := make([]C.GpuMat, len(dst))
 
@@ -525,5 +525,5 @@ func SplitWithStream(src GpuMat, dst []GpuMat, s Stream) {
 		length: C.int(len(dstv)),
 	}
 
-	C.Cuda_Split(src.p, c_dstv, s.p)
+	return OpenCVResult(C.Cuda_Split(src.p, c_dstv, s.p))
 }

--- a/cuda/arithm.h
+++ b/cuda/arithm.h
@@ -17,37 +17,37 @@ typedef cv::Ptr< cv::cuda::LookUpTable >* LookUpTable;
 typedef void* LookUpTable;
 #endif
 
-void GpuAbs(GpuMat src, GpuMat dst, Stream s);
-void GpuAbsDiff(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
-void GpuAdd(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
-void GpuBitwiseAnd(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
-void GpuBitwiseNot(GpuMat src, GpuMat dst, Stream s);
-void GpuBitwiseOr(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
-void GpuBitwiseXor(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
-void GpuDivide(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
-void GpuExp(GpuMat src, GpuMat dst, Stream s);
-void GpuLog(GpuMat src, GpuMat dst, Stream s);
-void GpuMax(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
-void GpuMin(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
-void GpuMultiply(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
-void GpuSqr(GpuMat src, GpuMat dst, Stream s);
-void GpuSqrt(GpuMat src, GpuMat dst, Stream s);
-void GpuSubtract(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
-void GpuThreshold(GpuMat src, GpuMat dst, double thresh, double maxval, int typ, Stream s);
-void GpuFlip(GpuMat src, GpuMat dst, int flipCode, Stream s);
-void GpuMerge(struct GpuMats mats, GpuMat dst, Stream s);
-void GpuTranspose(GpuMat src, GpuMat dst, Stream s);
-void GpuAddWeighted(GpuMat src1, double alpha, GpuMat src2, double beta, double gamma, GpuMat dst, int dType, Stream s);
-void GpuCopyMakeBorder(GpuMat src, GpuMat dst, int top, int bottom, int left, int right, int borderType, Scalar value, Stream s);
+OpenCVResult GpuAbs(GpuMat src, GpuMat dst, Stream s);
+OpenCVResult GpuAbsDiff(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
+OpenCVResult GpuAdd(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
+OpenCVResult GpuBitwiseAnd(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
+OpenCVResult GpuBitwiseNot(GpuMat src, GpuMat dst, Stream s);
+OpenCVResult GpuBitwiseOr(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
+OpenCVResult GpuBitwiseXor(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
+OpenCVResult GpuDivide(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
+OpenCVResult GpuExp(GpuMat src, GpuMat dst, Stream s);
+OpenCVResult GpuLog(GpuMat src, GpuMat dst, Stream s);
+OpenCVResult GpuMax(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
+OpenCVResult GpuMin(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
+OpenCVResult GpuMultiply(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
+OpenCVResult GpuSqr(GpuMat src, GpuMat dst, Stream s);
+OpenCVResult GpuSqrt(GpuMat src, GpuMat dst, Stream s);
+OpenCVResult GpuSubtract(GpuMat src1, GpuMat src2, GpuMat dst, Stream s);
+OpenCVResult GpuThreshold(GpuMat src, GpuMat dst, double thresh, double maxval, int typ, Stream s);
+OpenCVResult GpuFlip(GpuMat src, GpuMat dst, int flipCode, Stream s);
+OpenCVResult GpuMerge(struct GpuMats mats, GpuMat dst, Stream s);
+OpenCVResult GpuTranspose(GpuMat src, GpuMat dst, Stream s);
+OpenCVResult GpuAddWeighted(GpuMat src1, double alpha, GpuMat src2, double beta, double gamma, GpuMat dst, int dType, Stream s);
+OpenCVResult GpuCopyMakeBorder(GpuMat src, GpuMat dst, int top, int bottom, int left, int right, int borderType, Scalar value, Stream s);
 
 //LookUpTable
 LookUpTable Cuda_Create_LookUpTable(GpuMat lut);
 void Cuda_LookUpTable_Close(LookUpTable lt);
-void Cuda_LookUpTable_Transform(LookUpTable lt, GpuMat src, GpuMat dst, Stream s);
+OpenCVResult Cuda_LookUpTable_Transform(LookUpTable lt, GpuMat src, GpuMat dst, Stream s);
 
 bool Cuda_LookUpTable_Empty(LookUpTable lut);
 
-void Cuda_Split(GpuMat src, GpuMats dst, Stream s);
+OpenCVResult Cuda_Split(GpuMat src, GpuMats dst, Stream s);
 #ifdef __cplusplus
 }
 #endif

--- a/cuda/arithm_test.go
+++ b/cuda/arithm_test.go
@@ -29,6 +29,28 @@ func TestAbs(t *testing.T) {
 	}
 }
 
+func TestAbsException(t *testing.T) {
+	src := gocv.NewMat()
+	defer src.Close()
+
+	var cimg, dimg = NewGpuMat(), NewGpuMat()
+	defer cimg.Close()
+	defer dimg.Close()
+
+	cimg.Upload(src)
+
+	dest := gocv.NewMat()
+	defer dest.Close()
+
+	err := Abs(cimg, &dimg)
+	if err == nil {
+		t.Error("Expected exception in test")
+	}
+	if len(err.Error()) == 0 {
+		t.Error("Expected exception message in test")
+	}
+}
+
 func TestAbsWithStream(t *testing.T) {
 	src := gocv.IMRead("../images/gocvlogo.jpg", gocv.IMReadColor)
 	if src.Empty() {

--- a/cuda/bgsegm.cpp
+++ b/cuda/bgsegm.cpp
@@ -1,7 +1,12 @@
 #include "bgsegm.h"
 
 CudaBackgroundSubtractorMOG2 CudaBackgroundSubtractorMOG2_Create() {
-    return new cv::Ptr<cv::cuda::BackgroundSubtractorMOG2>(cv::cuda::createBackgroundSubtractorMOG2());
+    try {
+        return new cv::Ptr<cv::cuda::BackgroundSubtractorMOG2>(cv::cuda::createBackgroundSubtractorMOG2());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void CudaBackgroundSubtractorMOG2_Close(CudaBackgroundSubtractorMOG2 b) {
@@ -9,15 +14,24 @@ void CudaBackgroundSubtractorMOG2_Close(CudaBackgroundSubtractorMOG2 b) {
 }
 
 void CudaBackgroundSubtractorMOG2_Apply(CudaBackgroundSubtractorMOG2 b, GpuMat src, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        (*b)->apply(*src, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            (*b)->apply(*src, *dst);
+            return;
+        }
+        (*b)->apply(*src, *dst, -1.0, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    (*b)->apply(*src, *dst, -1.0, *s);
 }
 
 CudaBackgroundSubtractorMOG CudaBackgroundSubtractorMOG_Create() {
-    return new cv::Ptr<cv::cuda::BackgroundSubtractorMOG>(cv::cuda::createBackgroundSubtractorMOG());
+    try {
+        return new cv::Ptr<cv::cuda::BackgroundSubtractorMOG>(cv::cuda::createBackgroundSubtractorMOG());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void CudaBackgroundSubtractorMOG_Close(CudaBackgroundSubtractorMOG b) {
@@ -25,9 +39,13 @@ void CudaBackgroundSubtractorMOG_Close(CudaBackgroundSubtractorMOG b) {
 }
 
 void CudaBackgroundSubtractorMOG_Apply(CudaBackgroundSubtractorMOG b, GpuMat src, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        (*b)->apply(*src, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            (*b)->apply(*src, *dst);
+            return;
+        }
+        (*b)->apply(*src, *dst, -1.0, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    (*b)->apply(*src, *dst, -1.0, *s);
 }

--- a/cuda/bgsegm.cpp
+++ b/cuda/bgsegm.cpp
@@ -13,15 +13,16 @@ void CudaBackgroundSubtractorMOG2_Close(CudaBackgroundSubtractorMOG2 b) {
     delete b;
 }
 
-void CudaBackgroundSubtractorMOG2_Apply(CudaBackgroundSubtractorMOG2 b, GpuMat src, GpuMat dst, Stream s) {
+OpenCVResult CudaBackgroundSubtractorMOG2_Apply(CudaBackgroundSubtractorMOG2 b, GpuMat src, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             (*b)->apply(*src, *dst);
-            return;
+        } else {
+            (*b)->apply(*src, *dst, -1.0, *s);
         }
-        (*b)->apply(*src, *dst, -1.0, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -38,14 +39,15 @@ void CudaBackgroundSubtractorMOG_Close(CudaBackgroundSubtractorMOG b) {
     delete b;
 }
 
-void CudaBackgroundSubtractorMOG_Apply(CudaBackgroundSubtractorMOG b, GpuMat src, GpuMat dst, Stream s) {
+OpenCVResult CudaBackgroundSubtractorMOG_Apply(CudaBackgroundSubtractorMOG b, GpuMat src, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             (*b)->apply(*src, *dst);
-            return;
+        } else {
+            (*b)->apply(*src, *dst, -1.0, *s);
         }
-        (*b)->apply(*src, *dst, -1.0, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }

--- a/cuda/bgsegm.go
+++ b/cuda/bgsegm.go
@@ -40,9 +40,8 @@ func (b *BackgroundSubtractorMOG2) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/df/d23/classcv_1_1cuda_1_1BackgroundSubtractorMOG2.html#a92408f07bf1268c1b778cb186b3113b0
-func (b *BackgroundSubtractorMOG2) Apply(src GpuMat, dst *GpuMat) {
-	C.CudaBackgroundSubtractorMOG2_Apply((C.CudaBackgroundSubtractorMOG2)(b.p), src.p, dst.p, nil)
-	return
+func (b *BackgroundSubtractorMOG2) Apply(src GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.CudaBackgroundSubtractorMOG2_Apply((C.CudaBackgroundSubtractorMOG2)(b.p), src.p, dst.p, nil))
 }
 
 // ApplyWithStream computes a foreground mask using the current BackgroundSubtractorMOG2
@@ -50,9 +49,8 @@ func (b *BackgroundSubtractorMOG2) Apply(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/df/d23/classcv_1_1cuda_1_1BackgroundSubtractorMOG2.html#a92408f07bf1268c1b778cb186b3113b0
-func (b *BackgroundSubtractorMOG2) ApplyWithStream(src GpuMat, dst *GpuMat, s Stream) {
-	C.CudaBackgroundSubtractorMOG2_Apply((C.CudaBackgroundSubtractorMOG2)(b.p), src.p, dst.p, s.p)
-	return
+func (b *BackgroundSubtractorMOG2) ApplyWithStream(src GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.CudaBackgroundSubtractorMOG2_Apply((C.CudaBackgroundSubtractorMOG2)(b.p), src.p, dst.p, s.p))
 }
 
 // NewBackgroundSubtractorMOG returns a new BackgroundSubtractor algorithm
@@ -76,9 +74,8 @@ func (b *BackgroundSubtractorMOG) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/dfe/classcv_1_1cuda_1_1BackgroundSubtractorMOG.html#a8f52d2f7abd1c77c84243efc53972cbf
-func (b *BackgroundSubtractorMOG) Apply(src GpuMat, dst *GpuMat) {
-	C.CudaBackgroundSubtractorMOG_Apply((C.CudaBackgroundSubtractorMOG)(b.p), src.p, dst.p, nil)
-	return
+func (b *BackgroundSubtractorMOG) Apply(src GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.CudaBackgroundSubtractorMOG_Apply((C.CudaBackgroundSubtractorMOG)(b.p), src.p, dst.p, nil))
 }
 
 // ApplyWithStream computes a foreground mask using the current BackgroundSubtractorMOG
@@ -86,7 +83,6 @@ func (b *BackgroundSubtractorMOG) Apply(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/dfe/classcv_1_1cuda_1_1BackgroundSubtractorMOG.html#a8f52d2f7abd1c77c84243efc53972cbf
-func (b *BackgroundSubtractorMOG) ApplyWithStream(src GpuMat, dst *GpuMat, s Stream) {
-	C.CudaBackgroundSubtractorMOG_Apply((C.CudaBackgroundSubtractorMOG)(b.p), src.p, dst.p, s.p)
-	return
+func (b *BackgroundSubtractorMOG) ApplyWithStream(src GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.CudaBackgroundSubtractorMOG_Apply((C.CudaBackgroundSubtractorMOG)(b.p), src.p, dst.p, s.p))
 }

--- a/cuda/bgsegm.h
+++ b/cuda/bgsegm.h
@@ -21,11 +21,11 @@ typedef void* CudaBackgroundSubtractorMOG;
 
 CudaBackgroundSubtractorMOG2 CudaBackgroundSubtractorMOG2_Create();
 void CudaBackgroundSubtractorMOG2_Close(CudaBackgroundSubtractorMOG2 b);
-void CudaBackgroundSubtractorMOG2_Apply(CudaBackgroundSubtractorMOG2 b, GpuMat src, GpuMat dst, Stream s);
+OpenCVResult CudaBackgroundSubtractorMOG2_Apply(CudaBackgroundSubtractorMOG2 b, GpuMat src, GpuMat dst, Stream s);
 
 CudaBackgroundSubtractorMOG CudaBackgroundSubtractorMOG_Create();
 void CudaBackgroundSubtractorMOG_Close(CudaBackgroundSubtractorMOG b);
-void CudaBackgroundSubtractorMOG_Apply(CudaBackgroundSubtractorMOG b, GpuMat src, GpuMat dst, Stream s);
+OpenCVResult CudaBackgroundSubtractorMOG_Apply(CudaBackgroundSubtractorMOG b, GpuMat src, GpuMat dst, Stream s);
 
 #ifdef __cplusplus
 }

--- a/cuda/cuda.cpp
+++ b/cuda/cuda.cpp
@@ -1,35 +1,63 @@
 #include "cuda.h"
 
 GpuMat GpuMat_New() {
-    return new cv::cuda::GpuMat();
+    try {
+        return new cv::cuda::GpuMat();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 GpuMat GpuMat_NewFromMat(Mat mat) {
-    return new cv::cuda::GpuMat(*mat);
+    try {
+        return new cv::cuda::GpuMat(*mat);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 GpuMat GpuMat_NewWithSize(int rows, int cols, int type) {
-    return new cv::cuda::GpuMat(rows, cols, type);
+    try {
+        return new cv::cuda::GpuMat(rows, cols, type);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void GpuMat_Upload(GpuMat m, Mat data, Stream s){
-    if (s == NULL) {
-        m->upload(*data);
-        return;
+    try {
+        if (s == NULL) {
+            m->upload(*data);
+            return;
+        }
+        m->upload(*data, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    m->upload(*data, *s);
 }
 
 void GpuMat_Download(GpuMat m, Mat dst, Stream s){
-    if (s == NULL) {
-        m->download(*dst);
-        return;
+    try {
+        if (s == NULL) {
+            m->download(*dst);
+            return;
+        }
+        m->download(*dst, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    m->download(*dst, *s);
 }
 
 int GpuMat_Empty(GpuMat m){
-    return m->empty();
+    try {
+        return m->empty();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return true;
+    }
 }
 
 void GpuMat_Close(GpuMat m){
@@ -37,55 +65,103 @@ void GpuMat_Close(GpuMat m){
 }
 
 void PrintCudaDeviceInfo(int device){
-    cv::cuda::printCudaDeviceInfo(device);
+    try {
+        cv::cuda::printCudaDeviceInfo(device);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void PrintShortCudaDeviceInfo(int device){
-    cv::cuda::printShortCudaDeviceInfo(device);
+    try {
+        cv::cuda::printShortCudaDeviceInfo(device);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 int GetCudaEnabledDeviceCount(){
-    return cv::cuda::getCudaEnabledDeviceCount();
+    try {
+        return cv::cuda::getCudaEnabledDeviceCount();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 int GetCudaDevice() {
-    return cv::cuda::getDevice();
+    try {
+        return cv::cuda::getDevice();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return -1;
+    }
 }
 
 void SetCudaDevice(int device) {
-    cv::cuda::setDevice(device);
+    try {
+        cv::cuda::setDevice(device);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void ResetCudaDevice(){
-    cv::cuda::resetDevice();
+    try {
+        cv::cuda::resetDevice();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 bool CudaDeviceSupports(int features) {
-    return cv::cuda::deviceSupports(cv::cuda::FeatureSet(features));
+    try {
+        return cv::cuda::deviceSupports(cv::cuda::FeatureSet(features));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 void GpuMat_ConvertTo(GpuMat m, GpuMat dst, int type, Stream s) {
-    if (s == NULL) {
-        m->convertTo(*dst, type);
-        return;
+    try {
+        if (s == NULL) {
+            m->convertTo(*dst, type);
+            return;
+        }
+        m->convertTo(*dst, type, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    m->convertTo(*dst, type, *s);
 }
 
 void GpuMat_ConvertFp16(GpuMat m, GpuMat dst) {
-    cv::cuda::convertFp16(*m, *dst);
+    try {
+        cv::cuda::convertFp16(*m, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void GpuMat_CopyTo(GpuMat m, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        m->copyTo(*dst);
-        return;
+    try {
+        if (s == NULL) {
+            m->copyTo(*dst);
+            return;
+        }
+        m->copyTo(*dst, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    m->copyTo(*dst, *s);
 }
 
 GpuMat GpuMat_Reshape(GpuMat m, int cn, int rows) {
-    return new cv::cuda::GpuMat(m->reshape(cn, rows));
+    try {
+        return new cv::cuda::GpuMat(m->reshape(cn, rows));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 int GpuMat_Cols(GpuMat m) {
@@ -105,7 +181,12 @@ int GpuMat_Type(GpuMat m) {
 }
 
 Stream Stream_New() {
-    return new cv::cuda::Stream();
+    try {
+        return new cv::cuda::Stream();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void Stream_Close(Stream s){
@@ -113,9 +194,18 @@ void Stream_Close(Stream s){
 }
 
 bool Stream_QueryIfComplete(Stream s) {
-    return s->queryIfComplete();
+    try {
+        return s->queryIfComplete();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 void Stream_WaitForCompletion(Stream s) {
-    s->waitForCompletion();
+    try {
+        s->waitForCompletion();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }

--- a/cuda/errors.go
+++ b/cuda/errors.go
@@ -1,0 +1,15 @@
+package cuda
+
+/*
+#include "../core.h"
+*/
+import "C"
+import "errors"
+
+// Converts a OpenCVResult struct to an error.
+func OpenCVResult(result C.OpenCVResult) error {
+	if result.Code == 0 {
+		return nil
+	}
+	return errors.New(C.GoString(result.Message))
+}

--- a/cuda/filters.cpp
+++ b/cuda/filters.cpp
@@ -3,13 +3,23 @@
 #include <string.h>
 
 GaussianFilter CreateGaussianFilter(int srcType, int dstType, Size ksize, double sigma1) {
-    cv::Size sz(ksize.width, ksize.height);
-    return new cv::Ptr<cv::cuda::Filter>(cv::cuda::createGaussianFilter(srcType, dstType, sz, sigma1));
+    try {
+        cv::Size sz(ksize.width, ksize.height);
+        return new cv::Ptr<cv::cuda::Filter>(cv::cuda::createGaussianFilter(srcType, dstType, sz, sigma1));    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 GaussianFilter CreateGaussianFilterWithParams(int srcType, int dstType, Size ksize, double sigma1, double sigma2, int rowBorderMode, int columnBorderMode) {
-    cv::Size sz(ksize.width, ksize.height);
-    return new cv::Ptr<cv::cuda::Filter>(cv::cuda::createGaussianFilter(srcType, dstType, sz, sigma1, sigma2, rowBorderMode, columnBorderMode));
+    try {
+        cv::Size sz(ksize.width, ksize.height);
+        return new cv::Ptr<cv::cuda::Filter>(cv::cuda::createGaussianFilter(srcType, dstType, sz, sigma1, sigma2, rowBorderMode, columnBorderMode));    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void GaussianFilter_Close(GaussianFilter gf) {
@@ -17,20 +27,33 @@ void GaussianFilter_Close(GaussianFilter gf) {
 }
 
 void GaussianFilter_Apply(GaussianFilter gf, GpuMat img, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        (*gf)->apply(*img, *dst);
-    } else {
+    try {
+        if (s == NULL) {
+            (*gf)->apply(*img, *dst);
+            return;
+        }
         (*gf)->apply(*img, *dst, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    return;
 }
 
 SobelFilter CreateSobelFilter(int srcType, int dstType, int dx, int dy) {
-    return new cv::Ptr<cv::cuda::Filter>(cv::cuda::createSobelFilter(srcType, dstType, dx, dy));
+    try {
+        return new cv::Ptr<cv::cuda::Filter>(cv::cuda::createSobelFilter(srcType, dstType, dx, dy));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 SobelFilter CreateSobelFilterWithParams(int srcType, int dstType, int dx, int dy, int ksize, double scale, int rowBorderMode, int columnBorderMode) {
-    return new cv::Ptr<cv::cuda::Filter>(cv::cuda::createSobelFilter(srcType, dstType, dx, dy, ksize, rowBorderMode, columnBorderMode));
+    try {
+        return new cv::Ptr<cv::cuda::Filter>(cv::cuda::createSobelFilter(srcType, dstType, dx, dy, ksize, rowBorderMode, columnBorderMode));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void SobelFilter_Close(SobelFilter sf) {
@@ -38,11 +61,13 @@ void SobelFilter_Close(SobelFilter sf) {
 }
 
 void SobelFilter_Apply(SobelFilter sf, GpuMat img, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        (*sf)->apply(*img, *dst);
-    } else {
+    try {
+        if (s == NULL) {
+            (*sf)->apply(*img, *dst);
+            return;
+        }
         (*sf)->apply(*img, *dst, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    return;
 }

--- a/cuda/filters.cpp
+++ b/cuda/filters.cpp
@@ -26,15 +26,16 @@ void GaussianFilter_Close(GaussianFilter gf) {
     delete gf;
 }
 
-void GaussianFilter_Apply(GaussianFilter gf, GpuMat img, GpuMat dst, Stream s) {
+OpenCVResult GaussianFilter_Apply(GaussianFilter gf, GpuMat img, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             (*gf)->apply(*img, *dst);
-            return;
+        } else {
+            (*gf)->apply(*img, *dst, *s);
         }
-        (*gf)->apply(*img, *dst, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -60,14 +61,15 @@ void SobelFilter_Close(SobelFilter sf) {
     delete sf;
 }
 
-void SobelFilter_Apply(SobelFilter sf, GpuMat img, GpuMat dst, Stream s) {
+OpenCVResult SobelFilter_Apply(SobelFilter sf, GpuMat img, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             (*sf)->apply(*img, *dst);
-            return;
+        } else {
+            (*sf)->apply(*img, *dst, *s);
         }
-        (*sf)->apply(*img, *dst, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }

--- a/cuda/filters.go
+++ b/cuda/filters.go
@@ -43,9 +43,8 @@ func (gf *GaussianFilter) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d2b/classcv_1_1cuda_1_1Filter.html#a20b58d13871027473b4c39cc698cf80f
-func (gf *GaussianFilter) Apply(img GpuMat, dst *GpuMat) {
-	C.GaussianFilter_Apply(C.GaussianFilter(gf.p), img.p, dst.p, nil)
-	return
+func (gf *GaussianFilter) Apply(img GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.GaussianFilter_Apply(C.GaussianFilter(gf.p), img.p, dst.p, nil))
 }
 
 // ApplyWithStream applies the Gaussian filter
@@ -53,9 +52,8 @@ func (gf *GaussianFilter) Apply(img GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d2b/classcv_1_1cuda_1_1Filter.html#a20b58d13871027473b4c39cc698cf80f
-func (gf *GaussianFilter) ApplyWithStream(img GpuMat, dst *GpuMat, s Stream) {
-	C.GaussianFilter_Apply(C.GaussianFilter(gf.p), img.p, dst.p, s.p)
-	return
+func (gf *GaussianFilter) ApplyWithStream(img GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.GaussianFilter_Apply(C.GaussianFilter(gf.p), img.p, dst.p, s.p))
 }
 
 // SobelFilter
@@ -87,9 +85,8 @@ func (sf *SobelFilter) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d2b/classcv_1_1cuda_1_1Filter.html#a20b58d13871027473b4c39cc698cf80f
-func (sf *SobelFilter) Apply(img GpuMat, dst *GpuMat) {
-	C.SobelFilter_Apply(C.SobelFilter(sf.p), img.p, dst.p, nil)
-	return
+func (sf *SobelFilter) Apply(img GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.SobelFilter_Apply(C.SobelFilter(sf.p), img.p, dst.p, nil))
 }
 
 // ApplyWithStream applies the Sobel filter
@@ -97,7 +94,6 @@ func (sf *SobelFilter) Apply(img GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d2b/classcv_1_1cuda_1_1Filter.html#a20b58d13871027473b4c39cc698cf80f
-func (sf *SobelFilter) ApplyWithStream(img GpuMat, dst *GpuMat, s Stream) {
-	C.SobelFilter_Apply(C.SobelFilter(sf.p), img.p, dst.p, s.p)
-	return
+func (sf *SobelFilter) ApplyWithStream(img GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.SobelFilter_Apply(C.SobelFilter(sf.p), img.p, dst.p, s.p))
 }

--- a/cuda/filters.h
+++ b/cuda/filters.h
@@ -23,13 +23,13 @@ typedef void* SobelFilter;
 GaussianFilter CreateGaussianFilter(int srcType, int dstType, Size ksize, double sigma1);
 GaussianFilter CreateGaussianFilterWithParams(int srcType, int dstType, Size ksize, double sigma1, double sigma2, int rowBorderMode, int columnBorderMode);
 void GaussianFilter_Close(GaussianFilter gf);
-void GaussianFilter_Apply(GaussianFilter gf, GpuMat img, GpuMat dst, Stream s);
+OpenCVResult GaussianFilter_Apply(GaussianFilter gf, GpuMat img, GpuMat dst, Stream s);
 
 // SobelFilter
 SobelFilter CreateSobelFilter(int srcType, int dstType, int dx, int dy);
 SobelFilter CreateSobelFilterWithParams(int srcType, int dstType, int dx, int dy, int ksize, double scale, int rowBorderMode, int columnBorderMode);
 void SobelFilter_Close(SobelFilter sf);
-void SobelFilter_Apply(SobelFilter sf, GpuMat img, GpuMat dst, Stream s);
+OpenCVResult SobelFilter_Apply(SobelFilter sf, GpuMat img, GpuMat dst, Stream s);
 
 #ifdef __cplusplus
 }

--- a/cuda/imgproc.cpp
+++ b/cuda/imgproc.cpp
@@ -2,27 +2,29 @@
 #include "imgproc.h"
 #include <string.h>
 
-void GpuCvtColor(GpuMat src, GpuMat dst, int code, Stream s) {
+OpenCVResult GpuCvtColor(GpuMat src, GpuMat dst, int code, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::cvtColor(*src, *dst, code);
-            return;
+        } else {
+            cv::cuda::cvtColor(*src, *dst, code, 0, *s);
         }
-        cv::cuda::cvtColor(*src, *dst, code, 0, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GpuDemosaicing(GpuMat src, GpuMat dst, int code, Stream s) {
+OpenCVResult GpuDemosaicing(GpuMat src, GpuMat dst, int code, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::demosaicing(*src, *dst, code);
-            return;
+        } else {
+            cv::cuda::demosaicing(*src, *dst, code, -1, *s);
         }
-        cv::cuda::demosaicing(*src, *dst, code, -1, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -48,15 +50,16 @@ void CannyEdgeDetector_Close(CannyEdgeDetector det) {
     delete det;
 }
 
-void CannyEdgeDetector_Detect(CannyEdgeDetector det, GpuMat img, GpuMat dst, Stream s) {
+OpenCVResult CannyEdgeDetector_Detect(CannyEdgeDetector det, GpuMat img, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             (*det)->detect(*img, *dst);
-            return;
+        } else {
+            (*det)->detect(*img, *dst, *s);
         }
-        (*det)->detect(*img, *dst, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -150,15 +153,16 @@ void HoughLinesDetector_Close(HoughLinesDetector hld) {
     delete hld;
 }
 
-void HoughLinesDetector_Detect(HoughLinesDetector hld, GpuMat img, GpuMat dst, Stream s) {
+OpenCVResult HoughLinesDetector_Detect(HoughLinesDetector hld, GpuMat img, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             (*hld)->detect(*img, *dst);
-            return;
+        } else {
+            (*hld)->detect(*img, *dst, *s);
         }
-        (*hld)->detect(*img, *dst, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -175,15 +179,16 @@ void HoughSegmentDetector_Close(HoughSegmentDetector hsd) {
     delete hsd;
 }
 
-void HoughSegmentDetector_Detect(HoughSegmentDetector hsd, GpuMat img, GpuMat dst, Stream s) {
+OpenCVResult HoughSegmentDetector_Detect(HoughSegmentDetector hsd, GpuMat img, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             (*hsd)->detect(*img, *dst);
-            return;
+        } else {
+            (*hsd)->detect(*img, *dst, *s);
         }
-        (*hsd)->detect(*img, *dst, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -200,185 +205,198 @@ void TemplateMatching_Close(TemplateMatching tm) {
     delete tm;
 }
 
-void TemplateMatching_Match(TemplateMatching tm, GpuMat img, GpuMat tmpl, GpuMat dst, Stream s) {
+OpenCVResult TemplateMatching_Match(TemplateMatching tm, GpuMat img, GpuMat tmpl, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             (*tm)->match(*img, *tmpl, *dst);
-            return;
+        } else {
+            (*tm)->match(*img, *tmpl, *dst, *s);
         }
-        (*tm)->match(*img, *tmpl, *dst, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void AlphaComp(GpuMat img1, GpuMat img2, GpuMat dst, int alpha_op, Stream s) {
+OpenCVResult AlphaComp(GpuMat img1, GpuMat img2, GpuMat dst, int alpha_op, Stream s) {
     try {
         if(s == NULL) {
             cv::cuda::alphaComp(*img1, *img2, *dst, alpha_op);
-            return;
+        } else {
+            cv::cuda::alphaComp(*img1, *img2, *dst, alpha_op, *s);
         }
-        cv::cuda::alphaComp(*img1, *img2, *dst, alpha_op, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GammaCorrection(GpuMat src, GpuMat dst, bool forward, Stream s) {
+OpenCVResult GammaCorrection(GpuMat src, GpuMat dst, bool forward, Stream s) {
     try {
         if(s == NULL) {
             cv::cuda::gammaCorrection(*src, *dst, forward);
-            return;
+        } else {
+            cv::cuda::gammaCorrection(*src, *dst, forward, *s);
         }
-        cv::cuda::gammaCorrection(*src, *dst, forward, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 
 }
 
-void SwapChannels(GpuMat image, int dstOrder[4], Stream s) {
+OpenCVResult SwapChannels(GpuMat image, int dstOrder[4], Stream s) {
     try {
         if(s == NULL) {
             cv::cuda::swapChannels(*image, dstOrder);
-            return;
+        } else {
+            cv::cuda::swapChannels(*image, dstOrder, *s);
         }
-        cv::cuda::swapChannels(*image, dstOrder, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Cuda_CalcHist(GpuMat src, GpuMat dst, Stream s) {
+OpenCVResult Cuda_CalcHist(GpuMat src, GpuMat dst, Stream s) {
     try {
         if(s == NULL) {
             cv::cuda::calcHist(*src, *dst);
-            return;
+        } else {
+            cv::cuda::calcHist(*src, *dst, *s);
         }
-        cv::cuda::calcHist(*src, *dst, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Cuda_CalcHist_WithParams(GpuMat src, GpuMat mask, GpuMat dst, Stream s) {
+OpenCVResult Cuda_CalcHist_WithParams(GpuMat src, GpuMat mask, GpuMat dst, Stream s) {
     try {
         if(s == NULL) {
             cv::cuda::calcHist(*src, *mask, *dst);
-            return;
+        } else {
+            cv::cuda::calcHist(*src, *mask, *dst, *s);
         }
-        cv::cuda::calcHist(*src, *mask, *dst, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Cuda_EqualizeHist(GpuMat src, GpuMat dst, Stream s) {
+OpenCVResult Cuda_EqualizeHist(GpuMat src, GpuMat dst, Stream s) {
     try {
         if(s == NULL) {
             cv::cuda::equalizeHist(*src, *dst);
-            return;
+        } else {
+            cv::cuda::equalizeHist(*src, *dst, *s);
         }
-        cv::cuda::equalizeHist(*src, *dst, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Cuda_EvenLevels(GpuMat levels, int nLevels, int lowerLevel, int upperLevel, Stream s) {
+OpenCVResult Cuda_EvenLevels(GpuMat levels, int nLevels, int lowerLevel, int upperLevel, Stream s) {
     try {
         if(s == NULL) {
             cv::cuda::evenLevels(*levels, nLevels, lowerLevel, upperLevel);
-            return;
+        } else {
+            cv::cuda::evenLevels(*levels, nLevels, lowerLevel, upperLevel, *s);
         }
-        cv::cuda::evenLevels(*levels, nLevels, lowerLevel, upperLevel, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Cuda_HistEven(GpuMat src, GpuMat hist, int histSize, int lowerLevel, int upperLevel, Stream s) {
+OpenCVResult Cuda_HistEven(GpuMat src, GpuMat hist, int histSize, int lowerLevel, int upperLevel, Stream s) {
     try {
         if(s == NULL) {
             cv::cuda::histEven(*src, *hist, histSize, lowerLevel, upperLevel);
-            return;
+        } else {
+            cv::cuda::histEven(*src, *hist, histSize, lowerLevel, upperLevel, *s);
         }
-        cv::cuda::histEven(*src, *hist, histSize, lowerLevel, upperLevel, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-
-void Cuda_HistRange(GpuMat src, GpuMat hist, GpuMat levels, Stream s){
+OpenCVResult Cuda_HistRange(GpuMat src, GpuMat hist, GpuMat levels, Stream s){
     try {
         if(s == NULL) {
             cv::cuda::histRange(*src, *hist, *levels);
-            return;
+        } else {
+            cv::cuda::histRange(*src, *hist, *levels, *s);
         }
-        cv::cuda::histRange(*src, *hist, *levels, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 } 
 
-void Cuda_BilateralFilter(GpuMat src, GpuMat dst, int kernel_size, float sigma_color, float sigma_spatial, int borderMode, Stream s) {
+OpenCVResult Cuda_BilateralFilter(GpuMat src, GpuMat dst, int kernel_size, float sigma_color, float sigma_spatial, int borderMode, Stream s) {
     try {
         if(s == NULL) {
             cv::cuda::bilateralFilter(*src, *dst, kernel_size, sigma_color, sigma_spatial, borderMode);
-            return;
+        } else {
+            cv::cuda::bilateralFilter(*src, *dst, kernel_size, sigma_color, sigma_spatial, borderMode, *s);
         }
-        cv::cuda::bilateralFilter(*src, *dst, kernel_size, sigma_color, sigma_spatial, borderMode, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Cuda_BlendLinear(GpuMat img1, GpuMat img2, GpuMat weights1, GpuMat weights2, GpuMat result, Stream s) {
+OpenCVResult Cuda_BlendLinear(GpuMat img1, GpuMat img2, GpuMat weights1, GpuMat weights2, GpuMat result, Stream s) {
     try {
         if(s == NULL) {
             cv::cuda::blendLinear(*img1, *img2, *weights1, *weights2, *result);
-            return;
+        } else {
+            cv::cuda::blendLinear(*img1, *img2, *weights1, *weights2, *result, *s);
         }
-        cv::cuda::blendLinear(*img1, *img2, *weights1, *weights2, *result, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Cuda_MeanShiftFiltering(GpuMat src, GpuMat dst, int sp, int sr, TermCriteria criteria, Stream s) {
+OpenCVResult Cuda_MeanShiftFiltering(GpuMat src, GpuMat dst, int sp, int sr, TermCriteria criteria, Stream s) {
     try {
         if(s == NULL) {
             cv::cuda::meanShiftFiltering(*src, *dst, sp, sr, *criteria);
-            return;
+        } else {
+            cv::cuda::meanShiftFiltering(*src, *dst, sp, sr, *criteria, *s);
         }
-        cv::cuda::meanShiftFiltering(*src, *dst, sp, sr, *criteria, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Cuda_MeanShiftProc(GpuMat src, GpuMat dstr, GpuMat dstsp, int sp, int sr, TermCriteria criteria, Stream s) {
+OpenCVResult Cuda_MeanShiftProc(GpuMat src, GpuMat dstr, GpuMat dstsp, int sp, int sr, TermCriteria criteria, Stream s) {
     try {
         if(s == NULL) {
             cv::cuda::meanShiftProc(*src, *dstr, *dstsp, sp, sr, *criteria);
-            return;
+        } else {
+            cv::cuda::meanShiftProc(*src, *dstr, *dstsp, sp, sr, *criteria, *s);
         }
-        cv::cuda::meanShiftProc(*src, *dstr, *dstsp, sp, sr, *criteria, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-
-void Cuda_MeanShiftSegmentation(GpuMat src, GpuMat dst, int sp, int sr, int minSize, TermCriteria criteria, Stream s) {
+OpenCVResult Cuda_MeanShiftSegmentation(GpuMat src, GpuMat dst, int sp, int sr, int minSize, TermCriteria criteria, Stream s) {
     try {
         if(s == NULL) {
             cv::cuda::meanShiftSegmentation(*src, *dst, sp, sr, minSize, *criteria);
-            return;
+        } else {
+            cv::cuda::meanShiftSegmentation(*src, *dst, sp, sr, minSize, *criteria, *s);
         }
-        cv::cuda::meanShiftSegmentation(*src, *dst, sp, sr, minSize, *criteria, *s);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }

--- a/cuda/imgproc.cpp
+++ b/cuda/imgproc.cpp
@@ -3,27 +3,45 @@
 #include <string.h>
 
 void GpuCvtColor(GpuMat src, GpuMat dst, int code, Stream s) {
-    if (s == NULL) {
-        cv::cuda::cvtColor(*src, *dst, code);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::cvtColor(*src, *dst, code);
+            return;
+        }
+        cv::cuda::cvtColor(*src, *dst, code, 0, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::cvtColor(*src, *dst, code, 0, *s);
 }
 
 void GpuDemosaicing(GpuMat src, GpuMat dst, int code, Stream s) {
-    if (s == NULL) {
-        cv::cuda::demosaicing(*src, *dst, code);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::demosaicing(*src, *dst, code);
+            return;
+        }
+        cv::cuda::demosaicing(*src, *dst, code, -1, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::demosaicing(*src, *dst, code, -1, *s);
 }
 
 CannyEdgeDetector CreateCannyEdgeDetector(double lowThresh, double highThresh) {
-    return new cv::Ptr<cv::cuda::CannyEdgeDetector>(cv::cuda::createCannyEdgeDetector(lowThresh, highThresh));
+    try {
+        return new cv::Ptr<cv::cuda::CannyEdgeDetector>(cv::cuda::createCannyEdgeDetector(lowThresh, highThresh));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 CannyEdgeDetector CreateCannyEdgeDetectorWithParams(double lowThresh, double highThresh, int appertureSize, bool L2gradient) {
-    return new cv::Ptr<cv::cuda::CannyEdgeDetector>(cv::cuda::createCannyEdgeDetector(lowThresh, highThresh, appertureSize, L2gradient));
+    try {
+        return new cv::Ptr<cv::cuda::CannyEdgeDetector>(cv::cuda::createCannyEdgeDetector(lowThresh, highThresh, appertureSize, L2gradient));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void CannyEdgeDetector_Close(CannyEdgeDetector det) {
@@ -31,52 +49,101 @@ void CannyEdgeDetector_Close(CannyEdgeDetector det) {
 }
 
 void CannyEdgeDetector_Detect(CannyEdgeDetector det, GpuMat img, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        (*det)->detect(*img, *dst);
-    } else {
+    try {
+        if (s == NULL) {
+            (*det)->detect(*img, *dst);
+            return;
+        }
         (*det)->detect(*img, *dst, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    return;
 }
 
 int CannyEdgeDetector_GetAppertureSize(CannyEdgeDetector det) {
-    return int((*det)->getAppertureSize());
+    try {
+        return int((*det)->getAppertureSize());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 double CannyEdgeDetector_GetHighThreshold(CannyEdgeDetector det) {
-    return double((*det)->getHighThreshold());
+    try {
+        return double((*det)->getHighThreshold());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 bool CannyEdgeDetector_GetL2Gradient(CannyEdgeDetector det) {
-    return bool((*det)->getL2Gradient());
+    try {
+        return bool((*det)->getL2Gradient());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 double CannyEdgeDetector_GetLowThreshold(CannyEdgeDetector det) {
-    return double((*det)->getLowThreshold());
+    try {
+        return double((*det)->getLowThreshold());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void CannyEdgeDetector_SetAppertureSize(CannyEdgeDetector det, int appertureSize) {
-     (*det)->setAppertureSize(appertureSize);
+    try {
+        (*det)->setAppertureSize(appertureSize);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void CannyEdgeDetector_SetHighThreshold(CannyEdgeDetector det, double highThresh) {
-     (*det)->setHighThreshold(highThresh);
+    try {
+        (*det)->setHighThreshold(highThresh);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void CannyEdgeDetector_SetL2Gradient(CannyEdgeDetector det, bool L2gradient) {
-     (*det)->setL2Gradient(L2gradient);
+    try {
+        (*det)->setL2Gradient(L2gradient);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void CannyEdgeDetector_SetLowThreshold(CannyEdgeDetector det, double lowThresh) {
-     (*det)->setLowThreshold(lowThresh);
+    try {
+        (*det)->setLowThreshold(lowThresh);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 HoughLinesDetector HoughLinesDetector_Create(double rho, double theta, int threshold) {
-    return new cv::Ptr<cv::cuda::HoughLinesDetector>(cv::cuda::createHoughLinesDetector(rho, theta, threshold));
+    try {
+        return new cv::Ptr<cv::cuda::HoughLinesDetector>(cv::cuda::createHoughLinesDetector(rho, theta, threshold));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 HoughLinesDetector HoughLinesDetector_CreateWithParams(double rho, double theta, int threshold, bool sort, int maxlines) {
-    return new cv::Ptr<cv::cuda::HoughLinesDetector>(cv::cuda::createHoughLinesDetector(rho, theta, threshold, sort, maxlines));
+    try {
+        return new cv::Ptr<cv::cuda::HoughLinesDetector>(cv::cuda::createHoughLinesDetector(rho, theta, threshold, sort, maxlines));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void HoughLinesDetector_Close(HoughLinesDetector hld) {
@@ -84,16 +151,24 @@ void HoughLinesDetector_Close(HoughLinesDetector hld) {
 }
 
 void HoughLinesDetector_Detect(HoughLinesDetector hld, GpuMat img, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        (*hld)->detect(*img, *dst);
-    } else {
+    try {
+        if (s == NULL) {
+            (*hld)->detect(*img, *dst);
+            return;
+        }
         (*hld)->detect(*img, *dst, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    return;
 }
 
 HoughSegmentDetector HoughSegmentDetector_Create(double rho, double theta, int minLineLength, int maxLineGap) {
-    return new cv::Ptr<cv::cuda::HoughSegmentDetector>(cv::cuda::createHoughSegmentDetector(rho, theta, minLineLength, maxLineGap));
+    try {
+        return new cv::Ptr<cv::cuda::HoughSegmentDetector>(cv::cuda::createHoughSegmentDetector(rho, theta, minLineLength, maxLineGap));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void HoughSegmentDetector_Close(HoughSegmentDetector hsd) {
@@ -101,16 +176,24 @@ void HoughSegmentDetector_Close(HoughSegmentDetector hsd) {
 }
 
 void HoughSegmentDetector_Detect(HoughSegmentDetector hsd, GpuMat img, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        (*hsd)->detect(*img, *dst);
-    } else {
+    try {
+        if (s == NULL) {
+            (*hsd)->detect(*img, *dst);
+            return;
+        }
         (*hsd)->detect(*img, *dst, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    return;
 }
 
 TemplateMatching TemplateMatching_Create(int srcType, int method) {
-    return new cv::Ptr<cv::cuda::TemplateMatching>(cv::cuda::createTemplateMatching(srcType, method));
+    try {
+        return new cv::Ptr<cv::cuda::TemplateMatching>(cv::cuda::createTemplateMatching(srcType, method));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void TemplateMatching_Close(TemplateMatching tm) {
@@ -118,124 +201,184 @@ void TemplateMatching_Close(TemplateMatching tm) {
 }
 
 void TemplateMatching_Match(TemplateMatching tm, GpuMat img, GpuMat tmpl, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        (*tm)->match(*img, *tmpl, *dst);
-    } else {
+    try {
+        if (s == NULL) {
+            (*tm)->match(*img, *tmpl, *dst);
+            return;
+        }
         (*tm)->match(*img, *tmpl, *dst, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    return;
 }
 
 void AlphaComp(GpuMat img1, GpuMat img2, GpuMat dst, int alpha_op, Stream s) {
-    if(s == NULL) {
-        cv::cuda::alphaComp(*img1, *img2, *dst, alpha_op);
-    } else {
+    try {
+        if(s == NULL) {
+            cv::cuda::alphaComp(*img1, *img2, *dst, alpha_op);
+            return;
+        }
         cv::cuda::alphaComp(*img1, *img2, *dst, alpha_op, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
 }
 
 void GammaCorrection(GpuMat src, GpuMat dst, bool forward, Stream s) {
-    if(s == NULL) {
-        cv::cuda::gammaCorrection(*src, *dst, forward);
-    } else {
+    try {
+        if(s == NULL) {
+            cv::cuda::gammaCorrection(*src, *dst, forward);
+            return;
+        }
         cv::cuda::gammaCorrection(*src, *dst, forward, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
+
 }
 
 void SwapChannels(GpuMat image, int dstOrder[4], Stream s) {
-    if(s == NULL) {
-        cv::cuda::swapChannels(*image, dstOrder);
-    } else {
+    try {
+        if(s == NULL) {
+            cv::cuda::swapChannels(*image, dstOrder);
+            return;
+        }
         cv::cuda::swapChannels(*image, dstOrder, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
 }
 
 void Cuda_CalcHist(GpuMat src, GpuMat dst, Stream s) {
-    if(s == NULL) {
-        cv::cuda::calcHist(*src, *dst);
-    }else{
+    try {
+        if(s == NULL) {
+            cv::cuda::calcHist(*src, *dst);
+            return;
+        }
         cv::cuda::calcHist(*src, *dst, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
 }
 
 void Cuda_CalcHist_WithParams(GpuMat src, GpuMat mask, GpuMat dst, Stream s) {
-    if(s == NULL) {
-        cv::cuda::calcHist(*src, *mask, *dst);
-    }else{
+    try {
+        if(s == NULL) {
+            cv::cuda::calcHist(*src, *mask, *dst);
+            return;
+        }
         cv::cuda::calcHist(*src, *mask, *dst, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
 }
 
 void Cuda_EqualizeHist(GpuMat src, GpuMat dst, Stream s) {
-    if(s == NULL) {
-        cv::cuda::equalizeHist(*src, *dst);
-    }else{
+    try {
+        if(s == NULL) {
+            cv::cuda::equalizeHist(*src, *dst);
+            return;
+        }
         cv::cuda::equalizeHist(*src, *dst, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
 }
 
 void Cuda_EvenLevels(GpuMat levels, int nLevels, int lowerLevel, int upperLevel, Stream s) {
-    if(s == NULL) {
-        cv::cuda::evenLevels(*levels, nLevels, lowerLevel, upperLevel);
-    }else{
+    try {
+        if(s == NULL) {
+            cv::cuda::evenLevels(*levels, nLevels, lowerLevel, upperLevel);
+            return;
+        }
         cv::cuda::evenLevels(*levels, nLevels, lowerLevel, upperLevel, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
 }
 
 void Cuda_HistEven(GpuMat src, GpuMat hist, int histSize, int lowerLevel, int upperLevel, Stream s) {
-    if(s == NULL) {
-        cv::cuda::histEven(*src, *hist, histSize, lowerLevel, upperLevel);
-    }else{
+    try {
+        if(s == NULL) {
+            cv::cuda::histEven(*src, *hist, histSize, lowerLevel, upperLevel);
+            return;
+        }
         cv::cuda::histEven(*src, *hist, histSize, lowerLevel, upperLevel, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
 }
 
 
 void Cuda_HistRange(GpuMat src, GpuMat hist, GpuMat levels, Stream s){
-    if(s == NULL) {
-        cv::cuda::histRange(*src, *hist, *levels);
-    } else {
+    try {
+        if(s == NULL) {
+            cv::cuda::histRange(*src, *hist, *levels);
+            return;
+        }
         cv::cuda::histRange(*src, *hist, *levels, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
 } 
 
 void Cuda_BilateralFilter(GpuMat src, GpuMat dst, int kernel_size, float sigma_color, float sigma_spatial, int borderMode, Stream s) {
-    if(s == NULL) {
-        cv::cuda::bilateralFilter(*src, *dst, kernel_size, sigma_color, sigma_spatial, borderMode);
-    } else {
+    try {
+        if(s == NULL) {
+            cv::cuda::bilateralFilter(*src, *dst, kernel_size, sigma_color, sigma_spatial, borderMode);
+            return;
+        }
         cv::cuda::bilateralFilter(*src, *dst, kernel_size, sigma_color, sigma_spatial, borderMode, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
 }
 
 void Cuda_BlendLinear(GpuMat img1, GpuMat img2, GpuMat weights1, GpuMat weights2, GpuMat result, Stream s) {
-    if(s == NULL) {
-        cv::cuda::blendLinear(*img1, *img2, *weights1, *weights2, *result);
-    } else {
+    try {
+        if(s == NULL) {
+            cv::cuda::blendLinear(*img1, *img2, *weights1, *weights2, *result);
+            return;
+        }
         cv::cuda::blendLinear(*img1, *img2, *weights1, *weights2, *result, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
 }
 
 void Cuda_MeanShiftFiltering(GpuMat src, GpuMat dst, int sp, int sr, TermCriteria criteria, Stream s) {
-    if(s == NULL) {
-        cv::cuda::meanShiftFiltering(*src, *dst, sp, sr, *criteria);
-    } else {
+    try {
+        if(s == NULL) {
+            cv::cuda::meanShiftFiltering(*src, *dst, sp, sr, *criteria);
+            return;
+        }
         cv::cuda::meanShiftFiltering(*src, *dst, sp, sr, *criteria, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
 }
 
 void Cuda_MeanShiftProc(GpuMat src, GpuMat dstr, GpuMat dstsp, int sp, int sr, TermCriteria criteria, Stream s) {
-    if(s == NULL) {
-        cv::cuda::meanShiftProc(*src, *dstr, *dstsp, sp, sr, *criteria);
-    } else {
+    try {
+        if(s == NULL) {
+            cv::cuda::meanShiftProc(*src, *dstr, *dstsp, sp, sr, *criteria);
+            return;
+        }
         cv::cuda::meanShiftProc(*src, *dstr, *dstsp, sp, sr, *criteria, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
 }
 
 
 void Cuda_MeanShiftSegmentation(GpuMat src, GpuMat dst, int sp, int sr, int minSize, TermCriteria criteria, Stream s) {
-    if(s == NULL) {
-        cv::cuda::meanShiftSegmentation(*src, *dst, sp, sr, minSize, *criteria);
-    } else {
+    try {
+        if(s == NULL) {
+            cv::cuda::meanShiftSegmentation(*src, *dst, sp, sr, minSize, *criteria);
+            return;
+        }
         cv::cuda::meanShiftSegmentation(*src, *dst, sp, sr, minSize, *criteria, *s);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
 }

--- a/cuda/imgproc.go
+++ b/cuda/imgproc.go
@@ -42,9 +42,8 @@ func (h *CannyEdgeDetector) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d43/classcv_1_1cuda_1_1CannyEdgeDetector.html#a6438cf8453f2dfd6703ceb50056de309
-func (h *CannyEdgeDetector) Detect(img GpuMat, dst *GpuMat) {
-	C.CannyEdgeDetector_Detect(C.CannyEdgeDetector(h.p), img.p, dst.p, nil)
-	return
+func (h *CannyEdgeDetector) Detect(img GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.CannyEdgeDetector_Detect(C.CannyEdgeDetector(h.p), img.p, dst.p, nil))
 }
 
 // DetectWithStream finds edges in an image using the Canny algorithm
@@ -52,9 +51,8 @@ func (h *CannyEdgeDetector) Detect(img GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d0/d43/classcv_1_1cuda_1_1CannyEdgeDetector.html#a6438cf8453f2dfd6703ceb50056de309
-func (h *CannyEdgeDetector) DetectWithStream(img GpuMat, dst *GpuMat, s Stream) {
-	C.CannyEdgeDetector_Detect(C.CannyEdgeDetector(h.p), img.p, dst.p, s.p)
-	return
+func (h *CannyEdgeDetector) DetectWithStream(img GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.CannyEdgeDetector_Detect(C.CannyEdgeDetector(h.p), img.p, dst.p, s.p))
 }
 
 // GetAppertureSize
@@ -127,8 +125,8 @@ func (h *CannyEdgeDetector) SetLowThreshold(lowThresh float64) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d8c/group__cudaimgproc__color.html#ga48d0f208181d5ca370d8ff6b62cbe826
-func CvtColor(src GpuMat, dst *GpuMat, code gocv.ColorConversionCode) {
-	C.GpuCvtColor(src.p, dst.p, C.int(code), nil)
+func CvtColor(src GpuMat, dst *GpuMat, code gocv.ColorConversionCode) error {
+	return OpenCVResult(C.GpuCvtColor(src.p, dst.p, C.int(code), nil))
 }
 
 // CvtColorWithStream converts an image from one color space to another
@@ -138,8 +136,8 @@ func CvtColor(src GpuMat, dst *GpuMat, code gocv.ColorConversionCode) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d8c/group__cudaimgproc__color.html#ga48d0f208181d5ca370d8ff6b62cbe826
-func CvtColorWithStream(src GpuMat, dst *GpuMat, code gocv.ColorConversionCode, s Stream) {
-	C.GpuCvtColor(src.p, dst.p, C.int(code), s.p)
+func CvtColorWithStream(src GpuMat, dst *GpuMat, code gocv.ColorConversionCode, s Stream) error {
+	return OpenCVResult(C.GpuCvtColor(src.p, dst.p, C.int(code), s.p))
 }
 
 // Demosaicing converts an image from Bayer pattern to RGB or grayscale.
@@ -148,8 +146,8 @@ func CvtColorWithStream(src GpuMat, dst *GpuMat, code gocv.ColorConversionCode, 
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d8c/group__cudaimgproc__color.html#ga7fb153572b573ebd2d7610fcbe64166e
-func Demosaicing(src GpuMat, dst *GpuMat, code gocv.ColorConversionCode) {
-	C.GpuDemosaicing(src.p, dst.p, C.int(code), nil)
+func Demosaicing(src GpuMat, dst *GpuMat, code gocv.ColorConversionCode) error {
+	return OpenCVResult(C.GpuDemosaicing(src.p, dst.p, C.int(code), nil))
 }
 
 // DemosaicingWithStream converts an image from Bayer pattern to RGB or grayscale
@@ -159,8 +157,8 @@ func Demosaicing(src GpuMat, dst *GpuMat, code gocv.ColorConversionCode) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d8c/group__cudaimgproc__color.html#ga7fb153572b573ebd2d7610fcbe64166e
-func DemosaicingWithStream(src GpuMat, dst *GpuMat, code gocv.ColorConversionCode, s Stream) {
-	C.GpuDemosaicing(src.p, dst.p, C.int(code), s.p)
+func DemosaicingWithStream(src GpuMat, dst *GpuMat, code gocv.ColorConversionCode, s Stream) error {
+	return OpenCVResult(C.GpuDemosaicing(src.p, dst.p, C.int(code), s.p))
 }
 
 // HoughLinesDetector
@@ -192,9 +190,8 @@ func (h *HoughLinesDetector) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/dcd/classcv_1_1cuda_1_1HoughLinesDetector.html#a18ff6d0886833ac6215054e191ae2520
-func (h *HoughLinesDetector) Detect(img GpuMat, dst *GpuMat) {
-	C.HoughLinesDetector_Detect(C.HoughLinesDetector(h.p), img.p, dst.p, nil)
-	return
+func (h *HoughLinesDetector) Detect(img GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.HoughLinesDetector_Detect(C.HoughLinesDetector(h.p), img.p, dst.p, nil))
 }
 
 // DetectWithStream finds lines in a binary image using the classical Hough transform
@@ -202,9 +199,8 @@ func (h *HoughLinesDetector) Detect(img GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d2/dcd/classcv_1_1cuda_1_1HoughLinesDetector.html#a18ff6d0886833ac6215054e191ae2520
-func (h *HoughLinesDetector) DetectWithStream(img GpuMat, dst *GpuMat, s Stream) {
-	C.HoughLinesDetector_Detect(C.HoughLinesDetector(h.p), img.p, dst.p, s.p)
-	return
+func (h *HoughLinesDetector) DetectWithStream(img GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.HoughLinesDetector_Detect(C.HoughLinesDetector(h.p), img.p, dst.p, s.p))
 }
 
 // HoughSegmentDetector
@@ -230,9 +226,8 @@ func (h *HoughSegmentDetector) Close() error {
 // Detect finds lines in a binary image using the Hough probabilistic transform.
 // For further details, please see:
 // https://docs.opencv.org/master/d6/df9/classcv_1_1cuda_1_1HoughSegmentDetector.html#a739bf84825ca455966d69dd75ca0ea6e
-func (h *HoughSegmentDetector) Detect(img GpuMat, dst *GpuMat) {
-	C.HoughSegmentDetector_Detect(C.HoughSegmentDetector(h.p), img.p, dst.p, nil)
-	return
+func (h *HoughSegmentDetector) Detect(img GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.HoughSegmentDetector_Detect(C.HoughSegmentDetector(h.p), img.p, dst.p, nil))
 }
 
 // DetectWithStream finds lines in a binary image using the Hough probabilistic transform
@@ -240,9 +235,8 @@ func (h *HoughSegmentDetector) Detect(img GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/df9/classcv_1_1cuda_1_1HoughSegmentDetector.html#a739bf84825ca455966d69dd75ca0ea6e
-func (h *HoughSegmentDetector) DetectWithStream(img GpuMat, dst *GpuMat, s Stream) {
-	C.HoughSegmentDetector_Detect(C.HoughSegmentDetector(h.p), img.p, dst.p, s.p)
-	return
+func (h *HoughSegmentDetector) DetectWithStream(img GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.HoughSegmentDetector_Detect(C.HoughSegmentDetector(h.p), img.p, dst.p, s.p))
 }
 
 // TemplateMatching
@@ -268,9 +262,8 @@ func (tm *TemplateMatching) Close() error {
 // Match computes a proximity map for a raster template and an image where the template is searched for.
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/d2/d58/classcv_1_1cuda_1_1TemplateMatching.html#a05a565a53461c916b3b10737cbe43a01
-func (tm *TemplateMatching) Match(img GpuMat, tmpl GpuMat, dst *GpuMat) {
-	C.TemplateMatching_Match(C.TemplateMatching(tm.p), img.p, tmpl.p, dst.p, nil)
-	return
+func (tm *TemplateMatching) Match(img GpuMat, tmpl GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.TemplateMatching_Match(C.TemplateMatching(tm.p), img.p, tmpl.p, dst.p, nil))
 }
 
 // MatchWithStream computes a proximity map for a raster template and an image where the template is searched for
@@ -278,9 +271,8 @@ func (tm *TemplateMatching) Match(img GpuMat, tmpl GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/d2/d58/classcv_1_1cuda_1_1TemplateMatching.html#a05a565a53461c916b3b10737cbe43a01
-func (tm *TemplateMatching) MatchWithStream(img GpuMat, tmpl GpuMat, dst *GpuMat, s Stream) {
-	C.TemplateMatching_Match(C.TemplateMatching(tm.p), img.p, tmpl.p, dst.p, s.p)
-	return
+func (tm *TemplateMatching) MatchWithStream(img GpuMat, tmpl GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.TemplateMatching_Match(C.TemplateMatching(tm.p), img.p, tmpl.p, dst.p, s.p))
 }
 
 // AlphaComp Composites two images using alpha opacity values contained in each image.
@@ -295,8 +287,8 @@ func (tm *TemplateMatching) MatchWithStream(img GpuMat, tmpl GpuMat, dst *GpuMat
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/db/d8c/group__cudaimgproc__color.html#ga08a698700458d9311390997b57fbf8dc
-func AlphaComp(img1 GpuMat, img2 GpuMat, dst *GpuMat, alphaOp AlphaCompTypes) {
-	C.AlphaComp(img1.p, img2.p, dst.p, C.int(alphaOp), nil)
+func AlphaComp(img1 GpuMat, img2 GpuMat, dst *GpuMat, alphaOp AlphaCompTypes) error {
+	return OpenCVResult(C.AlphaComp(img1.p, img2.p, dst.p, C.int(alphaOp), nil))
 }
 
 // AlphaCompWithStream Composites two images using alpha opacity values contained in each image.
@@ -313,8 +305,8 @@ func AlphaComp(img1 GpuMat, img2 GpuMat, dst *GpuMat, alphaOp AlphaCompTypes) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/db/d8c/group__cudaimgproc__color.html#ga08a698700458d9311390997b57fbf8dc
-func AlphaCompWithStream(img1 GpuMat, img2 GpuMat, dst *GpuMat, alphaOp AlphaCompTypes, s Stream) {
-	C.AlphaComp(img1.p, img2.p, dst.p, C.int(alphaOp), s.p)
+func AlphaCompWithStream(img1 GpuMat, img2 GpuMat, dst *GpuMat, alphaOp AlphaCompTypes, s Stream) error {
+	return OpenCVResult(C.AlphaComp(img1.p, img2.p, dst.p, C.int(alphaOp), s.p))
 }
 
 // GammaCorrection Routines for correcting image color gamma.
@@ -327,8 +319,8 @@ func AlphaCompWithStream(img1 GpuMat, img2 GpuMat, dst *GpuMat, alphaOp AlphaCom
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/db/d8c/group__cudaimgproc__color.html#gaf4195a8409c3b8fbfa37295c2b2c4729
-func GammaCorrection(src GpuMat, dst *GpuMat, forward bool) {
-	C.GammaCorrection(src.p, dst.p, C.bool(forward), nil)
+func GammaCorrection(src GpuMat, dst *GpuMat, forward bool) error {
+	return OpenCVResult(C.GammaCorrection(src.p, dst.p, C.bool(forward), nil))
 }
 
 // GammaCorrectionWithStream Routines for correcting image color gamma.
@@ -343,8 +335,8 @@ func GammaCorrection(src GpuMat, dst *GpuMat, forward bool) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/db/d8c/group__cudaimgproc__color.html#gaf4195a8409c3b8fbfa37295c2b2c4729
-func GammaCorrectionWithStream(src GpuMat, dst *GpuMat, forward bool, s Stream) {
-	C.GammaCorrection(src.p, dst.p, C.bool(forward), s.p)
+func GammaCorrectionWithStream(src GpuMat, dst *GpuMat, forward bool, s Stream) error {
+	return OpenCVResult(C.GammaCorrection(src.p, dst.p, C.bool(forward), s.p))
 }
 
 // SwapChannels Exchanges the color channels of an image in-place.
@@ -359,8 +351,8 @@ func GammaCorrectionWithStream(src GpuMat, dst *GpuMat, forward bool, s Stream) 
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/db/d8c/group__cudaimgproc__color.html#ga75a29cc4a97cde0d43ea066b01de927e
-func SwapChannels(image *GpuMat, dstOrder []int) {
-	C.SwapChannels(image.p, (*C.int)(unsafe.Pointer(&dstOrder[0])), nil)
+func SwapChannels(image *GpuMat, dstOrder []int) error {
+	return OpenCVResult(C.SwapChannels(image.p, (*C.int)(unsafe.Pointer(&dstOrder[0])), nil))
 }
 
 // SwapChannelsWithStream Exchanges the color channels of an image in-place.
@@ -377,8 +369,8 @@ func SwapChannels(image *GpuMat, dstOrder []int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/db/d8c/group__cudaimgproc__color.html#ga75a29cc4a97cde0d43ea066b01de927e
-func SwapChannelsWithStream(image *GpuMat, dstOrder []int, s Stream) {
-	C.SwapChannels(image.p, (*C.int)(unsafe.Pointer(&dstOrder[0])), s.p)
+func SwapChannelsWithStream(image *GpuMat, dstOrder []int, s Stream) error {
+	return OpenCVResult(C.SwapChannels(image.p, (*C.int)(unsafe.Pointer(&dstOrder[0])), s.p))
 }
 
 // CalcHist Calculates histogram for one channel 8-bit image.
@@ -389,8 +381,8 @@ func SwapChannelsWithStream(image *GpuMat, dstOrder []int, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d8/d0e/group__cudaimgproc__hist.html#gaaf3944106890947020bb4522a7619c26
-func CalcHist(src GpuMat, dst *GpuMat) {
-	C.Cuda_CalcHist(src.p, dst.p, nil)
+func CalcHist(src GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.Cuda_CalcHist(src.p, dst.p, nil))
 }
 
 // CalcHistWithStream Calculates histogram for one channel 8-bit image.
@@ -403,8 +395,8 @@ func CalcHist(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d8/d0e/group__cudaimgproc__hist.html#gaaf3944106890947020bb4522a7619c26
-func CalcHistWithStream(src GpuMat, dst *GpuMat, s Stream) {
-	C.Cuda_CalcHist(src.p, dst.p, s.p)
+func CalcHistWithStream(src GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.Cuda_CalcHist(src.p, dst.p, s.p))
 }
 
 // CalcHistWithParams Calculates histogram for one channel 8-bit image confined in given mask.
@@ -419,8 +411,8 @@ func CalcHistWithStream(src GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d8/d0e/group__cudaimgproc__hist.html#ga2d55b444ce776c8bbd3087cc90c47f32
-func CalcHistWithParams(src GpuMat, mask GpuMat, dst *GpuMat, s Stream) {
-	C.Cuda_CalcHist_WithParams(src.p, mask.p, dst.p, s.p)
+func CalcHistWithParams(src GpuMat, mask GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.Cuda_CalcHist_WithParams(src.p, mask.p, dst.p, s.p))
 }
 
 // EqualizeHist Equalizes the histogram of a grayscale image.
@@ -431,8 +423,8 @@ func CalcHistWithParams(src GpuMat, mask GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d8/d0e/group__cudaimgproc__hist.html#ga2384be74bd2feba7e6c46815513f0060
-func EqualizeHist(src GpuMat, dst *GpuMat) {
-	C.Cuda_EqualizeHist(src.p, dst.p, nil)
+func EqualizeHist(src GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.Cuda_EqualizeHist(src.p, dst.p, nil))
 }
 
 // EqualizeHistWithStream Equalizes the histogram of a grayscale image.
@@ -445,8 +437,8 @@ func EqualizeHist(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d8/d0e/group__cudaimgproc__hist.html#ga2384be74bd2feba7e6c46815513f0060
-func EqualizeHistWithStream(src GpuMat, dst *GpuMat, s Stream) {
-	C.Cuda_EqualizeHist(src.p, dst.p, s.p)
+func EqualizeHistWithStream(src GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.Cuda_EqualizeHist(src.p, dst.p, s.p))
 }
 
 // EvenLevels Computes levels with even distribution.
@@ -461,8 +453,8 @@ func EqualizeHistWithStream(src GpuMat, dst *GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d8/d0e/group__cudaimgproc__hist.html#ga2f2cbd21dc6d7367a7c4ee1a826f389dFor further details, please see:
-func EvenLevels(levels *GpuMat, nLevels int, lowerLevel int, upperLevel int) {
-	C.Cuda_EvenLevels(levels.p, C.int(nLevels), C.int(lowerLevel), C.int(upperLevel), nil)
+func EvenLevels(levels *GpuMat, nLevels int, lowerLevel int, upperLevel int) error {
+	return OpenCVResult(C.Cuda_EvenLevels(levels.p, C.int(nLevels), C.int(lowerLevel), C.int(upperLevel), nil))
 }
 
 // EvenLevelsWithStream Computes levels with even distribution.
@@ -479,8 +471,8 @@ func EvenLevels(levels *GpuMat, nLevels int, lowerLevel int, upperLevel int) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d8/d0e/group__cudaimgproc__hist.html#ga2f2cbd21dc6d7367a7c4ee1a826f389dFor further details, please see:
-func EvenLevelsWithStream(levels *GpuMat, nLevels int, lowerLevel int, upperLevel int, s Stream) {
-	C.Cuda_EvenLevels(levels.p, C.int(nLevels), C.int(lowerLevel), C.int(upperLevel), s.p)
+func EvenLevelsWithStream(levels *GpuMat, nLevels int, lowerLevel int, upperLevel int, s Stream) error {
+	return OpenCVResult(C.Cuda_EvenLevels(levels.p, C.int(nLevels), C.int(lowerLevel), C.int(upperLevel), s.p))
 }
 
 // HistEven Calculates a histogram with evenly distributed bins.
@@ -498,8 +490,8 @@ func EvenLevelsWithStream(levels *GpuMat, nLevels int, lowerLevel int, upperLeve
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d8/d0e/group__cudaimgproc__hist.html#gacd3b14279fb77a57a510cb8c89a1856f
-func HistEven(src GpuMat, hist *GpuMat, histSize int, lowerLevel int, upperLevel int) {
-	C.Cuda_HistEven(src.p, hist.p, C.int(histSize), C.int(lowerLevel), C.int(upperLevel), nil)
+func HistEven(src GpuMat, hist *GpuMat, histSize int, lowerLevel int, upperLevel int) error {
+	return OpenCVResult(C.Cuda_HistEven(src.p, hist.p, C.int(histSize), C.int(lowerLevel), C.int(upperLevel), nil))
 }
 
 // HistEvenWithStream Calculates a histogram with evenly distributed bins.
@@ -519,8 +511,8 @@ func HistEven(src GpuMat, hist *GpuMat, histSize int, lowerLevel int, upperLevel
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d8/d0e/group__cudaimgproc__hist.html#gacd3b14279fb77a57a510cb8c89a1856f
-func HistEvenWithStream(src GpuMat, hist *GpuMat, histSize int, lowerLevel int, upperLevel int, s Stream) {
-	C.Cuda_HistEven(src.p, hist.p, C.int(histSize), C.int(lowerLevel), C.int(upperLevel), s.p)
+func HistEvenWithStream(src GpuMat, hist *GpuMat, histSize int, lowerLevel int, upperLevel int, s Stream) error {
+	return OpenCVResult(C.Cuda_HistEven(src.p, hist.p, C.int(histSize), C.int(lowerLevel), C.int(upperLevel), s.p))
 }
 
 // HistRange Calculates a histogram with bins determined by the levels array.
@@ -534,8 +526,8 @@ func HistEvenWithStream(src GpuMat, hist *GpuMat, histSize int, lowerLevel int, 
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d8/d0e/group__cudaimgproc__hist.html#ga87819085c1059186d9cdeacd92cea783
-func HistRange(src GpuMat, hist *GpuMat, levels GpuMat) {
-	C.Cuda_HistRange(src.p, hist.p, levels.p, nil)
+func HistRange(src GpuMat, hist *GpuMat, levels GpuMat) error {
+	return OpenCVResult(C.Cuda_HistRange(src.p, hist.p, levels.p, nil))
 }
 
 // HistRangeWithStream Calculates a histogram with bins determined by the levels array.
@@ -551,8 +543,8 @@ func HistRange(src GpuMat, hist *GpuMat, levels GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d8/d0e/group__cudaimgproc__hist.html#ga87819085c1059186d9cdeacd92cea783
-func HistRangeWithStream(src GpuMat, hist *GpuMat, levels GpuMat, s Stream) {
-	C.Cuda_HistRange(src.p, hist.p, levels.p, s.p)
+func HistRangeWithStream(src GpuMat, hist *GpuMat, levels GpuMat, s Stream) error {
+	return OpenCVResult(C.Cuda_HistRange(src.p, hist.p, levels.p, s.p))
 }
 
 // BilateralFilter Performs bilateral filtering of passed image.
@@ -572,8 +564,8 @@ func HistRangeWithStream(src GpuMat, hist *GpuMat, levels GpuMat, s Stream) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d0/d05/group__cudaimgproc.html#ga6abeaecdd4e7edc0bd1393a04f4f20bd
-func BilateralFilter(src GpuMat, dst *GpuMat, kernelSize int, sigmaColor float32, sigmaSpatial float32, borderMode BorderType) {
-	C.Cuda_BilateralFilter(src.p, dst.p, C.int(kernelSize), C.float(sigmaColor), C.float(sigmaSpatial), C.int(borderMode), nil)
+func BilateralFilter(src GpuMat, dst *GpuMat, kernelSize int, sigmaColor float32, sigmaSpatial float32, borderMode BorderType) error {
+	return OpenCVResult(C.Cuda_BilateralFilter(src.p, dst.p, C.int(kernelSize), C.float(sigmaColor), C.float(sigmaSpatial), C.int(borderMode), nil))
 }
 
 // BilateralFilterWithStream Performs bilateral filtering of passed image.
@@ -595,8 +587,8 @@ func BilateralFilter(src GpuMat, dst *GpuMat, kernelSize int, sigmaColor float32
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d0/d05/group__cudaimgproc.html#ga6abeaecdd4e7edc0bd1393a04f4f20bd
-func BilateralFilterWithStream(src GpuMat, dst *GpuMat, kernelSize int, sigmaColor float32, sigmaSpatial float32, borderMode BorderType, s Stream) {
-	C.Cuda_BilateralFilter(src.p, dst.p, C.int(kernelSize), C.float(sigmaColor), C.float(sigmaSpatial), C.int(borderMode), s.p)
+func BilateralFilterWithStream(src GpuMat, dst *GpuMat, kernelSize int, sigmaColor float32, sigmaSpatial float32, borderMode BorderType, s Stream) error {
+	return OpenCVResult(C.Cuda_BilateralFilter(src.p, dst.p, C.int(kernelSize), C.float(sigmaColor), C.float(sigmaSpatial), C.int(borderMode), s.p))
 }
 
 // BlendLinear Performs linear blending of two images.
@@ -613,8 +605,8 @@ func BilateralFilterWithStream(src GpuMat, dst *GpuMat, kernelSize int, sigmaCol
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d0/d05/group__cudaimgproc.html#ga4793607e5729bcc15b27ea33d9fe335e
-func BlendLinear(img1 GpuMat, img2 GpuMat, weights1 GpuMat, weights2 GpuMat, result *GpuMat) {
-	C.Cuda_BlendLinear(img1.p, img2.p, weights1.p, weights2.p, result.p, nil)
+func BlendLinear(img1 GpuMat, img2 GpuMat, weights1 GpuMat, weights2 GpuMat, result *GpuMat) error {
+	return OpenCVResult(C.Cuda_BlendLinear(img1.p, img2.p, weights1.p, weights2.p, result.p, nil))
 }
 
 // BlendLinearWithStream Performs linear blending of two images.
@@ -633,8 +625,8 @@ func BlendLinear(img1 GpuMat, img2 GpuMat, weights1 GpuMat, weights2 GpuMat, res
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d0/d05/group__cudaimgproc.html#ga4793607e5729bcc15b27ea33d9fe335e
-func BlendLinearWithStream(img1 GpuMat, img2 GpuMat, weights1 GpuMat, weights2 GpuMat, result *GpuMat, s Stream) {
-	C.Cuda_BlendLinear(img1.p, img2.p, weights1.p, weights2.p, result.p, s.p)
+func BlendLinearWithStream(img1 GpuMat, img2 GpuMat, weights1 GpuMat, weights2 GpuMat, result *GpuMat, s Stream) error {
+	return OpenCVResult(C.Cuda_BlendLinear(img1.p, img2.p, weights1.p, weights2.p, result.p, s.p))
 }
 
 // MeanShiftFiltering Performs mean-shift filtering for each point of the source image.
@@ -653,8 +645,8 @@ func BlendLinearWithStream(img1 GpuMat, img2 GpuMat, weights1 GpuMat, weights2 G
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d0/d05/group__cudaimgproc.html#gae13b3035bc6df0e512d876dbb8c00555
-func MeanShiftFiltering(src GpuMat, dst *GpuMat, sp int, sr int, criteria gocv.TermCriteria) {
-	C.Cuda_MeanShiftFiltering(src.p, dst.p, C.int(sp), C.int(sr), C.TermCriteria(criteria.Ptr()), nil)
+func MeanShiftFiltering(src GpuMat, dst *GpuMat, sp int, sr int, criteria gocv.TermCriteria) error {
+	return OpenCVResult(C.Cuda_MeanShiftFiltering(src.p, dst.p, C.int(sp), C.int(sr), C.TermCriteria(criteria.Ptr()), nil))
 }
 
 // MeanShiftFilteringWithStream Performs mean-shift filtering for each point of the source image.
@@ -675,8 +667,8 @@ func MeanShiftFiltering(src GpuMat, dst *GpuMat, sp int, sr int, criteria gocv.T
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d0/d05/group__cudaimgproc.html#gae13b3035bc6df0e512d876dbb8c00555
-func MeanShiftFilteringWithStream(src GpuMat, dst *GpuMat, sp int, sr int, criteria gocv.TermCriteria, s Stream) {
-	C.Cuda_MeanShiftFiltering(src.p, dst.p, C.int(sp), C.int(sr), C.TermCriteria(criteria.Ptr()), s.p)
+func MeanShiftFilteringWithStream(src GpuMat, dst *GpuMat, sp int, sr int, criteria gocv.TermCriteria, s Stream) error {
+	return OpenCVResult(C.Cuda_MeanShiftFiltering(src.p, dst.p, C.int(sp), C.int(sr), C.TermCriteria(criteria.Ptr()), s.p))
 }
 
 // MeanShiftProc Performs a mean-shift procedure and stores information
@@ -696,8 +688,8 @@ func MeanShiftFilteringWithStream(src GpuMat, dst *GpuMat, sp int, sr int, crite
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d0/d05/group__cudaimgproc.html#ga6039dc8ecbe2f912bc83fcc9b3bcca39
-func MeanShiftProc(src GpuMat, dstr *GpuMat, dstsp *GpuMat, sp int, sr int, criteria gocv.TermCriteria) {
-	C.Cuda_MeanShiftProc(src.p, dstr.p, dstsp.p, C.int(sp), C.int(sr), C.TermCriteria(criteria.Ptr()), nil)
+func MeanShiftProc(src GpuMat, dstr *GpuMat, dstsp *GpuMat, sp int, sr int, criteria gocv.TermCriteria) error {
+	return OpenCVResult(C.Cuda_MeanShiftProc(src.p, dstr.p, dstsp.p, C.int(sp), C.int(sr), C.TermCriteria(criteria.Ptr()), nil))
 }
 
 // MeanShiftProcWithStream Performs a mean-shift procedure and stores information
@@ -719,8 +711,8 @@ func MeanShiftProc(src GpuMat, dstr *GpuMat, dstsp *GpuMat, sp int, sr int, crit
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d0/d05/group__cudaimgproc.html#ga6039dc8ecbe2f912bc83fcc9b3bcca39
-func MeanShiftProcWithStream(src GpuMat, dstr *GpuMat, dstsp *GpuMat, sp int, sr int, criteria gocv.TermCriteria, s Stream) {
-	C.Cuda_MeanShiftProc(src.p, dstr.p, dstsp.p, C.int(sp), C.int(sr), C.TermCriteria(criteria.Ptr()), s.p)
+func MeanShiftProcWithStream(src GpuMat, dstr *GpuMat, dstsp *GpuMat, sp int, sr int, criteria gocv.TermCriteria, s Stream) error {
+	return OpenCVResult(C.Cuda_MeanShiftProc(src.p, dstr.p, dstsp.p, C.int(sp), C.int(sr), C.TermCriteria(criteria.Ptr()), s.p))
 }
 
 // MeanShiftSegmentation Performs a mean-shift segmentation of the source image and eliminates small segments.
@@ -739,8 +731,8 @@ func MeanShiftProcWithStream(src GpuMat, dstr *GpuMat, dstsp *GpuMat, sp int, sr
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d0/d05/group__cudaimgproc.html#ga70ed80533a448829dc48cf22b1845c16
-func MeanShiftSegmentation(src GpuMat, dst *GpuMat, sp int, sr int, minSize int, criteria gocv.TermCriteria) {
-	C.Cuda_MeanShiftSegmentation(src.p, dst.p, C.int(sp), C.int(sr), C.int(minSize), C.TermCriteria(criteria.Ptr()), nil)
+func MeanShiftSegmentation(src GpuMat, dst *GpuMat, sp int, sr int, minSize int, criteria gocv.TermCriteria) error {
+	return OpenCVResult(C.Cuda_MeanShiftSegmentation(src.p, dst.p, C.int(sp), C.int(sr), C.int(minSize), C.TermCriteria(criteria.Ptr()), nil))
 }
 
 // MeanShiftSegmentationWithStream Performs a mean-shift segmentation of the source image and eliminates small segments.
@@ -761,6 +753,6 @@ func MeanShiftSegmentation(src GpuMat, dst *GpuMat, sp int, sr int, minSize int,
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d0/d05/group__cudaimgproc.html#ga70ed80533a448829dc48cf22b1845c16
-func MeanShiftSegmentationWithStream(src GpuMat, dst *GpuMat, sp int, sr int, minSize int, criteria gocv.TermCriteria, s Stream) {
-	C.Cuda_MeanShiftSegmentation(src.p, dst.p, C.int(sp), C.int(sr), C.int(minSize), C.TermCriteria(criteria.Ptr()), s.p)
+func MeanShiftSegmentationWithStream(src GpuMat, dst *GpuMat, sp int, sr int, minSize int, criteria gocv.TermCriteria, s Stream) error {
+	return OpenCVResult(C.Cuda_MeanShiftSegmentation(src.p, dst.p, C.int(sp), C.int(sr), C.int(minSize), C.TermCriteria(criteria.Ptr()), s.p))
 }

--- a/cuda/imgproc.h
+++ b/cuda/imgproc.h
@@ -25,28 +25,28 @@ typedef void* TemplateMatching;
 #endif
 
 // standalone functions
-void GpuCvtColor(GpuMat src, GpuMat dst, int code, Stream s);
-void GpuDemosaicing(GpuMat src, GpuMat dst, int code, Stream s);
-void AlphaComp(GpuMat img1, GpuMat img2, GpuMat dst, int alpha_op, Stream s);
-void GammaCorrection(GpuMat src, GpuMat dst, bool forward, Stream s);
-void SwapChannels(GpuMat image, int dstOrder[4], Stream s);
-void Cuda_CalcHist(GpuMat src, GpuMat dst, Stream s);
-void Cuda_CalcHist_WithParams(GpuMat src, GpuMat mask, GpuMat dst, Stream s);
-void Cuda_EqualizeHist(GpuMat src, GpuMat dst, Stream s);
-void Cuda_EvenLevels(GpuMat levels, int nLevels, int lowerLevel, int upperLevel, Stream s);
-void Cuda_HistEven(GpuMat src, GpuMat hist, int histSize, int lowerLevel, int upperLevel, Stream s);
-void Cuda_HistRange(GpuMat src, GpuMat hist, GpuMat levels, Stream s);
-void Cuda_BilateralFilter(GpuMat src, GpuMat dst, int kernel_size, float sigma_color, float sigma_spatial, int borderMode, Stream s);
-void Cuda_BlendLinear(GpuMat img1, GpuMat img2, GpuMat weights1, GpuMat weights2, GpuMat result, Stream s);
-void Cuda_MeanShiftFiltering(GpuMat src, GpuMat dst, int sp, int sr, TermCriteria criteria, Stream s);
-void Cuda_MeanShiftProc(GpuMat src, GpuMat dstr, GpuMat dstsp, int sp, int sr, TermCriteria criteria, Stream s);
-void Cuda_MeanShiftSegmentation(GpuMat src, GpuMat dst, int sp, int sr, int minSize, TermCriteria criteria, Stream s);
+OpenCVResult GpuCvtColor(GpuMat src, GpuMat dst, int code, Stream s);
+OpenCVResult GpuDemosaicing(GpuMat src, GpuMat dst, int code, Stream s);
+OpenCVResult AlphaComp(GpuMat img1, GpuMat img2, GpuMat dst, int alpha_op, Stream s);
+OpenCVResult GammaCorrection(GpuMat src, GpuMat dst, bool forward, Stream s);
+OpenCVResult SwapChannels(GpuMat image, int dstOrder[4], Stream s);
+OpenCVResult Cuda_CalcHist(GpuMat src, GpuMat dst, Stream s);
+OpenCVResult Cuda_CalcHist_WithParams(GpuMat src, GpuMat mask, GpuMat dst, Stream s);
+OpenCVResult Cuda_EqualizeHist(GpuMat src, GpuMat dst, Stream s);
+OpenCVResult Cuda_EvenLevels(GpuMat levels, int nLevels, int lowerLevel, int upperLevel, Stream s);
+OpenCVResult Cuda_HistEven(GpuMat src, GpuMat hist, int histSize, int lowerLevel, int upperLevel, Stream s);
+OpenCVResult Cuda_HistRange(GpuMat src, GpuMat hist, GpuMat levels, Stream s);
+OpenCVResult Cuda_BilateralFilter(GpuMat src, GpuMat dst, int kernel_size, float sigma_color, float sigma_spatial, int borderMode, Stream s);
+OpenCVResult Cuda_BlendLinear(GpuMat img1, GpuMat img2, GpuMat weights1, GpuMat weights2, GpuMat result, Stream s);
+OpenCVResult Cuda_MeanShiftFiltering(GpuMat src, GpuMat dst, int sp, int sr, TermCriteria criteria, Stream s);
+OpenCVResult Cuda_MeanShiftProc(GpuMat src, GpuMat dstr, GpuMat dstsp, int sp, int sr, TermCriteria criteria, Stream s);
+OpenCVResult Cuda_MeanShiftSegmentation(GpuMat src, GpuMat dst, int sp, int sr, int minSize, TermCriteria criteria, Stream s);
 
 // CannyEdgeDetector
 CannyEdgeDetector CreateCannyEdgeDetector(double lowThresh, double highThresh);
 CannyEdgeDetector CreateCannyEdgeDetectorWithParams(double lowThresh, double highThresh, int appertureSize, bool L2gradient);
 void CannyEdgeDetector_Close(CannyEdgeDetector det);
-void CannyEdgeDetector_Detect(CannyEdgeDetector det, GpuMat img, GpuMat dst, Stream s);
+OpenCVResult CannyEdgeDetector_Detect(CannyEdgeDetector det, GpuMat img, GpuMat dst, Stream s);
 int CannyEdgeDetector_GetAppertureSize(CannyEdgeDetector det);
 double CannyEdgeDetector_GetHighThreshold(CannyEdgeDetector det);
 bool CannyEdgeDetector_GetL2Gradient(CannyEdgeDetector det);
@@ -60,17 +60,17 @@ void CannyEdgeDetector_SetLowThreshold(CannyEdgeDetector det, double lowThresh);
 HoughLinesDetector HoughLinesDetector_Create(double rho, double theta, int threshold);
 HoughLinesDetector HoughLinesDetector_CreateWithParams(double rho, double theta, int threshold, bool sort, int maxlines);
 void HoughLinesDetector_Close(HoughLinesDetector hld);
-void HoughLinesDetector_Detect(HoughLinesDetector hld, GpuMat img, GpuMat dst, Stream s);
+OpenCVResult HoughLinesDetector_Detect(HoughLinesDetector hld, GpuMat img, GpuMat dst, Stream s);
 
 // HoughSegmentDetector
 HoughSegmentDetector HoughSegmentDetector_Create(double rho, double theta, int minLineLength, int maxLineGap);
 void HoughSegmentDetector_Close(HoughSegmentDetector hsd);
-void HoughSegmentDetector_Detect(HoughSegmentDetector hsd, GpuMat img, GpuMat dst, Stream s);
+OpenCVResult HoughSegmentDetector_Detect(HoughSegmentDetector hsd, GpuMat img, GpuMat dst, Stream s);
 
 // TemplateMatching
 TemplateMatching TemplateMatching_Create(int srcType, int method);
 void TemplateMatching_Close(TemplateMatching tm);
-void TemplateMatching_Match(TemplateMatching tm, GpuMat img, GpuMat tmpl, GpuMat dst, Stream s);
+OpenCVResult TemplateMatching_Match(TemplateMatching tm, GpuMat img, GpuMat tmpl, GpuMat dst, Stream s);
 
 #ifdef __cplusplus
 }

--- a/cuda/objdetect.cpp
+++ b/cuda/objdetect.cpp
@@ -5,151 +5,284 @@
 // CascadeClassifier_GPU
 
 CascadeClassifier_GPU CascadeClassifier_GPU_Create(const char*  cascade_name) {
-    return new cv::Ptr<cv::cuda::CascadeClassifier>(cv::cuda::CascadeClassifier::create(cascade_name));
+    try {
+        return new cv::Ptr<cv::cuda::CascadeClassifier>(cv::cuda::CascadeClassifier::create(cascade_name));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 struct Rects CascadeClassifier_GPU_DetectMultiScale(CascadeClassifier_GPU cs, GpuMat img) {
-    std::vector<cv::Rect> detected;
-    cv::cuda::GpuMat objbuf;
+    try {
+        std::vector<cv::Rect> detected;
+        cv::cuda::GpuMat objbuf;
+        
+        (*cs)->detectMultiScale(*img, objbuf); // uses all default parameters
+        (*cs)->convert(objbuf, detected);
+        
+        Rect* rects = new Rect[detected.size()];
     
-    (*cs)->detectMultiScale(*img, objbuf); // uses all default parameters
-    (*cs)->convert(objbuf, detected);
+        for (size_t i = 0; i < detected.size(); ++i) {
+            Rect r = {detected[i].x, detected[i].y, detected[i].width, detected[i].height};
+            rects[i] = r;
+        }
     
-    Rect* rects = new Rect[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        Rect r = {detected[i].x, detected[i].y, detected[i].width, detected[i].height};
-        rects[i] = r;
+        Rects ret = {rects, (int)detected.size()};
+        return ret;    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Rects ret = {NULL, 0};
+        return ret;
     }
-
-    Rects ret = {rects, (int)detected.size()};
-    return ret;
 }
 
 // HOG
 
 HOG HOG_Create() {
-    return new cv::Ptr<cv::cuda::HOG>(cv::cuda::HOG::create());
+    try {
+        return new cv::Ptr<cv::cuda::HOG>(cv::cuda::HOG::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 HOG HOG_CreateWithParams(Size winSize, Size blockSize, Size blockStride, Size cellSize, int nbins) {
-    cv::Size winSz(winSize.width, winSize.height);
-    cv::Size blockSz(blockSize.width, blockSize.height);
-    cv::Size blockSt(blockStride.width, blockStride.height);
-    cv::Size cellSz(cellSize.width, cellSize.height);
-
-    return new cv::Ptr<cv::cuda::HOG>(cv::cuda::HOG::create(winSz, blockSz, blockSt, cellSz, nbins));
+    try {
+        cv::Size winSz(winSize.width, winSize.height);
+        cv::Size blockSz(blockSize.width, blockSize.height);
+        cv::Size blockSt(blockStride.width, blockStride.height);
+        cv::Size cellSz(cellSize.width, cellSize.height);
+    
+        return new cv::Ptr<cv::cuda::HOG>(cv::cuda::HOG::create(winSz, blockSz, blockSt, cellSz, nbins));    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 struct Rects HOG_DetectMultiScale(HOG hog, GpuMat img) {    
-    std::vector<cv::Rect> detected;    
-    (*hog)->detectMultiScale(*img, detected);
-
-    Rect* rects = new Rect[detected.size()];
-    for (size_t i = 0; i < detected.size(); ++i) {
-        Rect r = {detected[i].x, detected[i].y, detected[i].width, detected[i].height};
-        rects[i] = r;
+    try {
+        std::vector<cv::Rect> detected;    
+        (*hog)->detectMultiScale(*img, detected);
+    
+        Rect* rects = new Rect[detected.size()];
+        for (size_t i = 0; i < detected.size(); ++i) {
+            Rect r = {detected[i].x, detected[i].y, detected[i].width, detected[i].height};
+            rects[i] = r;
+        }
+    
+        Rects ret = {rects, (int)detected.size()};
+        return ret;    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Rects ret = {NULL, 0};
+        return ret;
     }
-
-    Rects ret = {rects, (int)detected.size()};
-    return ret;
 }
 
 GpuMat HOG_Compute(HOG hog, GpuMat img) {    
-    GpuMat dst = new cv::cuda::GpuMat();
-    (*hog)->compute(*img, *dst);
-
-    return dst;
+    try {
+        GpuMat dst = new cv::cuda::GpuMat();
+        (*hog)->compute(*img, *dst);
+    
+        return dst;    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 Mat HOG_GetPeopleDetector(HOG hog) {
-    return new cv::Mat((*hog)->getDefaultPeopleDetector());
+    try {
+        return new cv::Mat((*hog)->getDefaultPeopleDetector());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 void HOG_SetSVMDetector(HOG hog, Mat det) {
-    (*hog)->setSVMDetector(*det);
+    try {
+        (*hog)->setSVMDetector(*det);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 int HOG_GetDescriptorFormat(HOG hog) {
-    return int((*hog)->getDescriptorFormat());
+    try {
+        return int((*hog)->getDescriptorFormat());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 size_t HOG_GetBlockHistogramSize(HOG hog) {
-    return size_t((*hog)->getBlockHistogramSize());
+    try {
+        return size_t((*hog)->getBlockHistogramSize());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 size_t HOG_GetDescriptorSize(HOG hog) {
-    return size_t((*hog)->getDescriptorSize());
+    try {
+        return size_t((*hog)->getDescriptorSize());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 bool HOG_GetGammaCorrection(HOG hog) {
-    return bool((*hog)->getGammaCorrection());
+    try {
+        return bool((*hog)->getGammaCorrection());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 int HOG_GetGroupThreshold(HOG hog) {
-    return int((*hog)->getGroupThreshold());
+    try {
+        return int((*hog)->getGroupThreshold());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 double HOG_GetHitThreshold(HOG hog) {
-    return double((*hog)->getHitThreshold());
+    try {
+        return double((*hog)->getHitThreshold());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 double HOG_GetL2HysThreshold(HOG hog) {
-    return double((*hog)->getL2HysThreshold());
+    try {
+        return double((*hog)->getL2HysThreshold());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 int HOG_GetNumLevels(HOG hog) {
-    return int((*hog)->getNumLevels());
+    try {
+        return int((*hog)->getNumLevels());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 double HOG_GetScaleFactor(HOG hog) {
-    return double((*hog)->getScaleFactor());
+    try {
+        return double((*hog)->getScaleFactor());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 double HOG_GetWinSigma(HOG hog) {
-    return double((*hog)->getWinSigma());
+    try {
+        return double((*hog)->getWinSigma());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 struct Size HOG_GetWinStride(HOG hog) {
-    cv::Size sz = (*hog)->getWinStride();
-    Size size = {sz.width, sz.height};
-    return size;
+    try {
+        cv::Size sz = (*hog)->getWinStride();
+        Size size = {sz.width, sz.height};
+        return size;    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Size size = {0, 0};
+        return size;
+    }
 }
 
 void HOG_SetDescriptorFormat(HOG hog, int descrFormat) {
-    auto df = static_cast<cv::HOGDescriptor::DescriptorStorageFormat>(descrFormat); 
-     (*hog)->setDescriptorFormat(df);
+    try {
+        auto df = static_cast<cv::HOGDescriptor::DescriptorStorageFormat>(descrFormat); 
+        (*hog)->setDescriptorFormat(df);   
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void HOG_SetGammaCorrection(HOG hog, bool gammaCorrection) {
-     (*hog)->setGammaCorrection(gammaCorrection);
+    try {
+        (*hog)->setGammaCorrection(gammaCorrection);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void HOG_SetGroupThreshold(HOG hog, int groupThreshold) {
-     (*hog)->setGroupThreshold(groupThreshold);
+    try {
+        (*hog)->setGroupThreshold(groupThreshold);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void HOG_SetHitThreshold(HOG hog, double hitThreshold) {
-     (*hog)->setHitThreshold(hitThreshold);
+    try {
+        (*hog)->setHitThreshold(hitThreshold);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void HOG_SetL2HysThreshold(HOG hog, double thresholdL2hys) {
-     (*hog)->setL2HysThreshold(thresholdL2hys);
+    try {
+        (*hog)->setL2HysThreshold(thresholdL2hys);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void HOG_SetNumLevels(HOG hog, int nlevels) {
-     (*hog)->setNumLevels(nlevels);
+    try {
+        (*hog)->setNumLevels(nlevels);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void HOG_SetScaleFactor(HOG hog, double scale0) {
-     (*hog)->setScaleFactor(scale0);
+    try {
+        (*hog)->setScaleFactor(scale0);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void HOG_SetWinSigma(HOG hog, double winSigma) {
-     (*hog)->setWinSigma(winSigma);
+    try {
+        (*hog)->setWinSigma(winSigma);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void HOG_SetWinStride(HOG hog, Size dsize) {
-    cv::Size sz(dsize.width, dsize.height);
-    (*hog)->setWinStride(sz);
+    try {
+        cv::Size sz(dsize.width, dsize.height);
+        (*hog)->setWinStride(sz);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }

--- a/cuda/optflow.cpp
+++ b/cuda/optflow.cpp
@@ -1,9 +1,18 @@
 #include "optflow.h"
 
 CudaSparsePyrLKOpticalFlow CudaSparsePyrLKOpticalFlow_Create() {
-    return new cv::Ptr<cv::cuda::SparsePyrLKOpticalFlow>(cv::cuda::SparsePyrLKOpticalFlow::create());
+    try {
+        return new cv::Ptr<cv::cuda::SparsePyrLKOpticalFlow>(cv::cuda::SparsePyrLKOpticalFlow::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void CudaSparsePyrLKOpticalFlow_Calc(CudaSparsePyrLKOpticalFlow p, GpuMat prevImg, GpuMat nextImg, GpuMat prevPts, GpuMat nextPts, GpuMat status){
-    (*p)->calc(*prevImg,*nextImg,*prevPts,*nextPts,*status);
+    try {
+        (*p)->calc(*prevImg,*nextImg,*prevPts,*nextPts,*status);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }

--- a/cuda/optflow.cpp
+++ b/cuda/optflow.cpp
@@ -9,10 +9,11 @@ CudaSparsePyrLKOpticalFlow CudaSparsePyrLKOpticalFlow_Create() {
     }
 }
 
-void CudaSparsePyrLKOpticalFlow_Calc(CudaSparsePyrLKOpticalFlow p, GpuMat prevImg, GpuMat nextImg, GpuMat prevPts, GpuMat nextPts, GpuMat status){
+OpenCVResult CudaSparsePyrLKOpticalFlow_Calc(CudaSparsePyrLKOpticalFlow p, GpuMat prevImg, GpuMat nextImg, GpuMat prevPts, GpuMat nextPts, GpuMat status){
     try {
         (*p)->calc(*prevImg,*nextImg,*prevPts,*nextPts,*status);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }

--- a/cuda/optflow.go
+++ b/cuda/optflow.go
@@ -26,6 +26,6 @@ func NewSparsePyrLKOpticalFlow() SparsePyrLKOpticalFlow {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d5/dcf/classcv_1_1cuda_1_1SparseOpticalFlow.html#a80d5efbb7788e3dc4c49e6226ba34347
-func (s SparsePyrLKOpticalFlow) Calc(prevImg, nextImg, prevPts, nextPts, status GpuMat) {
-	C.CudaSparsePyrLKOpticalFlow_Calc(C.CudaSparsePyrLKOpticalFlow(s.p), prevImg.p, nextImg.p, prevPts.p, nextPts.p, status.p)
+func (s SparsePyrLKOpticalFlow) Calc(prevImg, nextImg, prevPts, nextPts, status GpuMat) error {
+	return OpenCVResult(C.CudaSparsePyrLKOpticalFlow_Calc(C.CudaSparsePyrLKOpticalFlow(s.p), prevImg.p, nextImg.p, prevPts.p, nextPts.p, status.p))
 }

--- a/cuda/optflow.h
+++ b/cuda/optflow.h
@@ -19,7 +19,7 @@ typedef void* CudaSparsePyrLKOpticalFlow;
 #endif
 
 CudaSparsePyrLKOpticalFlow CudaSparsePyrLKOpticalFlow_Create();
-void CudaSparsePyrLKOpticalFlow_Calc(CudaSparsePyrLKOpticalFlow p, GpuMat prevImg, GpuMat nextImg, GpuMat prevPts, GpuMat nextPts, GpuMat status);
+OpenCVResult CudaSparsePyrLKOpticalFlow_Calc(CudaSparsePyrLKOpticalFlow p, GpuMat prevImg, GpuMat nextImg, GpuMat prevPts, GpuMat nextPts, GpuMat status);
 
 #ifdef __cplusplus
 }

--- a/cuda/warping.cpp
+++ b/cuda/warping.cpp
@@ -1,120 +1,129 @@
 #include "warping.h"
 
-void CudaResize(GpuMat src, GpuMat dst, Size dsize, double fx, double fy, int interp, Stream s) {
+OpenCVResult CudaResize(GpuMat src, GpuMat dst, Size dsize, double fx, double fy, int interp, Stream s) {
     try {
         cv::Size sz(dsize.width, dsize.height);
 
         if (s == NULL) {
             cv::cuda::resize(*src, *dst, sz, fx, fy, interp);
-            return;
+        } else {
+            cv::cuda::resize(*src, *dst, sz, fx, fy, interp, *s);
         }
-        cv::cuda::resize(*src, *dst, sz, fx, fy, interp, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void CudaPyrDown(GpuMat src, GpuMat dst, Stream s) {
+OpenCVResult CudaPyrDown(GpuMat src, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::pyrDown(*src, *dst);
-            return;
+        } else {
+            cv::cuda::pyrDown(*src, *dst, *s);
         }
-        cv::cuda::pyrDown(*src, *dst, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void CudaPyrUp(GpuMat src, GpuMat dst, Stream s) {
+OpenCVResult CudaPyrUp(GpuMat src, GpuMat dst, Stream s) {
     try {
         if (s == NULL) {
             cv::cuda::pyrUp(*src, *dst);
-            return;
+        } else {
+            cv::cuda::pyrUp(*src, *dst, *s);
         }
-        cv::cuda::pyrUp(*src, *dst, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void CudaBuildWarpAffineMaps(GpuMat M, bool inverse, Size dsize, GpuMat xmap, GpuMat ymap, Stream s) {
+OpenCVResult CudaBuildWarpAffineMaps(GpuMat M, bool inverse, Size dsize, GpuMat xmap, GpuMat ymap, Stream s) {
     try {
         cv::Size sz(dsize.width, dsize.height);
         if (s == NULL) {
             cv::cuda::buildWarpAffineMaps(*M, inverse, sz, *xmap, *ymap);
-            return;
+        } else {
+            cv::cuda::buildWarpAffineMaps(*M, inverse, sz, *xmap, *ymap, *s);
         }
-        cv::cuda::buildWarpAffineMaps(*M, inverse, sz, *xmap, *ymap, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void CudaBuildWarpPerspectiveMaps(GpuMat M, bool inverse, Size dsize, GpuMat xmap, GpuMat ymap, Stream s) {
+OpenCVResult CudaBuildWarpPerspectiveMaps(GpuMat M, bool inverse, Size dsize, GpuMat xmap, GpuMat ymap, Stream s) {
     try {
         cv::Size sz(dsize.width, dsize.height);
         if (s == NULL) {
             cv::cuda::buildWarpPerspectiveMaps(*M, inverse, sz, *xmap, *ymap);
-            return;
+        } else {
+            cv::cuda::buildWarpPerspectiveMaps(*M, inverse, sz, *xmap, *ymap, *s);
         }
-        cv::cuda::buildWarpPerspectiveMaps(*M, inverse, sz, *xmap, *ymap, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void CudaRemap(GpuMat src, GpuMat dst, GpuMat xmap, GpuMat ymap, int interp, int borderMode, Scalar borderValue, Stream s) {
+OpenCVResult CudaRemap(GpuMat src, GpuMat dst, GpuMat xmap, GpuMat ymap, int interp, int borderMode, Scalar borderValue, Stream s) {
     try {
         cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
         if (s == NULL) {
             cv::cuda::remap(*src, *dst, *xmap, *ymap, interp, borderMode, c);
-            return;
+        } else {
+            cv::cuda::remap(*src, *dst, *xmap, *ymap, interp, borderMode, c, *s);
         }
-        cv::cuda::remap(*src, *dst, *xmap, *ymap, interp, borderMode, c, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void CudaRotate(GpuMat src, GpuMat dst, Size dsize, double angle, double xShift, double yShift, int interp, Stream s) {
+OpenCVResult CudaRotate(GpuMat src, GpuMat dst, Size dsize, double angle, double xShift, double yShift, int interp, Stream s) {
     try {
         cv::Size sz(dsize.width, dsize.height);
         if (s == NULL) {
             cv::cuda::rotate(*src, *dst, sz, angle, xShift, yShift, interp);
-            return;
+        } else {
+            cv::cuda::rotate(*src, *dst, sz, angle, xShift, yShift, interp, *s);
         }
-        cv::cuda::rotate(*src, *dst, sz, angle, xShift, yShift, interp, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void CudaWarpAffine(GpuMat src, GpuMat dst, GpuMat M, Size dsize, int flags, int borderMode, Scalar borderValue, Stream s) {
+OpenCVResult CudaWarpAffine(GpuMat src, GpuMat dst, GpuMat M, Size dsize, int flags, int borderMode, Scalar borderValue, Stream s) {
     try {
         cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
         cv::Size sz(dsize.width, dsize.height);
     
         if (s == NULL) {
             cv::cuda::warpAffine(*src, *dst, *M, sz, flags, borderMode, c);
-            return;
+        } else {
+            cv::cuda::warpAffine(*src, *dst, *M, sz, flags, borderMode, c, *s);
         }
-        cv::cuda::warpAffine(*src, *dst, *M, sz, flags, borderMode, c, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void CudaWarpPerspective(GpuMat src, GpuMat dst, GpuMat M, Size dsize, int flags, int borderMode, Scalar borderValue, Stream s) {
+OpenCVResult CudaWarpPerspective(GpuMat src, GpuMat dst, GpuMat M, Size dsize, int flags, int borderMode, Scalar borderValue, Stream s) {
     try {
         cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
         cv::Size sz(dsize.width, dsize.height);
         if (s == NULL) {
             cv::cuda::warpPerspective(*src, *dst, *M, sz, flags, borderMode, c);
-            return;
+        } else {
+            cv::cuda::warpPerspective(*src, *dst, *M, sz, flags, borderMode, c, *s);
         }
-        cv::cuda::warpPerspective(*src, *dst, *M, sz, flags, borderMode, c, *s);    
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }

--- a/cuda/warping.cpp
+++ b/cuda/warping.cpp
@@ -1,84 +1,120 @@
 #include "warping.h"
 
 void CudaResize(GpuMat src, GpuMat dst, Size dsize, double fx, double fy, int interp, Stream s) {
-    cv::Size sz(dsize.width, dsize.height);
+    try {
+        cv::Size sz(dsize.width, dsize.height);
 
-    if (s == NULL) {
-        cv::cuda::resize(*src, *dst, sz, fx, fy, interp);
-        return;
+        if (s == NULL) {
+            cv::cuda::resize(*src, *dst, sz, fx, fy, interp);
+            return;
+        }
+        cv::cuda::resize(*src, *dst, sz, fx, fy, interp, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::resize(*src, *dst, sz, fx, fy, interp, *s);
 }
 
 void CudaPyrDown(GpuMat src, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::pyrDown(*src, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::pyrDown(*src, *dst);
+            return;
+        }
+        cv::cuda::pyrDown(*src, *dst, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::pyrDown(*src, *dst, *s);
 }
 
 void CudaPyrUp(GpuMat src, GpuMat dst, Stream s) {
-    if (s == NULL) {
-        cv::cuda::pyrUp(*src, *dst);
-        return;
+    try {
+        if (s == NULL) {
+            cv::cuda::pyrUp(*src, *dst);
+            return;
+        }
+        cv::cuda::pyrUp(*src, *dst, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::pyrUp(*src, *dst, *s);
 }
 
 void CudaBuildWarpAffineMaps(GpuMat M, bool inverse, Size dsize, GpuMat xmap, GpuMat ymap, Stream s) {
-    cv::Size sz(dsize.width, dsize.height);
-    if (s == NULL) {
-        cv::cuda::buildWarpAffineMaps(*M, inverse, sz, *xmap, *ymap);
-        return;
+    try {
+        cv::Size sz(dsize.width, dsize.height);
+        if (s == NULL) {
+            cv::cuda::buildWarpAffineMaps(*M, inverse, sz, *xmap, *ymap);
+            return;
+        }
+        cv::cuda::buildWarpAffineMaps(*M, inverse, sz, *xmap, *ymap, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::buildWarpAffineMaps(*M, inverse, sz, *xmap, *ymap, *s);
 }
 
 void CudaBuildWarpPerspectiveMaps(GpuMat M, bool inverse, Size dsize, GpuMat xmap, GpuMat ymap, Stream s) {
-    cv::Size sz(dsize.width, dsize.height);
-    if (s == NULL) {
-        cv::cuda::buildWarpPerspectiveMaps(*M, inverse, sz, *xmap, *ymap);
-        return;
+    try {
+        cv::Size sz(dsize.width, dsize.height);
+        if (s == NULL) {
+            cv::cuda::buildWarpPerspectiveMaps(*M, inverse, sz, *xmap, *ymap);
+            return;
+        }
+        cv::cuda::buildWarpPerspectiveMaps(*M, inverse, sz, *xmap, *ymap, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::buildWarpPerspectiveMaps(*M, inverse, sz, *xmap, *ymap, *s);
 }
 
 void CudaRemap(GpuMat src, GpuMat dst, GpuMat xmap, GpuMat ymap, int interp, int borderMode, Scalar borderValue, Stream s) {
-    cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
-    if (s == NULL) {
-        cv::cuda::remap(*src, *dst, *xmap, *ymap, interp, borderMode, c);
-        return;
+    try {
+        cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
+        if (s == NULL) {
+            cv::cuda::remap(*src, *dst, *xmap, *ymap, interp, borderMode, c);
+            return;
+        }
+        cv::cuda::remap(*src, *dst, *xmap, *ymap, interp, borderMode, c, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::remap(*src, *dst, *xmap, *ymap, interp, borderMode, c, *s);
 }
 
 void CudaRotate(GpuMat src, GpuMat dst, Size dsize, double angle, double xShift, double yShift, int interp, Stream s) {
-    cv::Size sz(dsize.width, dsize.height);
-    if (s == NULL) {
-        cv::cuda::rotate(*src, *dst, sz, angle, xShift, yShift, interp);
-        return;
+    try {
+        cv::Size sz(dsize.width, dsize.height);
+        if (s == NULL) {
+            cv::cuda::rotate(*src, *dst, sz, angle, xShift, yShift, interp);
+            return;
+        }
+        cv::cuda::rotate(*src, *dst, sz, angle, xShift, yShift, interp, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::rotate(*src, *dst, sz, angle, xShift, yShift, interp, *s);
 }
 
 void CudaWarpAffine(GpuMat src, GpuMat dst, GpuMat M, Size dsize, int flags, int borderMode, Scalar borderValue, Stream s) {
-    cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
-    cv::Size sz(dsize.width, dsize.height);
-
-    if (s == NULL) {
-        cv::cuda::warpAffine(*src, *dst, *M, sz, flags, borderMode, c);
-        return;
+    try {
+        cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
+        cv::Size sz(dsize.width, dsize.height);
+    
+        if (s == NULL) {
+            cv::cuda::warpAffine(*src, *dst, *M, sz, flags, borderMode, c);
+            return;
+        }
+        cv::cuda::warpAffine(*src, *dst, *M, sz, flags, borderMode, c, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::warpAffine(*src, *dst, *M, sz, flags, borderMode, c, *s);
 }
 
 void CudaWarpPerspective(GpuMat src, GpuMat dst, GpuMat M, Size dsize, int flags, int borderMode, Scalar borderValue, Stream s) {
-    cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
-    cv::Size sz(dsize.width, dsize.height);
-    if (s == NULL) {
-        cv::cuda::warpPerspective(*src, *dst, *M, sz, flags, borderMode, c);
-        return;
+    try {
+        cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
+        cv::Size sz(dsize.width, dsize.height);
+        if (s == NULL) {
+            cv::cuda::warpPerspective(*src, *dst, *M, sz, flags, borderMode, c);
+            return;
+        }
+        cv::cuda::warpPerspective(*src, *dst, *M, sz, flags, borderMode, c, *s);    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::cuda::warpPerspective(*src, *dst, *M, sz, flags, borderMode, c, *s);
 }

--- a/cuda/warping.go
+++ b/cuda/warping.go
@@ -71,13 +71,13 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga4f5fa0770d1c9efbadb9be1b92a6452a
-func Resize(src GpuMat, dst *GpuMat, sz image.Point, fx, fy float64, interp InterpolationFlags) {
+func Resize(src GpuMat, dst *GpuMat, sz image.Point, fx, fy float64, interp InterpolationFlags) error {
 	pSize := C.struct_Size{
 		width:  C.int(sz.X),
 		height: C.int(sz.Y),
 	}
 
-	C.CudaResize(src.p, dst.p, pSize, C.double(fx), C.double(fy), C.int(interp), nil)
+	return OpenCVResult(C.CudaResize(src.p, dst.p, pSize, C.double(fx), C.double(fy), C.int(interp), nil))
 }
 
 // ResizeWithStream resizes an image
@@ -85,25 +85,25 @@ func Resize(src GpuMat, dst *GpuMat, sz image.Point, fx, fy float64, interp Inte
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga4f5fa0770d1c9efbadb9be1b92a6452a
-func ResizeWithStream(src GpuMat, dst *GpuMat, sz image.Point, fx, fy float64, interp InterpolationFlags, s Stream) {
+func ResizeWithStream(src GpuMat, dst *GpuMat, sz image.Point, fx, fy float64, interp InterpolationFlags, s Stream) error {
 	pSize := C.struct_Size{
 		width:  C.int(sz.X),
 		height: C.int(sz.Y),
 	}
 
-	C.CudaResize(src.p, dst.p, pSize, C.double(fx), C.double(fy), C.int(interp), s.p)
+	return OpenCVResult(C.CudaResize(src.p, dst.p, pSize, C.double(fx), C.double(fy), C.int(interp), s.p))
 }
 
 // Rotate rotates an image around the origin (0,0) and then shifts it.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga55d958eceb0f871e04b1be0adc6ef1b5
-func Rotate(src GpuMat, dst *GpuMat, sz image.Point, angle, xShift, yShift float64, interp InterpolationFlags) {
+func Rotate(src GpuMat, dst *GpuMat, sz image.Point, angle, xShift, yShift float64, interp InterpolationFlags) error {
 	pSize := C.struct_Size{
 		width:  C.int(sz.X),
 		height: C.int(sz.Y),
 	}
-	C.CudaRotate(src.p, dst.p, pSize, C.double(angle), C.double(xShift), C.double(yShift), C.int(interp), nil)
+	return OpenCVResult(C.CudaRotate(src.p, dst.p, pSize, C.double(angle), C.double(xShift), C.double(yShift), C.int(interp), nil))
 }
 
 // RotateWithStream rotates an image around the origin (0,0) and then shifts it
@@ -111,26 +111,26 @@ func Rotate(src GpuMat, dst *GpuMat, sz image.Point, angle, xShift, yShift float
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga55d958eceb0f871e04b1be0adc6ef1b5
-func RotateWithStream(src GpuMat, dst *GpuMat, sz image.Point, angle, xShift, yShift float64, interp InterpolationFlags, s Stream) {
+func RotateWithStream(src GpuMat, dst *GpuMat, sz image.Point, angle, xShift, yShift float64, interp InterpolationFlags, s Stream) error {
 	pSize := C.struct_Size{
 		width:  C.int(sz.X),
 		height: C.int(sz.Y),
 	}
-	C.CudaRotate(src.p, dst.p, pSize, C.double(angle), C.double(xShift), C.double(yShift), C.int(interp), s.p)
+	return OpenCVResult(C.CudaRotate(src.p, dst.p, pSize, C.double(angle), C.double(xShift), C.double(yShift), C.int(interp), s.p))
 }
 
 // Remap applies a generic geometrical transformation to an image.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga0ece6c76e8efa3171adb8432d842beb0
-func Remap(src GpuMat, dst, xmap, ymap *GpuMat, interpolation InterpolationFlags, borderMode BorderType, borderValue color.RGBA) {
+func Remap(src GpuMat, dst, xmap, ymap *GpuMat, interpolation InterpolationFlags, borderMode BorderType, borderValue color.RGBA) error {
 	bv := C.struct_Scalar{
 		val1: C.double(borderValue.B),
 		val2: C.double(borderValue.G),
 		val3: C.double(borderValue.R),
 		val4: C.double(borderValue.A),
 	}
-	C.CudaRemap(src.p, dst.p, xmap.p, ymap.p, C.int(interpolation), C.int(borderMode), bv, nil)
+	return OpenCVResult(C.CudaRemap(src.p, dst.p, xmap.p, ymap.p, C.int(interpolation), C.int(borderMode), bv, nil))
 }
 
 // RemapWithStream applies a generic geometrical transformation to an image
@@ -138,22 +138,22 @@ func Remap(src GpuMat, dst, xmap, ymap *GpuMat, interpolation InterpolationFlags
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga0ece6c76e8efa3171adb8432d842beb0
-func RemapWithStream(src GpuMat, dst, xmap, ymap *GpuMat, interpolation InterpolationFlags, borderMode BorderType, borderValue color.RGBA, s Stream) {
+func RemapWithStream(src GpuMat, dst, xmap, ymap *GpuMat, interpolation InterpolationFlags, borderMode BorderType, borderValue color.RGBA, s Stream) error {
 	bv := C.struct_Scalar{
 		val1: C.double(borderValue.B),
 		val2: C.double(borderValue.G),
 		val3: C.double(borderValue.R),
 		val4: C.double(borderValue.A),
 	}
-	C.CudaRemap(src.p, dst.p, xmap.p, ymap.p, C.int(interpolation), C.int(borderMode), bv, s.p)
+	return OpenCVResult(C.CudaRemap(src.p, dst.p, xmap.p, ymap.p, C.int(interpolation), C.int(borderMode), bv, s.p))
 }
 
 // PyrDown blurs an image and downsamples it.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga9c8456de9792d96431e065f407c7a91b
-func PyrDown(src GpuMat, dst *GpuMat) {
-	C.CudaPyrDown(src.p, dst.p, nil)
+func PyrDown(src GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.CudaPyrDown(src.p, dst.p, nil))
 }
 
 // PyrDownWithStream blurs an image and downsamples it
@@ -161,16 +161,16 @@ func PyrDown(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga9c8456de9792d96431e065f407c7a91b
-func PyrDownWithStream(src GpuMat, dst *GpuMat, s Stream) {
-	C.CudaPyrDown(src.p, dst.p, s.p)
+func PyrDownWithStream(src GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.CudaPyrDown(src.p, dst.p, s.p))
 }
 
 // PyrUp upsamples an image and then blurs it.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga2048da0dfdb9e4a726232c5cef7e5747
-func PyrUp(src GpuMat, dst *GpuMat) {
-	C.CudaPyrUp(src.p, dst.p, nil)
+func PyrUp(src GpuMat, dst *GpuMat) error {
+	return OpenCVResult(C.CudaPyrUp(src.p, dst.p, nil))
 }
 
 // PyrUpWithStream upsamples an image and then blurs it
@@ -178,15 +178,15 @@ func PyrUp(src GpuMat, dst *GpuMat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga2048da0dfdb9e4a726232c5cef7e5747
-func PyrUpWithStream(src GpuMat, dst *GpuMat, s Stream) {
-	C.CudaPyrUp(src.p, dst.p, s.p)
+func PyrUpWithStream(src GpuMat, dst *GpuMat, s Stream) error {
+	return OpenCVResult(C.CudaPyrUp(src.p, dst.p, s.p))
 }
 
 // WarpPerspective applies a perspective transformation to an image.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga7a6cf95065536712de6b155f3440ccff
-func WarpPerspective(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point, flags InterpolationFlags, borderType BorderType, borderValue color.RGBA) {
+func WarpPerspective(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point, flags InterpolationFlags, borderType BorderType, borderValue color.RGBA) error {
 	pSize := C.struct_Size{
 		width:  C.int(sz.X),
 		height: C.int(sz.Y),
@@ -198,7 +198,7 @@ func WarpPerspective(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point, flags In
 		val4: C.double(borderValue.A),
 	}
 
-	C.CudaWarpPerspective(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv, nil)
+	return OpenCVResult(C.CudaWarpPerspective(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv, nil))
 }
 
 // WarpPerspectiveWithStream applies a perspective transformation to an image
@@ -206,7 +206,7 @@ func WarpPerspective(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point, flags In
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga7a6cf95065536712de6b155f3440ccff
-func WarpPerspectiveWithStream(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point, flags InterpolationFlags, borderType BorderType, borderValue color.RGBA, s Stream) {
+func WarpPerspectiveWithStream(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point, flags InterpolationFlags, borderType BorderType, borderValue color.RGBA, s Stream) error {
 	pSize := C.struct_Size{
 		width:  C.int(sz.X),
 		height: C.int(sz.Y),
@@ -218,14 +218,14 @@ func WarpPerspectiveWithStream(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point
 		val4: C.double(borderValue.A),
 	}
 
-	C.CudaWarpPerspective(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv, s.p)
+	return OpenCVResult(C.CudaWarpPerspective(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv, s.p))
 }
 
 // WarpAffine applies an affine transformation to an image. For more parameters please check WarpAffineWithParams
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga9e8dd9e73b96bdc8e27d85c0e83f1130
-func WarpAffine(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point, flags InterpolationFlags, borderType BorderType, borderValue color.RGBA) {
+func WarpAffine(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point, flags InterpolationFlags, borderType BorderType, borderValue color.RGBA) error {
 	pSize := C.struct_Size{
 		width:  C.int(sz.X),
 		height: C.int(sz.Y),
@@ -237,7 +237,7 @@ func WarpAffine(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point, flags Interpo
 		val4: C.double(borderValue.A),
 	}
 
-	C.CudaWarpAffine(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv, nil)
+	return OpenCVResult(C.CudaWarpAffine(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv, nil))
 }
 
 // WarpAffineWithStream applies an affine transformation to an image
@@ -247,7 +247,7 @@ func WarpAffine(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point, flags Interpo
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga9e8dd9e73b96bdc8e27d85c0e83f1130
-func WarpAffineWithStream(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point, flags InterpolationFlags, borderType BorderType, borderValue color.RGBA, s Stream) {
+func WarpAffineWithStream(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point, flags InterpolationFlags, borderType BorderType, borderValue color.RGBA, s Stream) error {
 	pSize := C.struct_Size{
 		width:  C.int(sz.X),
 		height: C.int(sz.Y),
@@ -259,20 +259,20 @@ func WarpAffineWithStream(src GpuMat, dst *GpuMat, m GpuMat, sz image.Point, fla
 		val4: C.double(borderValue.A),
 	}
 
-	C.CudaWarpAffine(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv, s.p)
+	return OpenCVResult(C.CudaWarpAffine(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv, s.p))
 }
 
 // BuildWarpAffineMaps builds transformation maps for affine transformation.
 //
 // For further details. please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga63504590a96e4cc702d994281d17bc1c
-func BuildWarpAffineMaps(M GpuMat, inverse bool, sz image.Point, xmap, ymap *GpuMat) {
+func BuildWarpAffineMaps(M GpuMat, inverse bool, sz image.Point, xmap, ymap *GpuMat) error {
 	pSize := C.struct_Size{
 		width:  C.int(sz.X),
 		height: C.int(sz.Y),
 	}
 
-	C.CudaBuildWarpAffineMaps(M.p, C.bool(inverse), pSize, xmap.p, ymap.p, nil)
+	return OpenCVResult(C.CudaBuildWarpAffineMaps(M.p, C.bool(inverse), pSize, xmap.p, ymap.p, nil))
 }
 
 // BuildWarpAffineMapsWithStream builds transformation maps for affine transformation
@@ -280,26 +280,26 @@ func BuildWarpAffineMaps(M GpuMat, inverse bool, sz image.Point, xmap, ymap *Gpu
 //
 // For further details. please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga63504590a96e4cc702d994281d17bc1c
-func BuildWarpAffineMapsWithStream(M GpuMat, inverse bool, sz image.Point, xmap, ymap *GpuMat, s Stream) {
+func BuildWarpAffineMapsWithStream(M GpuMat, inverse bool, sz image.Point, xmap, ymap *GpuMat, s Stream) error {
 	pSize := C.struct_Size{
 		width:  C.int(sz.X),
 		height: C.int(sz.Y),
 	}
 
-	C.CudaBuildWarpAffineMaps(M.p, C.bool(inverse), pSize, xmap.p, ymap.p, s.p)
+	return OpenCVResult(C.CudaBuildWarpAffineMaps(M.p, C.bool(inverse), pSize, xmap.p, ymap.p, s.p))
 }
 
 // BuildWarpPerspectiveMaps builds transformation maps for perspective transformation.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga8d16e3003703bd3b89cca98c913ef864
-func BuildWarpPerspectiveMaps(M GpuMat, inverse bool, sz image.Point, xmap, ymap *GpuMat) {
+func BuildWarpPerspectiveMaps(M GpuMat, inverse bool, sz image.Point, xmap, ymap *GpuMat) error {
 	pSize := C.struct_Size{
 		width:  C.int(sz.X),
 		height: C.int(sz.Y),
 	}
 
-	C.CudaBuildWarpPerspectiveMaps(M.p, C.bool(inverse), pSize, xmap.p, ymap.p, nil)
+	return OpenCVResult(C.CudaBuildWarpPerspectiveMaps(M.p, C.bool(inverse), pSize, xmap.p, ymap.p, nil))
 }
 
 // BuildWarpPerspectiveMapsWithStream builds transformation maps for perspective transformation
@@ -307,11 +307,11 @@ func BuildWarpPerspectiveMaps(M GpuMat, inverse bool, sz image.Point, xmap, ymap
 //
 // For further details, please see:
 // https://docs.opencv.org/master/db/d29/group__cudawarping.html#ga8d16e3003703bd3b89cca98c913ef864
-func BuildWarpPerspectiveMapsWithStream(M GpuMat, inverse bool, sz image.Point, xmap, ymap *GpuMat, s Stream) {
+func BuildWarpPerspectiveMapsWithStream(M GpuMat, inverse bool, sz image.Point, xmap, ymap *GpuMat, s Stream) error {
 	pSize := C.struct_Size{
 		width:  C.int(sz.X),
 		height: C.int(sz.Y),
 	}
 
-	C.CudaBuildWarpPerspectiveMaps(M.p, C.bool(inverse), pSize, xmap.p, ymap.p, s.p)
+	return OpenCVResult(C.CudaBuildWarpPerspectiveMaps(M.p, C.bool(inverse), pSize, xmap.p, ymap.p, s.p))
 }

--- a/cuda/warping.h
+++ b/cuda/warping.h
@@ -11,15 +11,15 @@ extern "C" {
 #include "../core.h"
 #include "cuda.h"
 
-void CudaResize(GpuMat src, GpuMat dst, Size dsize, double fx, double fy, int interp, Stream s);
-void CudaPyrDown(GpuMat src, GpuMat dst, Stream s);
-void CudaPyrUp(GpuMat src, GpuMat dst, Stream s);
-void CudaBuildWarpAffineMaps(GpuMat M, bool inverse, Size dsize, GpuMat xmap, GpuMat ymap, Stream s);
-void CudaBuildWarpPerspectiveMaps(GpuMat M, bool inverse, Size dsize, GpuMat xmap, GpuMat ymap, Stream s);
-void CudaRemap(GpuMat src, GpuMat dst, GpuMat xmap, GpuMat ymap, int interp, int borderMode, Scalar borderValue, Stream s);
-void CudaRotate(GpuMat src, GpuMat dst, Size dsize, double angle, double xShift, double yShift, int interp, Stream s);
-void CudaWarpAffine(GpuMat src, GpuMat dst, GpuMat M, Size dsize, int flags, int borderMode, Scalar borderValue, Stream s);
-void CudaWarpPerspective(GpuMat src, GpuMat dst, GpuMat M, Size dsize, int flags, int borderMode, Scalar borderValue, Stream s);
+OpenCVResult CudaResize(GpuMat src, GpuMat dst, Size dsize, double fx, double fy, int interp, Stream s);
+OpenCVResult CudaPyrDown(GpuMat src, GpuMat dst, Stream s);
+OpenCVResult CudaPyrUp(GpuMat src, GpuMat dst, Stream s);
+OpenCVResult CudaBuildWarpAffineMaps(GpuMat M, bool inverse, Size dsize, GpuMat xmap, GpuMat ymap, Stream s);
+OpenCVResult CudaBuildWarpPerspectiveMaps(GpuMat M, bool inverse, Size dsize, GpuMat xmap, GpuMat ymap, Stream s);
+OpenCVResult CudaRemap(GpuMat src, GpuMat dst, GpuMat xmap, GpuMat ymap, int interp, int borderMode, Scalar borderValue, Stream s);
+OpenCVResult CudaRotate(GpuMat src, GpuMat dst, Size dsize, double angle, double xShift, double yShift, int interp, Stream s);
+OpenCVResult CudaWarpAffine(GpuMat src, GpuMat dst, GpuMat M, Size dsize, int flags, int borderMode, Scalar borderValue, Stream s);
+OpenCVResult CudaWarpPerspective(GpuMat src, GpuMat dst, GpuMat M, Size dsize, int flags, int borderMode, Scalar borderValue, Stream s);
 #ifdef __cplusplus
 }
 #endif

--- a/dnn.cpp
+++ b/dnn.cpp
@@ -1,51 +1,96 @@
 #include "dnn.h"
 
 Net Net_ReadNet(const char* model, const char* config) {
-    Net n = new cv::dnn::Net(cv::dnn::readNet(model, config));
-    return n;
+    try {
+        Net n = new cv::dnn::Net(cv::dnn::readNet(model, config));
+        return n;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 Net Net_ReadNetBytes(const char* framework, struct ByteArray model, struct ByteArray config) {
-    std::vector<uchar> modelv(model.data, model.data + model.length);
-    std::vector<uchar> configv(config.data, config.data + config.length);
-    Net n = new cv::dnn::Net(cv::dnn::readNet(framework, modelv, configv));
-    return n;
+    try {
+        std::vector<uchar> modelv(model.data, model.data + model.length);
+        std::vector<uchar> configv(config.data, config.data + config.length);
+        Net n = new cv::dnn::Net(cv::dnn::readNet(framework, modelv, configv));
+        return n;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 Net Net_ReadNetFromCaffe(const char* prototxt, const char* caffeModel) {
-    Net n = new cv::dnn::Net(cv::dnn::readNetFromCaffe(prototxt, caffeModel));
-    return n;
+    try {
+        Net n = new cv::dnn::Net(cv::dnn::readNetFromCaffe(prototxt, caffeModel));
+        return n;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 Net Net_ReadNetFromCaffeBytes(struct ByteArray prototxt, struct ByteArray caffeModel) {
-    Net n = new cv::dnn::Net(cv::dnn::readNetFromCaffe(prototxt.data, prototxt.length,
-                            caffeModel.data, caffeModel.length));
-    return n;
+    try {
+        Net n = new cv::dnn::Net(cv::dnn::readNetFromCaffe(prototxt.data, prototxt.length,
+            caffeModel.data, caffeModel.length));
+        return n;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 Net Net_ReadNetFromTensorflow(const char* model) {
-    Net n = new cv::dnn::Net(cv::dnn::readNetFromTensorflow(model));
-    return n;
+    try {
+        Net n = new cv::dnn::Net(cv::dnn::readNetFromTensorflow(model));
+        return n;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 Net Net_ReadNetFromTensorflowBytes(struct ByteArray model) {
-    Net n = new cv::dnn::Net(cv::dnn::readNetFromTensorflow(model.data, model.length));
-    return n;
+    try {
+        Net n = new cv::dnn::Net(cv::dnn::readNetFromTensorflow(model.data, model.length));
+        return n;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 Net Net_ReadNetFromTorch(const char* model) {
-    Net n = new cv::dnn::Net(cv::dnn::readNetFromTorch(model));
-    return n;
+    try {
+        Net n = new cv::dnn::Net(cv::dnn::readNetFromTorch(model));
+        return n;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 Net Net_ReadNetFromONNX(const char* model) {
-    Net n = new cv::dnn::Net(cv::dnn::readNetFromONNX(model));
-    return n;
+    try {
+        Net n = new cv::dnn::Net(cv::dnn::readNetFromONNX(model));
+        return n;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 Net Net_ReadNetFromONNXBytes(struct ByteArray model) {
-    Net n = new cv::dnn::Net(cv::dnn::readNetFromONNX(model.data, model.length));
-    return n;
+    try {
+        Net n = new cv::dnn::Net(cv::dnn::readNetFromONNX(model.data, model.length));
+        return n;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void Net_Close(Net net) {
@@ -53,190 +98,258 @@ void Net_Close(Net net) {
 }
 
 bool Net_Empty(Net net) {
-    return net->empty();
+    try {
+        return net->empty();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 void Net_SetInput(Net net, Mat blob, const char* name) {
-    net->setInput(*blob, name);
+    try {
+        net->setInput(*blob, name);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 Mat Net_Forward(Net net, const char* outputName) {
-    return new cv::Mat(net->forward(outputName));
+    try {
+        return new cv::Mat(net->forward(outputName));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 void Net_ForwardLayers(Net net, struct Mats* outputBlobs, struct CStrings outBlobNames) {
-    std::vector< cv::Mat > blobs;
+    try {
+        std::vector< cv::Mat > blobs;
 
-    std::vector< cv::String > names;
-    for (int i = 0; i < outBlobNames.length; ++i) {
-        names.push_back(cv::String(outBlobNames.strs[i]));
+        std::vector< cv::String > names;
+        for (int i = 0; i < outBlobNames.length; ++i) {
+            names.push_back(cv::String(outBlobNames.strs[i]));
+        }
+        net->forward(blobs, names);
+    
+        // copy blobs into outputBlobs
+        outputBlobs->mats = new Mat[blobs.size()];
+    
+        for (size_t i = 0; i < blobs.size(); ++i) {
+            outputBlobs->mats[i] = new cv::Mat(blobs[i]);
+        }
+    
+        outputBlobs->length = (int)blobs.size();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    net->forward(blobs, names);
-
-    // copy blobs into outputBlobs
-    outputBlobs->mats = new Mat[blobs.size()];
-
-    for (size_t i = 0; i < blobs.size(); ++i) {
-        outputBlobs->mats[i] = new cv::Mat(blobs[i]);
-    }
-
-    outputBlobs->length = (int)blobs.size();
 }
 
 void Net_SetPreferableBackend(Net net, int backend) {
-    net->setPreferableBackend(backend);
+    try {
+        net->setPreferableBackend(backend);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Net_SetPreferableTarget(Net net, int target) {
-    net->setPreferableTarget(target);
+    try {
+        net->setPreferableTarget(target);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 int64_t Net_GetPerfProfile(Net net) {
-    std::vector<double> layersTimes;
-    return net->getPerfProfile(layersTimes);
+    try {
+        std::vector<double> layersTimes;
+        return net->getPerfProfile(layersTimes);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 void Net_GetUnconnectedOutLayers(Net net, IntVector* res) {
-    std::vector< int > cids(net->getUnconnectedOutLayers());
-    int* ids = new int[cids.size()];
+    try {
+        std::vector< int > cids(net->getUnconnectedOutLayers());
+        int* ids = new int[cids.size()];
+        
+        for (size_t i = 0; i < cids.size(); ++i) {
+            ids[i] = cids[i];
+        }
     
-    for (size_t i = 0; i < cids.size(); ++i) {
-        ids[i] = cids[i];
+        res->length = cids.size();
+        res->val = ids;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    res->length = cids.size();
-    res->val = ids;
-    return;
 }
 
 void Net_GetLayerNames(Net net, CStrings* names) {
-    std::vector< cv::String > cstrs(net->getLayerNames());
-    const char **strs = new const char*[cstrs.size()];
-
-    for (size_t i = 0; i < cstrs.size(); ++i) {
-        strs[i] = cstrs[i].c_str();
+    try {
+        std::vector< cv::String > cstrs(net->getLayerNames());
+        const char **strs = new const char*[cstrs.size()];
+    
+        for (size_t i = 0; i < cstrs.size(); ++i) {
+            strs[i] = cstrs[i].c_str();
+        }
+    
+        names->length = cstrs.size();
+        names->strs = strs;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    names->length = cstrs.size();
-    names->strs = strs;
-    return;
 }
 
 struct Rect Net_BlobRectToImageRect(struct Rect rect, Size originalSize, double scalefactor, Size size, Scalar mean, bool swapRB,
                     int ddepth, int dataLayout, int paddingMode, Scalar borderValue) {
-
-    cv::Scalar sf(scalefactor);
-    cv::Size sz(size.width, size.height);
-    cv::Scalar cm(mean.val1, mean.val2, mean.val3, mean.val4);
-    cv::dnn::DataLayout dl = static_cast<cv::dnn::DataLayout>(dataLayout);
-    cv::dnn::ImagePaddingMode pm = static_cast<cv::dnn::ImagePaddingMode>(paddingMode);
-    cv::Scalar bv(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
-    cv::dnn::Image2BlobParams params = cv::dnn::Image2BlobParams(sf, sz, cm, swapRB, ddepth, dl, pm, bv);
-
-    cv::Rect bRect = params.blobRectToImageRect(cv::Rect(rect.x, rect.y, rect.width, rect.height), cv::Size(originalSize.width, originalSize.height));
-    Rect r = {bRect.x, bRect.y, bRect.width, bRect.height};
-    return r;
+    try {
+        cv::Scalar sf(scalefactor);
+        cv::Size sz(size.width, size.height);
+        cv::Scalar cm(mean.val1, mean.val2, mean.val3, mean.val4);
+        cv::dnn::DataLayout dl = static_cast<cv::dnn::DataLayout>(dataLayout);
+        cv::dnn::ImagePaddingMode pm = static_cast<cv::dnn::ImagePaddingMode>(paddingMode);
+        cv::Scalar bv(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
+        cv::dnn::Image2BlobParams params = cv::dnn::Image2BlobParams(sf, sz, cm, swapRB, ddepth, dl, pm, bv);
+    
+        cv::Rect bRect = params.blobRectToImageRect(cv::Rect(rect.x, rect.y, rect.width, rect.height), cv::Size(originalSize.width, originalSize.height));
+        Rect r = {bRect.x, bRect.y, bRect.width, bRect.height};
+        return r;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Rect r = {0, 0, 0, 0};
+        return r;
+    }
 }
 
 struct Rects Net_BlobRectsToImageRects(struct Rects rects, Size originalSize, double scalefactor, Size size, Scalar mean, bool swapRB,
                     int ddepth, int dataLayout, int paddingMode, Scalar borderValue) {
-
-    std::vector<cv::Rect> _cRects;
-    for (int i = 0; i < rects.length; ++i) {
-        _cRects.push_back(cv::Rect(
-            rects.rects[i].x,
-            rects.rects[i].y,
-            rects.rects[i].width,
-            rects.rects[i].height
-        ));
+    try {
+        std::vector<cv::Rect> _cRects;
+        for (int i = 0; i < rects.length; ++i) {
+            _cRects.push_back(cv::Rect(
+                rects.rects[i].x,
+                rects.rects[i].y,
+                rects.rects[i].width,
+                rects.rects[i].height
+            ));
+        }
+    
+        cv::Scalar sf(scalefactor);
+        cv::Size sz(size.width, size.height);
+        cv::Scalar cm(mean.val1, mean.val2, mean.val3, mean.val4);
+        cv::dnn::DataLayout dl = static_cast<cv::dnn::DataLayout>(dataLayout);
+        cv::dnn::ImagePaddingMode pm = static_cast<cv::dnn::ImagePaddingMode>(paddingMode);
+        cv::Scalar bv(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
+        cv::dnn::Image2BlobParams params = cv::dnn::Image2BlobParams(sf, sz, cm, swapRB, ddepth, dl, pm, bv);
+    
+        std::vector<cv::Rect> detected;
+        params.blobRectsToImageRects(_cRects, detected, cv::Size(originalSize.width, originalSize.height));
+        Rect* drects = new Rect[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            Rect r = {detected[i].x, detected[i].y, detected[i].width, detected[i].height};
+            drects[i] = r;
+        }
+    
+        Rects ret = {drects, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Rects ret = {NULL, 0};
+        return ret;
     }
-
-    cv::Scalar sf(scalefactor);
-    cv::Size sz(size.width, size.height);
-    cv::Scalar cm(mean.val1, mean.val2, mean.val3, mean.val4);
-    cv::dnn::DataLayout dl = static_cast<cv::dnn::DataLayout>(dataLayout);
-    cv::dnn::ImagePaddingMode pm = static_cast<cv::dnn::ImagePaddingMode>(paddingMode);
-    cv::Scalar bv(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
-    cv::dnn::Image2BlobParams params = cv::dnn::Image2BlobParams(sf, sz, cm, swapRB, ddepth, dl, pm, bv);
-
-    std::vector<cv::Rect> detected;
-    params.blobRectsToImageRects(_cRects, detected, cv::Size(originalSize.width, originalSize.height));
-    Rect* drects = new Rect[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        Rect r = {detected[i].x, detected[i].y, detected[i].width, detected[i].height};
-        drects[i] = r;
-    }
-
-    Rects ret = {drects, (int)detected.size()};
-    return ret;
 }
 
 Mat Net_BlobFromImage(Mat image, double scalefactor, Size size, Scalar mean, bool swapRB,
                       bool crop) {
-    cv::Size sz(size.width, size.height);
-    cv::Scalar cm(mean.val1, mean.val2, mean.val3, mean.val4);
-    // use the default target ddepth here.
-    return new cv::Mat(cv::dnn::blobFromImage(*image, scalefactor, sz, cm, swapRB, crop));
+    try {
+        cv::Size sz(size.width, size.height);
+        cv::Scalar cm(mean.val1, mean.val2, mean.val3, mean.val4);
+        // use the default target ddepth here.
+        return new cv::Mat(cv::dnn::blobFromImage(*image, scalefactor, sz, cm, swapRB, crop));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 Mat Net_BlobFromImageWithParams(Mat image, double scalefactor, Size size, Scalar mean, bool swapRB,
                       int ddepth, int dataLayout, int paddingMode, Scalar borderValue) {
-
-    cv::Scalar sf(scalefactor);
-    cv::Size sz(size.width, size.height);
-    cv::Scalar cm(mean.val1, mean.val2, mean.val3, mean.val4);
-    cv::dnn::DataLayout dl = static_cast<cv::dnn::DataLayout>(dataLayout);
-    cv::dnn::ImagePaddingMode pm = static_cast<cv::dnn::ImagePaddingMode>(paddingMode);
-    cv::Scalar bv(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
-    cv::dnn::Image2BlobParams params = cv::dnn::Image2BlobParams(sf, sz, cm, swapRB, ddepth, dl, pm, bv);
-
-    return new cv::Mat(cv::dnn::blobFromImageWithParams(*image, params));
+    try {
+        cv::Scalar sf(scalefactor);
+        cv::Size sz(size.width, size.height);
+        cv::Scalar cm(mean.val1, mean.val2, mean.val3, mean.val4);
+        cv::dnn::DataLayout dl = static_cast<cv::dnn::DataLayout>(dataLayout);
+        cv::dnn::ImagePaddingMode pm = static_cast<cv::dnn::ImagePaddingMode>(paddingMode);
+        cv::Scalar bv(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
+        cv::dnn::Image2BlobParams params = cv::dnn::Image2BlobParams(sf, sz, cm, swapRB, ddepth, dl, pm, bv);
+    
+        return new cv::Mat(cv::dnn::blobFromImageWithParams(*image, params));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 void Net_BlobFromImages(struct Mats images, Mat blob, double scalefactor, Size size,
                        Scalar mean, bool swapRB, bool crop, int ddepth) {
-    std::vector<cv::Mat> imgs;
+    try {
+        std::vector<cv::Mat> imgs;
     
-    for (int i = 0; i < images.length; ++i) {
-        imgs.push_back(*images.mats[i]);
+        for (int i = 0; i < images.length; ++i) {
+            imgs.push_back(*images.mats[i]);
+        }
+    
+        cv::Size sz(size.width, size.height);
+        cv::Scalar cm = cv::Scalar(mean.val1, mean.val2, mean.val3, mean.val4);
+    
+        // ignore the passed in ddepth, just use default.
+        cv::dnn::blobFromImages(imgs, *blob, scalefactor, sz, cm, swapRB, crop);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    cv::Size sz(size.width, size.height);
-    cv::Scalar cm = cv::Scalar(mean.val1, mean.val2, mean.val3, mean.val4);
-
-    // ignore the passed in ddepth, just use default.
-    cv::dnn::blobFromImages(imgs, *blob, scalefactor, sz, cm, swapRB, crop);
 }
 
 void Net_BlobFromImagesWithParams(struct Mats images, Mat blob, double scalefactor, Size size,
                        Scalar mean, bool swapRB, int ddepth, int dataLayout, int paddingMode, Scalar borderValue) {
-    std::vector<cv::Mat> imgs;
+    try {
+        std::vector<cv::Mat> imgs;
     
-    for (int i = 0; i < images.length; ++i) {
-        imgs.push_back(*images.mats[i]);
+        for (int i = 0; i < images.length; ++i) {
+            imgs.push_back(*images.mats[i]);
+        }
+    
+        cv::Scalar sf(scalefactor);
+        cv::Size sz(size.width, size.height);
+        cv::Scalar cm(mean.val1, mean.val2, mean.val3, mean.val4);
+        cv::dnn::DataLayout dl = static_cast<cv::dnn::DataLayout>(dataLayout);
+        cv::dnn::ImagePaddingMode pm = static_cast<cv::dnn::ImagePaddingMode>(paddingMode);
+        cv::Scalar bv(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
+        cv::dnn::Image2BlobParams params = cv::dnn::Image2BlobParams(sf, sz, cm, swapRB, ddepth, dl, pm, bv);
+    
+        cv::dnn::blobFromImagesWithParams(imgs, *blob, params);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    cv::Scalar sf(scalefactor);
-    cv::Size sz(size.width, size.height);
-    cv::Scalar cm(mean.val1, mean.val2, mean.val3, mean.val4);
-   cv::dnn::DataLayout dl = static_cast<cv::dnn::DataLayout>(dataLayout);
-    cv::dnn::ImagePaddingMode pm = static_cast<cv::dnn::ImagePaddingMode>(paddingMode);
-    cv::Scalar bv(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
-    cv::dnn::Image2BlobParams params = cv::dnn::Image2BlobParams(sf, sz, cm, swapRB, ddepth, dl, pm, bv);
-
-    cv::dnn::blobFromImagesWithParams(imgs, *blob, params);
 }
 
 void Net_ImagesFromBlob(Mat blob_, struct Mats* images_) {
-    std::vector<cv::Mat> imgs;
-    cv::dnn::imagesFromBlob(*blob_, imgs);
-    images_->mats = new Mat[imgs.size()];
-
-    for (size_t i = 0; i < imgs.size(); ++i) {
-        images_->mats[i] = new cv::Mat(imgs[i]);
+    try {
+        std::vector<cv::Mat> imgs;
+        cv::dnn::imagesFromBlob(*blob_, imgs);
+        images_->mats = new Mat[imgs.size()];
+    
+        for (size_t i = 0; i < imgs.size(); ++i) {
+            images_->mats[i] = new cv::Mat(imgs[i]);
+        }
+        images_->length = (int) imgs.size();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    images_->length = (int) imgs.size();
 }
 
 Mat Net_GetBlobChannel(Mat blob, int imgidx, int chnidx) {
@@ -255,7 +368,12 @@ Scalar Net_GetBlobSize(Mat blob) {
 }
 
 Layer Net_GetLayer(Net net, int layerid) {
-    return new cv::Ptr<cv::dnn::Layer>(net->getLayer(layerid));
+    try {
+        return new cv::Ptr<cv::dnn::Layer>(net->getLayer(layerid));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void Layer_Close(Layer layer) {
@@ -263,87 +381,113 @@ void Layer_Close(Layer layer) {
 }
 
 int Layer_InputNameToIndex(Layer layer, const char* name) {
-    return (*layer)->inputNameToIndex(name);
+    try {
+        return (*layer)->inputNameToIndex(name);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return -1;
+    }
 }
 
 int Layer_OutputNameToIndex(Layer layer, const char* name) {
-    return (*layer)->outputNameToIndex(name);
+    try {
+        return (*layer)->outputNameToIndex(name);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return -1;
+    }
 }
 
 const char* Layer_GetName(Layer layer) {
-    return (*layer)->name.c_str();
+    try {
+        return (*layer)->name.c_str();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return "";
+    }
 }
 
 const char* Layer_GetType(Layer layer) {
-    return (*layer)->type.c_str();
+    try {
+        return (*layer)->type.c_str();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return "";
+    }
 }
 
 void NMSBoxes(struct Rects bboxes, FloatVector scores, float score_threshold, float nms_threshold, IntVector* indices) {
-    std::vector<cv::Rect> _bboxes;
+    try {
+        std::vector<cv::Rect> _bboxes;
 
-    for (int i = 0; i < bboxes.length; ++i) {
-        _bboxes.push_back(cv::Rect(
-            bboxes.rects[i].x,
-            bboxes.rects[i].y,
-            bboxes.rects[i].width,
-            bboxes.rects[i].height
-        ));
+        for (int i = 0; i < bboxes.length; ++i) {
+            _bboxes.push_back(cv::Rect(
+                bboxes.rects[i].x,
+                bboxes.rects[i].y,
+                bboxes.rects[i].width,
+                bboxes.rects[i].height
+            ));
+        }
+    
+        std::vector<float> _scores;
+    
+        float* f;
+        int i;
+        for (i = 0, f = scores.val; i < scores.length; ++f, ++i) {
+            _scores.push_back(*f);
+        }
+    
+        std::vector<int> _indices(indices->length);
+    
+        cv::dnn::NMSBoxes(_bboxes, _scores, score_threshold, nms_threshold, _indices, 1.f, 0);
+    
+        int* ptr = new int[_indices.size()];
+    
+        for (size_t i=0; i<_indices.size(); ++i) {
+            ptr[i] = _indices[i];
+        }
+    
+        indices->length = _indices.size();
+        indices->val = ptr;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    std::vector<float> _scores;
-
-    float* f;
-    int i;
-    for (i = 0, f = scores.val; i < scores.length; ++f, ++i) {
-        _scores.push_back(*f);
-    }
-
-    std::vector<int> _indices(indices->length);
-
-    cv::dnn::NMSBoxes(_bboxes, _scores, score_threshold, nms_threshold, _indices, 1.f, 0);
-
-    int* ptr = new int[_indices.size()];
-
-    for (size_t i=0; i<_indices.size(); ++i) {
-        ptr[i] = _indices[i];
-    }
-
-    indices->length = _indices.size();
-    indices->val = ptr;
-    return;
 }
 
 void NMSBoxesWithParams(struct Rects bboxes, FloatVector scores, const float score_threshold, const float nms_threshold, IntVector* indices, const float eta, const int top_k) {
-    std::vector<cv::Rect> _bboxes;
+    try {
+        std::vector<cv::Rect> _bboxes;
 
-    for (int i = 0; i < bboxes.length; ++i) {
-        _bboxes.push_back(cv::Rect(
-            bboxes.rects[i].x,
-            bboxes.rects[i].y,
-            bboxes.rects[i].width,
-            bboxes.rects[i].height
-        ));
+        for (int i = 0; i < bboxes.length; ++i) {
+            _bboxes.push_back(cv::Rect(
+                bboxes.rects[i].x,
+                bboxes.rects[i].y,
+                bboxes.rects[i].width,
+                bboxes.rects[i].height
+            ));
+        }
+    
+        std::vector<float> _scores;
+    
+        float* f;
+        int i;
+        for (i = 0, f = scores.val; i < scores.length; ++f, ++i) {
+            _scores.push_back(*f);
+        }
+    
+        std::vector<int> _indices(indices->length);
+    
+        cv::dnn::NMSBoxes(_bboxes, _scores, score_threshold, nms_threshold, _indices, eta, top_k);
+    
+        int* ptr = new int[_indices.size()];
+    
+        for (size_t i=0; i<_indices.size(); ++i) {
+            ptr[i] = _indices[i];
+        }
+    
+        indices->length = _indices.size();
+        indices->val = ptr;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    std::vector<float> _scores;
-
-    float* f;
-    int i;
-    for (i = 0, f = scores.val; i < scores.length; ++f, ++i) {
-        _scores.push_back(*f);
-    }
-
-    std::vector<int> _indices(indices->length);
-
-    cv::dnn::NMSBoxes(_bboxes, _scores, score_threshold, nms_threshold, _indices, eta, top_k);
-
-    int* ptr = new int[_indices.size()];
-
-    for (size_t i=0; i<_indices.size(); ++i) {
-        ptr[i] = _indices[i];
-    }
-
-    indices->length = _indices.size();
-    indices->val = ptr;
-    return;
 }

--- a/features2d.cpp
+++ b/features2d.cpp
@@ -1,13 +1,23 @@
 #include "features2d.h"
 
 AKAZE AKAZE_Create() {
-    return new cv::Ptr<cv::AKAZE>(cv::AKAZE::create());
+    try {
+        return new cv::Ptr<cv::AKAZE>(cv::AKAZE::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 AKAZE AKAZE_CreateWithParams(int descriptor_type, int descriptor_size, int descriptor_channels,
                              float threshold, int nOctaves, int nOctaveLayers, int diffusivity) {
-    cv::AKAZE::DescriptorType type = static_cast<cv::AKAZE::DescriptorType>(descriptor_type);
+    try {
+        cv::AKAZE::DescriptorType type = static_cast<cv::AKAZE::DescriptorType>(descriptor_type);
 
-    return new cv::Ptr<cv::AKAZE>(cv::AKAZE::create(type, descriptor_size, descriptor_channels,threshold, nOctaves, nOctaveLayers, static_cast<cv::KAZE::DiffusivityType>(diffusivity)));
+        return new cv::Ptr<cv::AKAZE>(cv::AKAZE::create(type, descriptor_size, descriptor_channels,threshold, nOctaves, nOctaveLayers, static_cast<cv::KAZE::DiffusivityType>(diffusivity)));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 
@@ -16,102 +26,147 @@ void AKAZE_Close(AKAZE a) {
 }
 
 struct KeyPoints AKAZE_Detect(AKAZE a, Mat src) {
-    std::vector<cv::KeyPoint> detected;
-    (*a)->detect(*src, detected);
-
-    KeyPoint* kps = new KeyPoint[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
-                      detected[i].response, detected[i].octave, detected[i].class_id
-                     };
-        kps[i] = k;
+    try {
+        std::vector<cv::KeyPoint> detected;
+        (*a)->detect(*src, detected);
+    
+        KeyPoint* kps = new KeyPoint[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
+                          detected[i].response, detected[i].octave, detected[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    KeyPoints ret = {kps, (int)detected.size()};
-    return ret;
 }
 
 struct KeyPoints AKAZE_Compute(AKAZE a, Mat src, struct KeyPoints kp, Mat desc) {
-    std::vector<cv::KeyPoint> computed;
-    for (size_t i = 0; i < kp.length; i++) {
-        cv::KeyPoint k = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
-            kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
-            kp.keypoints[i].octave, kp.keypoints[i].classID);
-        computed.push_back(k);
+    try {
+        std::vector<cv::KeyPoint> computed;
+        for (size_t i = 0; i < kp.length; i++) {
+            cv::KeyPoint k = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
+                kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
+                kp.keypoints[i].octave, kp.keypoints[i].classID);
+            computed.push_back(k);
+        }
+    
+        (*a)->compute(*src, computed, *desc);
+    
+        KeyPoint* kps = new KeyPoint[computed.size()];
+    
+        for (size_t i = 0; i < computed.size(); ++i) {
+            KeyPoint k = {computed[i].pt.x, computed[i].pt.y, computed[i].size, computed[i].angle,
+                          computed[i].response, computed[i].octave, computed[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)computed.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    (*a)->compute(*src, computed, *desc);
-
-    KeyPoint* kps = new KeyPoint[computed.size()];
-
-    for (size_t i = 0; i < computed.size(); ++i) {
-        KeyPoint k = {computed[i].pt.x, computed[i].pt.y, computed[i].size, computed[i].angle,
-                      computed[i].response, computed[i].octave, computed[i].class_id
-                     };
-        kps[i] = k;
-    }
-
-    KeyPoints ret = {kps, (int)computed.size()};
-    return ret;
 }
 
 struct KeyPoints AKAZE_DetectAndCompute(AKAZE a, Mat src, Mat mask, Mat desc) {
-    std::vector<cv::KeyPoint> detected;
-    (*a)->detectAndCompute(*src, *mask, detected, *desc);
-
-    KeyPoint* kps = new KeyPoint[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
-                      detected[i].response, detected[i].octave, detected[i].class_id
-                     };
-        kps[i] = k;
+    try {
+        std::vector<cv::KeyPoint> detected;
+        (*a)->detectAndCompute(*src, *mask, detected, *desc);
+    
+        KeyPoint* kps = new KeyPoint[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
+                          detected[i].response, detected[i].octave, detected[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    KeyPoints ret = {kps, (int)detected.size()};
-    return ret;
 }
 
 AgastFeatureDetector AgastFeatureDetector_Create() {
-    return new cv::Ptr<cv::AgastFeatureDetector>(cv::AgastFeatureDetector::create());
+    try {
+        return new cv::Ptr<cv::AgastFeatureDetector>(cv::AgastFeatureDetector::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 AgastFeatureDetector AgastFeatureDetector_CreateWithParams(int threshold, bool nonmaxSuppression, int type) {
-    cv::AgastFeatureDetector::DetectorType detectorType = static_cast<cv::AgastFeatureDetector::DetectorType>(type);
-    return new cv::Ptr<cv::AgastFeatureDetector>(cv::AgastFeatureDetector::create(threshold, nonmaxSuppression, detectorType));
+    try {
+        cv::AgastFeatureDetector::DetectorType detectorType = static_cast<cv::AgastFeatureDetector::DetectorType>(type);
+        return new cv::Ptr<cv::AgastFeatureDetector>(cv::AgastFeatureDetector::create(threshold, nonmaxSuppression, detectorType));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
-
-
-
 
 void AgastFeatureDetector_Close(AgastFeatureDetector a) {
     delete a;
 }
 
 struct KeyPoints AgastFeatureDetector_Detect(AgastFeatureDetector a, Mat src) {
-    std::vector<cv::KeyPoint> detected;
-    (*a)->detect(*src, detected);
-
-    KeyPoint* kps = new KeyPoint[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
-                      detected[i].response, detected[i].octave, detected[i].class_id
-                     };
-        kps[i] = k;
+    try {
+        std::vector<cv::KeyPoint> detected;
+        (*a)->detect(*src, detected);
+    
+        KeyPoint* kps = new KeyPoint[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
+                          detected[i].response, detected[i].octave, detected[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    KeyPoints ret = {kps, (int)detected.size()};
-    return ret;
 }
 
 BRISK BRISK_Create() {
-    return new cv::Ptr<cv::BRISK>(cv::BRISK::create());
+    try {
+        return new cv::Ptr<cv::BRISK>(cv::BRISK::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 BRISK BRISK_CreateWithParams(int thresh, int octaves, float patternScale) {
-    return new cv::Ptr<cv::BRISK>(cv::BRISK::create(thresh, octaves, patternScale));
+    try {
+        return new cv::Ptr<cv::BRISK>(cv::BRISK::create(thresh, octaves, patternScale));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void BRISK_Close(BRISK b) {
@@ -119,71 +174,102 @@ void BRISK_Close(BRISK b) {
 }
 
 struct KeyPoints BRISK_Detect(BRISK b, Mat src) {
-    std::vector<cv::KeyPoint> detected;
-    (*b)->detect(*src, detected);
-
-    KeyPoint* kps = new KeyPoint[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
-                      detected[i].response, detected[i].octave, detected[i].class_id
-                     };
-        kps[i] = k;
+    try {
+        std::vector<cv::KeyPoint> detected;
+        (*b)->detect(*src, detected);
+    
+        KeyPoint* kps = new KeyPoint[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
+                          detected[i].response, detected[i].octave, detected[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    KeyPoints ret = {kps, (int)detected.size()};
-    return ret;
 }
 
 struct KeyPoints BRISK_Compute(BRISK b, Mat src, struct KeyPoints kp, Mat desc) {
-    std::vector<cv::KeyPoint> computed;
-    for (size_t i = 0; i < kp.length; i++) {
-        cv::KeyPoint k = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
-            kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
-            kp.keypoints[i].octave, kp.keypoints[i].classID);
-        computed.push_back(k);
+    try {
+        std::vector<cv::KeyPoint> computed;
+        for (size_t i = 0; i < kp.length; i++) {
+            cv::KeyPoint k = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
+                kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
+                kp.keypoints[i].octave, kp.keypoints[i].classID);
+            computed.push_back(k);
+        }
+    
+        (*b)->compute(*src, computed, *desc);
+    
+        KeyPoint* kps = new KeyPoint[computed.size()];
+    
+        for (size_t i = 0; i < computed.size(); ++i) {
+            KeyPoint k = {computed[i].pt.x, computed[i].pt.y, computed[i].size, computed[i].angle,
+                          computed[i].response, computed[i].octave, computed[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)computed.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    (*b)->compute(*src, computed, *desc);
-
-    KeyPoint* kps = new KeyPoint[computed.size()];
-
-    for (size_t i = 0; i < computed.size(); ++i) {
-        KeyPoint k = {computed[i].pt.x, computed[i].pt.y, computed[i].size, computed[i].angle,
-                      computed[i].response, computed[i].octave, computed[i].class_id
-                     };
-        kps[i] = k;
-    }
-
-    KeyPoints ret = {kps, (int)computed.size()};
-    return ret;
 }
 
 struct KeyPoints BRISK_DetectAndCompute(BRISK b, Mat src, Mat mask, Mat desc) {
-    std::vector<cv::KeyPoint> detected;
-    (*b)->detectAndCompute(*src, *mask, detected, *desc);
-
-    KeyPoint* kps = new KeyPoint[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
-                      detected[i].response, detected[i].octave, detected[i].class_id
-                     };
-        kps[i] = k;
+    try {
+        std::vector<cv::KeyPoint> detected;
+        (*b)->detectAndCompute(*src, *mask, detected, *desc);
+    
+        KeyPoint* kps = new KeyPoint[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
+                          detected[i].response, detected[i].octave, detected[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)detected.size()};
+        return ret;    
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    KeyPoints ret = {kps, (int)detected.size()};
-    return ret;
 }
 
 GFTTDetector GFTTDetector_Create() {
-    return new cv::Ptr<cv::GFTTDetector>(cv::GFTTDetector::create());
+    try {
+        return new cv::Ptr<cv::GFTTDetector>(cv::GFTTDetector::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 GFTTDetector GFTTDetector_Create_WithParams(const GFTTDetectorParams* params) {
-    // Create the GFTTDetector and return it wrapped in a smart pointer
-    return new cv::Ptr<cv::GFTTDetector>(cv::GFTTDetector::create(params->maxCorners, params->qualityLevel, params->minDistance,
-                                                                 params->blockSize, params->useHarrisDetector, params->k));
+    try {
+        // Create the GFTTDetector and return it wrapped in a smart pointer
+        return new cv::Ptr<cv::GFTTDetector>(cv::GFTTDetector::create(params->maxCorners, params->qualityLevel, params->minDistance,
+            params->blockSize, params->useHarrisDetector, params->k));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 
@@ -193,28 +279,45 @@ void GFTTDetector_Close(GFTTDetector a) {
 }
 
 struct KeyPoints GFTTDetector_Detect(GFTTDetector a, Mat src) {
-    std::vector<cv::KeyPoint> detected;
-    (*a)->detect(*src, detected);
-
-    KeyPoint* kps = new KeyPoint[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
-                      detected[i].response, detected[i].octave, detected[i].class_id
-                     };
-        kps[i] = k;
+    try {
+        std::vector<cv::KeyPoint> detected;
+        (*a)->detect(*src, detected);
+    
+        KeyPoint* kps = new KeyPoint[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
+                          detected[i].response, detected[i].octave, detected[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    KeyPoints ret = {kps, (int)detected.size()};
-    return ret;
 }
 
 KAZE KAZE_Create() {
-    return new cv::Ptr<cv::KAZE>(cv::KAZE::create());
+    try {
+        return new cv::Ptr<cv::KAZE>(cv::KAZE::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 KAZE KAZE_CreateWithParams(bool extended, bool upright, float threshold, int nOctaves, int nOctaveLayers, int diffusivity) {
-    return new cv::Ptr<cv::KAZE>(cv::KAZE::create(extended, upright, threshold, nOctaves, nOctaveLayers, static_cast<cv::KAZE::DiffusivityType>(diffusivity)));
+    try {
+        return new cv::Ptr<cv::KAZE>(cv::KAZE::create(extended, upright, threshold, nOctaves, nOctaveLayers, static_cast<cv::KAZE::DiffusivityType>(diffusivity)));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void KAZE_Close(KAZE a) {
@@ -222,71 +325,102 @@ void KAZE_Close(KAZE a) {
 }
 
 struct KeyPoints KAZE_Detect(KAZE a, Mat src) {
-    std::vector<cv::KeyPoint> detected;
-    (*a)->detect(*src, detected);
-
-    KeyPoint* kps = new KeyPoint[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
-                      detected[i].response, detected[i].octave, detected[i].class_id
-                     };
-        kps[i] = k;
+    try {
+        std::vector<cv::KeyPoint> detected;
+        (*a)->detect(*src, detected);
+    
+        KeyPoint* kps = new KeyPoint[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
+                          detected[i].response, detected[i].octave, detected[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    KeyPoints ret = {kps, (int)detected.size()};
-    return ret;
 }
 
 struct KeyPoints KAZE_Compute(KAZE a, Mat src, struct KeyPoints kp, Mat desc) {
-    std::vector<cv::KeyPoint> computed;
-    for (size_t i = 0; i < kp.length; i++) {
-        cv::KeyPoint k = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
-            kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
-            kp.keypoints[i].octave, kp.keypoints[i].classID);
-        computed.push_back(k);
+    try {
+        std::vector<cv::KeyPoint> computed;
+        for (size_t i = 0; i < kp.length; i++) {
+            cv::KeyPoint k = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
+                kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
+                kp.keypoints[i].octave, kp.keypoints[i].classID);
+            computed.push_back(k);
+        }
+    
+        (*a)->compute(*src, computed, *desc);
+    
+        KeyPoint* kps = new KeyPoint[computed.size()];
+    
+        for (size_t i = 0; i < computed.size(); ++i) {
+            KeyPoint k = {computed[i].pt.x, computed[i].pt.y, computed[i].size, computed[i].angle,
+                          computed[i].response, computed[i].octave, computed[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)computed.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    (*a)->compute(*src, computed, *desc);
-
-    KeyPoint* kps = new KeyPoint[computed.size()];
-
-    for (size_t i = 0; i < computed.size(); ++i) {
-        KeyPoint k = {computed[i].pt.x, computed[i].pt.y, computed[i].size, computed[i].angle,
-                      computed[i].response, computed[i].octave, computed[i].class_id
-                     };
-        kps[i] = k;
-    }
-
-    KeyPoints ret = {kps, (int)computed.size()};
-    return ret;
 }
 
 struct KeyPoints KAZE_DetectAndCompute(KAZE a, Mat src, Mat mask, Mat desc) {
-    std::vector<cv::KeyPoint> detected;
-    (*a)->detectAndCompute(*src, *mask, detected, *desc);
-
-    KeyPoint* kps = new KeyPoint[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
-                      detected[i].response, detected[i].octave, detected[i].class_id
-                     };
-        kps[i] = k;
+    try {
+        std::vector<cv::KeyPoint> detected;
+        (*a)->detectAndCompute(*src, *mask, detected, *desc);
+    
+        KeyPoint* kps = new KeyPoint[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
+                          detected[i].response, detected[i].octave, detected[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    KeyPoints ret = {kps, (int)detected.size()};
-    return ret;
 }
 
 MSER MSER_Create() {
-    return new cv::Ptr<cv::MSER>(cv::MSER::create());
+    try {
+        return new cv::Ptr<cv::MSER>(cv::MSER::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 MSER MSER_CreateWithParams(int delta, int min_area, int max_area, double max_variation, double min_diversity,
                  int max_evolution, double area_threshold, double min_margin, int edge_blur_size) {
-    return new cv::Ptr<cv::MSER>(cv::MSER::create(delta, min_area, max_area, max_variation, min_diversity,
-                                                   max_evolution, area_threshold, min_margin, edge_blur_size));
+    try {
+        return new cv::Ptr<cv::MSER>(cv::MSER::create(delta, min_area, max_area, max_variation, min_diversity,
+            max_evolution, area_threshold, min_margin, edge_blur_size));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }                
 }
 
 void MSER_Close(MSER a) {
@@ -294,24 +428,36 @@ void MSER_Close(MSER a) {
 }
 
 struct KeyPoints MSER_Detect(MSER a, Mat src) {
-    std::vector<cv::KeyPoint> detected;
-    (*a)->detect(*src, detected);
-
-    KeyPoint* kps = new KeyPoint[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
-                      detected[i].response, detected[i].octave, detected[i].class_id
-                     };
-        kps[i] = k;
+    try {
+        std::vector<cv::KeyPoint> detected;
+        (*a)->detect(*src, detected);
+    
+        KeyPoint* kps = new KeyPoint[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
+                          detected[i].response, detected[i].octave, detected[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    KeyPoints ret = {kps, (int)detected.size()};
-    return ret;
 }
 
 FastFeatureDetector FastFeatureDetector_Create() {
-    return new cv::Ptr<cv::FastFeatureDetector>(cv::FastFeatureDetector::create());
+    try {
+        return new cv::Ptr<cv::FastFeatureDetector>(cv::FastFeatureDetector::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void FastFeatureDetector_Close(FastFeatureDetector f) {
@@ -319,32 +465,54 @@ void FastFeatureDetector_Close(FastFeatureDetector f) {
 }
 
 FastFeatureDetector FastFeatureDetector_CreateWithParams(int threshold, bool nonmaxSuppression, int type) {
-    return new cv::Ptr<cv::FastFeatureDetector>(cv::FastFeatureDetector::create(threshold,nonmaxSuppression,static_cast<cv::FastFeatureDetector::DetectorType>(type)));
+    try {
+        return new cv::Ptr<cv::FastFeatureDetector>(cv::FastFeatureDetector::create(threshold,nonmaxSuppression,static_cast<cv::FastFeatureDetector::DetectorType>(type)));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 struct KeyPoints FastFeatureDetector_Detect(FastFeatureDetector f, Mat src) {
-    std::vector<cv::KeyPoint> detected;
-    (*f)->detect(*src, detected);
-
-    KeyPoint* kps = new KeyPoint[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
-                      detected[i].response, detected[i].octave, detected[i].class_id
-                     };
-        kps[i] = k;
+    try {
+        std::vector<cv::KeyPoint> detected;
+        (*f)->detect(*src, detected);
+    
+        KeyPoint* kps = new KeyPoint[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
+                          detected[i].response, detected[i].octave, detected[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    KeyPoints ret = {kps, (int)detected.size()};
-    return ret;
 }
 
 ORB ORB_Create() {
-    return new cv::Ptr<cv::ORB>(cv::ORB::create());
+    try {
+        return new cv::Ptr<cv::ORB>(cv::ORB::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 ORB ORB_CreateWithParams(int nfeatures, float scaleFactor, int nlevels, int edgeThreshold, int firstLevel, int WTA_K, int scoreType, int patchSize, int fastThreshold) {
-    return new cv::Ptr<cv::ORB>(cv::ORB::create(nfeatures, scaleFactor, nlevels, edgeThreshold, firstLevel, WTA_K, static_cast<cv::ORB::ScoreType>(scoreType), patchSize, fastThreshold));
+    try {
+        return new cv::Ptr<cv::ORB>(cv::ORB::create(nfeatures, scaleFactor, nlevels, edgeThreshold, firstLevel, WTA_K, static_cast<cv::ORB::ScoreType>(scoreType), patchSize, fastThreshold));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void ORB_Close(ORB o) {
@@ -352,61 +520,82 @@ void ORB_Close(ORB o) {
 }
 
 struct KeyPoints ORB_Detect(ORB o, Mat src) {
-    std::vector<cv::KeyPoint> detected;
-    (*o)->detect(*src, detected);
-
-    KeyPoint* kps = new KeyPoint[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
-                      detected[i].response, detected[i].octave, detected[i].class_id
-                     };
-        kps[i] = k;
+    try {
+        std::vector<cv::KeyPoint> detected;
+        (*o)->detect(*src, detected);
+    
+        KeyPoint* kps = new KeyPoint[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
+                          detected[i].response, detected[i].octave, detected[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    KeyPoints ret = {kps, (int)detected.size()};
-    return ret;
 }
 
 struct KeyPoints ORB_Compute(ORB o, Mat src, struct KeyPoints kp, Mat desc) {
-    std::vector<cv::KeyPoint> computed;
-    for (size_t i = 0; i < kp.length; i++) {
-        cv::KeyPoint k = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
-            kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
-            kp.keypoints[i].octave, kp.keypoints[i].classID);
-        computed.push_back(k);
+    try {
+        std::vector<cv::KeyPoint> computed;
+        for (size_t i = 0; i < kp.length; i++) {
+            cv::KeyPoint k = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
+                kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
+                kp.keypoints[i].octave, kp.keypoints[i].classID);
+            computed.push_back(k);
+        }
+    
+        (*o)->compute(*src, computed, *desc);
+    
+        KeyPoint* kps = new KeyPoint[computed.size()];
+    
+        for (size_t i = 0; i < computed.size(); ++i) {
+            KeyPoint k = {computed[i].pt.x, computed[i].pt.y, computed[i].size, computed[i].angle,
+                          computed[i].response, computed[i].octave, computed[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)computed.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    (*o)->compute(*src, computed, *desc);
-
-    KeyPoint* kps = new KeyPoint[computed.size()];
-
-    for (size_t i = 0; i < computed.size(); ++i) {
-        KeyPoint k = {computed[i].pt.x, computed[i].pt.y, computed[i].size, computed[i].angle,
-                      computed[i].response, computed[i].octave, computed[i].class_id
-                     };
-        kps[i] = k;
-    }
-
-    KeyPoints ret = {kps, (int)computed.size()};
-    return ret;
 }
 
 struct KeyPoints ORB_DetectAndCompute(ORB o, Mat src, Mat mask, Mat desc) {
-    std::vector<cv::KeyPoint> detected;
-    (*o)->detectAndCompute(*src, *mask, detected, *desc);
-
-    KeyPoint* kps = new KeyPoint[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
-                      detected[i].response, detected[i].octave, detected[i].class_id
-                     };
-        kps[i] = k;
+    try {
+        std::vector<cv::KeyPoint> detected;
+        (*o)->detectAndCompute(*src, *mask, detected, *desc);
+    
+        KeyPoint* kps = new KeyPoint[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
+                          detected[i].response, detected[i].octave, detected[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    KeyPoints ret = {kps, (int)detected.size()};
-    return ret;
 }
 
 cv::SimpleBlobDetector::Params ConvertCParamsToCPPParams(SimpleBlobDetectorParams params) {
@@ -462,16 +651,31 @@ SimpleBlobDetectorParams ConvertCPPParamsToCParams(cv::SimpleBlobDetector::Param
 }
 
 SimpleBlobDetector SimpleBlobDetector_Create_WithParams(SimpleBlobDetectorParams params){
-    cv::SimpleBlobDetector::Params actualParams;
-    return new cv::Ptr<cv::SimpleBlobDetector>(cv::SimpleBlobDetector::create(ConvertCParamsToCPPParams(params)));
+    try {
+        cv::SimpleBlobDetector::Params actualParams;
+        return new cv::Ptr<cv::SimpleBlobDetector>(cv::SimpleBlobDetector::create(ConvertCParamsToCPPParams(params)));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 SimpleBlobDetector SimpleBlobDetector_Create() {
-    return new cv::Ptr<cv::SimpleBlobDetector>(cv::SimpleBlobDetector::create());
+    try {
+        return new cv::Ptr<cv::SimpleBlobDetector>(cv::SimpleBlobDetector::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 SimpleBlobDetectorParams SimpleBlobDetectorParams_Create() {
-    return ConvertCPPParamsToCParams(cv::SimpleBlobDetector::Params());
+    try {
+        return ConvertCPPParamsToCParams(cv::SimpleBlobDetector::Params());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return SimpleBlobDetectorParams();
+    }
 }
 
 void SimpleBlobDetector_Close(SimpleBlobDetector b) {
@@ -479,28 +683,45 @@ void SimpleBlobDetector_Close(SimpleBlobDetector b) {
 }
 
 struct KeyPoints SimpleBlobDetector_Detect(SimpleBlobDetector b, Mat src) {
-    std::vector<cv::KeyPoint> detected;
-    (*b)->detect(*src, detected);
-
-    KeyPoint* kps = new KeyPoint[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
-                      detected[i].response, detected[i].octave, detected[i].class_id
-                     };
-        kps[i] = k;
+    try {
+        std::vector<cv::KeyPoint> detected;
+        (*b)->detect(*src, detected);
+    
+        KeyPoint* kps = new KeyPoint[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
+                          detected[i].response, detected[i].octave, detected[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    KeyPoints ret = {kps, (int)detected.size()};
-    return ret;
 }
 
 BFMatcher BFMatcher_Create() {
-    return new cv::Ptr<cv::BFMatcher>(cv::BFMatcher::create());
+    try {
+        return new cv::Ptr<cv::BFMatcher>(cv::BFMatcher::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 BFMatcher BFMatcher_CreateWithParams(int normType, bool crossCheck) {
-    return new cv::Ptr<cv::BFMatcher>(cv::BFMatcher::create(normType, crossCheck));
+    try {
+        return new cv::Ptr<cv::BFMatcher>(cv::BFMatcher::create(normType, crossCheck));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void BFMatcher_Close(BFMatcher b) {
@@ -508,56 +729,84 @@ void BFMatcher_Close(BFMatcher b) {
 }
 
 struct DMatches BFMatcher_Match(BFMatcher b, Mat query, Mat train) {
-    std::vector<cv::DMatch> matches;
-    (*b)->match(*query, *train, matches);
-
-    DMatch *dmatches = new DMatch[matches.size()];
-    for (size_t i = 0; i < matches.size(); ++i) {
-        DMatch dmatch = {matches[i].queryIdx, matches[i].trainIdx, matches[i].imgIdx, matches[i].distance};
-        dmatches[i] = dmatch;
+    try {
+        std::vector<cv::DMatch> matches;
+        (*b)->match(*query, *train, matches);
+    
+        DMatch *dmatches = new DMatch[matches.size()];
+        for (size_t i = 0; i < matches.size(); ++i) {
+            DMatch dmatch = {matches[i].queryIdx, matches[i].trainIdx, matches[i].imgIdx, matches[i].distance};
+            dmatches[i] = dmatch;
+        }
+        DMatches ret = {dmatches, (int) matches.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        DMatch *dmatches = new DMatch[0];
+        DMatches ret = {dmatches, 0};
+        return ret;
     }
-    DMatches ret = {dmatches, (int) matches.size()};
-    return ret;
 }
 
 struct MultiDMatches BFMatcher_KnnMatch(BFMatcher b, Mat query, Mat train, int k) {
-    std::vector< std::vector<cv::DMatch> > matches;
-    (*b)->knnMatch(*query, *train, matches, k);
-
-    DMatches *dms = new DMatches[matches.size()];
-    for (size_t i = 0; i < matches.size(); ++i) {
-        DMatch *dmatches = new DMatch[matches[i].size()];
-        for (size_t j = 0; j < matches[i].size(); ++j) {
-            DMatch dmatch = {matches[i][j].queryIdx, matches[i][j].trainIdx, matches[i][j].imgIdx,
-                             matches[i][j].distance};
-            dmatches[j] = dmatch;
+    try {
+        std::vector< std::vector<cv::DMatch> > matches;
+        (*b)->knnMatch(*query, *train, matches, k);
+    
+        DMatches *dms = new DMatches[matches.size()];
+        for (size_t i = 0; i < matches.size(); ++i) {
+            DMatch *dmatches = new DMatch[matches[i].size()];
+            for (size_t j = 0; j < matches[i].size(); ++j) {
+                DMatch dmatch = {matches[i][j].queryIdx, matches[i][j].trainIdx, matches[i][j].imgIdx,
+                                 matches[i][j].distance};
+                dmatches[j] = dmatch;
+            }
+            dms[i] = {dmatches, (int) matches[i].size()};
         }
-        dms[i] = {dmatches, (int) matches[i].size()};
+        MultiDMatches ret = {dms, (int) matches.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        DMatch *dmatches = new DMatch[0];
+        DMatches *dms = new DMatches[0];
+        MultiDMatches ret = {dms, 0};
+        return ret;
     }
-    MultiDMatches ret = {dms, (int) matches.size()};
-    return ret;
 }
 
 struct MultiDMatches BFMatcher_KnnMatchWithParams(BFMatcher b, Mat query, Mat train, int k, Mat mask, bool compactResult) {
-    std::vector< std::vector<cv::DMatch> > matches;
-    (*b)->knnMatch(*query, *train, matches, k, *mask, compactResult);
-
-    DMatches *dms = new DMatches[matches.size()];
-    for (size_t i = 0; i < matches.size(); ++i) {
-        DMatch *dmatches = new DMatch[matches[i].size()];
-        for (size_t j = 0; j < matches[i].size(); ++j) {
-            DMatch dmatch = {matches[i][j].queryIdx, matches[i][j].trainIdx, matches[i][j].imgIdx,
-                             matches[i][j].distance};
-            dmatches[j] = dmatch;
+    try {
+        std::vector< std::vector<cv::DMatch> > matches;
+        (*b)->knnMatch(*query, *train, matches, k, *mask, compactResult);
+    
+        DMatches *dms = new DMatches[matches.size()];
+        for (size_t i = 0; i < matches.size(); ++i) {
+            DMatch *dmatches = new DMatch[matches[i].size()];
+            for (size_t j = 0; j < matches[i].size(); ++j) {
+                DMatch dmatch = {matches[i][j].queryIdx, matches[i][j].trainIdx, matches[i][j].imgIdx,
+                                 matches[i][j].distance};
+                dmatches[j] = dmatch;
+            }
+            dms[i] = {dmatches, (int) matches[i].size()};
         }
-        dms[i] = {dmatches, (int) matches[i].size()};
+        MultiDMatches ret = {dms, (int) matches.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        DMatch *dmatches = new DMatch[0];
+        DMatches *dms = new DMatches[0];
+        MultiDMatches ret = {dms, 0};
+        return ret;
     }
-    MultiDMatches ret = {dms, (int) matches.size()};
-    return ret;
 }
 
 FlannBasedMatcher FlannBasedMatcher_Create() {
-    return new cv::Ptr<cv::FlannBasedMatcher>(cv::FlannBasedMatcher::create());
+    try {
+        return new cv::Ptr<cv::FlannBasedMatcher>(cv::FlannBasedMatcher::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void FlannBasedMatcher_Close(FlannBasedMatcher f) {
@@ -565,63 +814,92 @@ void FlannBasedMatcher_Close(FlannBasedMatcher f) {
 }
 
 struct MultiDMatches FlannBasedMatcher_KnnMatch(FlannBasedMatcher f, Mat query, Mat train, int k) {
-    std::vector< std::vector<cv::DMatch> > matches;
-    (*f)->knnMatch(*query, *train, matches, k);
-
-    DMatches *dms = new DMatches[matches.size()];
-    for (size_t i = 0; i < matches.size(); ++i) {
-        DMatch *dmatches = new DMatch[matches[i].size()];
-        for (size_t j = 0; j < matches[i].size(); ++j) {
-            DMatch dmatch = {matches[i][j].queryIdx, matches[i][j].trainIdx, matches[i][j].imgIdx,
-                             matches[i][j].distance};
-            dmatches[j] = dmatch;
+    try {
+        std::vector< std::vector<cv::DMatch> > matches;
+        (*f)->knnMatch(*query, *train, matches, k);
+    
+        DMatches *dms = new DMatches[matches.size()];
+        for (size_t i = 0; i < matches.size(); ++i) {
+            DMatch *dmatches = new DMatch[matches[i].size()];
+            for (size_t j = 0; j < matches[i].size(); ++j) {
+                DMatch dmatch = {matches[i][j].queryIdx, matches[i][j].trainIdx, matches[i][j].imgIdx,
+                                 matches[i][j].distance};
+                dmatches[j] = dmatch;
+            }
+            dms[i] = {dmatches, (int) matches[i].size()};
         }
-        dms[i] = {dmatches, (int) matches[i].size()};
+        MultiDMatches ret = {dms, (int) matches.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        DMatch *dmatches = new DMatch[0];
+        DMatches *dms = new DMatches[0];
+        MultiDMatches ret = {dms, 0};
+        return ret;
     }
-    MultiDMatches ret = {dms, (int) matches.size()};
-    return ret;
 }
 
 struct MultiDMatches FlannBasedMatcher_KnnMatchWithParams(FlannBasedMatcher f, Mat query, Mat train, int k, Mat mask, bool compactResult) {
-    std::vector< std::vector<cv::DMatch> > matches;
-    (*f)->knnMatch(*query, *train, matches, k, *mask, compactResult);
-
-    DMatches *dms = new DMatches[matches.size()];
-    for (size_t i = 0; i < matches.size(); ++i) {
-        DMatch *dmatches = new DMatch[matches[i].size()];
-        for (size_t j = 0; j < matches[i].size(); ++j) {
-            DMatch dmatch = {matches[i][j].queryIdx, matches[i][j].trainIdx, matches[i][j].imgIdx,
-                             matches[i][j].distance};
-            dmatches[j] = dmatch;
+    try {
+        std::vector< std::vector<cv::DMatch> > matches;
+        (*f)->knnMatch(*query, *train, matches, k, *mask, compactResult);
+    
+        DMatches *dms = new DMatches[matches.size()];
+        for (size_t i = 0; i < matches.size(); ++i) {
+            DMatch *dmatches = new DMatch[matches[i].size()];
+            for (size_t j = 0; j < matches[i].size(); ++j) {
+                DMatch dmatch = {matches[i][j].queryIdx, matches[i][j].trainIdx, matches[i][j].imgIdx,
+                                 matches[i][j].distance};
+                dmatches[j] = dmatch;
+            }
+            dms[i] = {dmatches, (int) matches[i].size()};
         }
-        dms[i] = {dmatches, (int) matches[i].size()};
+        MultiDMatches ret = {dms, (int) matches.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        DMatch *dmatches = new DMatch[0];
+        DMatches *dms = new DMatches[0];
+        MultiDMatches ret = {dms, 0};
+        return ret;
     }
-    MultiDMatches ret = {dms, (int) matches.size()};
-    return ret;
 }
 
 void DrawKeyPoints(Mat src, struct KeyPoints kp, Mat dst, Scalar s, int flags) {
+    try {
         std::vector<cv::KeyPoint> keypts;
         cv::KeyPoint keypt;
-
+    
         for (int i = 0; i < kp.length; ++i) {
                 keypt = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
                                 kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
                                 kp.keypoints[i].octave, kp.keypoints[i].classID);
                 keypts.push_back(keypt);
         }
-
-        cv::Scalar color = cv::Scalar(s.val1, s.val2, s.val3, s.val4);
-
+    
+        cv::Scalar color = cv::Scalar(s.val1, s.val2, s.val3, s.val4);    
         cv::drawKeypoints(*src, keypts, *dst, color, static_cast<cv::DrawMatchesFlags>(flags));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 SIFT SIFT_Create() {
-    return new cv::Ptr<cv::SIFT>(cv::SIFT::create());
+    try {
+        return new cv::Ptr<cv::SIFT>(cv::SIFT::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 SIFT SIFT_CreateWithParams(int nfeatures, int nOctaveLayers, double contrastThreshold, double edgeThreshold, double sigma) {
-    return new cv::Ptr<cv::SIFT>(cv::SIFT::create(nfeatures, nOctaveLayers, contrastThreshold, edgeThreshold, sigma));
+    try {
+        return new cv::Ptr<cv::SIFT>(cv::SIFT::create(nfeatures, nOctaveLayers, contrastThreshold, edgeThreshold, sigma));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 
@@ -630,98 +908,123 @@ void SIFT_Close(SIFT d) {
 }
 
 struct KeyPoints SIFT_Detect(SIFT d, Mat src) {
-    std::vector<cv::KeyPoint> detected;
-    (*d)->detect(*src, detected);
-
-    KeyPoint* kps = new KeyPoint[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
-                      detected[i].response, detected[i].octave, detected[i].class_id
-                     };
-        kps[i] = k;
+    try {
+        std::vector<cv::KeyPoint> detected;
+        (*d)->detect(*src, detected);
+    
+        KeyPoint* kps = new KeyPoint[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
+                          detected[i].response, detected[i].octave, detected[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    KeyPoints ret = {kps, (int)detected.size()};
-    return ret;
 }
 
 struct KeyPoints SIFT_Compute(SIFT d, Mat src, struct KeyPoints kp, Mat desc) {
-    std::vector<cv::KeyPoint> computed;
-    for (size_t i = 0; i < kp.length; i++) {
-        cv::KeyPoint k = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
-            kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
-            kp.keypoints[i].octave, kp.keypoints[i].classID);
-        computed.push_back(k);
+    try {
+        std::vector<cv::KeyPoint> computed;
+        for (size_t i = 0; i < kp.length; i++) {
+            cv::KeyPoint k = cv::KeyPoint(kp.keypoints[i].x, kp.keypoints[i].y,
+                kp.keypoints[i].size, kp.keypoints[i].angle, kp.keypoints[i].response,
+                kp.keypoints[i].octave, kp.keypoints[i].classID);
+            computed.push_back(k);
+        }
+    
+        (*d)->compute(*src, computed, *desc);
+    
+        KeyPoint* kps = new KeyPoint[computed.size()];
+    
+        for (size_t i = 0; i < computed.size(); ++i) {
+            KeyPoint k = {computed[i].pt.x, computed[i].pt.y, computed[i].size, computed[i].angle,
+                          computed[i].response, computed[i].octave, computed[i].class_id
+                         };
+            kps[i] = k;
+        }
+    
+        KeyPoints ret = {kps, (int)computed.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    (*d)->compute(*src, computed, *desc);
-
-    KeyPoint* kps = new KeyPoint[computed.size()];
-
-    for (size_t i = 0; i < computed.size(); ++i) {
-        KeyPoint k = {computed[i].pt.x, computed[i].pt.y, computed[i].size, computed[i].angle,
-                      computed[i].response, computed[i].octave, computed[i].class_id
-                     };
-        kps[i] = k;
-    }
-
-    KeyPoints ret = {kps, (int)computed.size()};
-    return ret;
 }
 
 struct KeyPoints SIFT_DetectAndCompute(SIFT d, Mat src, Mat mask, Mat desc) {
-    std::vector<cv::KeyPoint> detected;
-    (*d)->detectAndCompute(*src, *mask, detected, *desc);
+    try {
+        std::vector<cv::KeyPoint> detected;
+        (*d)->detectAndCompute(*src, *mask, detected, *desc);
 
-    KeyPoint* kps = new KeyPoint[detected.size()];
+        KeyPoint* kps = new KeyPoint[detected.size()];
 
-    for (size_t i = 0; i < detected.size(); ++i) {
-        KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
-                      detected[i].response, detected[i].octave, detected[i].class_id
-                     };
-        kps[i] = k;
+        for (size_t i = 0; i < detected.size(); ++i) {
+            KeyPoint k = {detected[i].pt.x, detected[i].pt.y, detected[i].size, detected[i].angle,
+                          detected[i].response, detected[i].octave, detected[i].class_id
+                         };
+            kps[i] = k;
+        }
+
+        KeyPoints ret = {kps, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        KeyPoint* kps = new KeyPoint[0];
+        KeyPoints ret = {kps, 0};
+        return ret;
     }
-
-    KeyPoints ret = {kps, (int)detected.size()};
-    return ret;
 }
 
 void DrawMatches(Mat img1, struct KeyPoints kp1, Mat img2, struct KeyPoints kp2, struct DMatches matches1to2, Mat outImg, const Scalar matchesColor, const Scalar pointColor, struct ByteArray matchesMask, int flags) {
-    std::vector<cv::KeyPoint> kp1vec, kp2vec;
-    cv::KeyPoint keypt;
+    try {
+        std::vector<cv::KeyPoint> kp1vec, kp2vec;
+        cv::KeyPoint keypt;
 
-    for (int i = 0; i < kp1.length; ++i) {
-        keypt = cv::KeyPoint(kp1.keypoints[i].x, kp1.keypoints[i].y,
-                            kp1.keypoints[i].size, kp1.keypoints[i].angle, kp1.keypoints[i].response,
-                            kp1.keypoints[i].octave, kp1.keypoints[i].classID);
-        kp1vec.push_back(keypt);
+        for (int i = 0; i < kp1.length; ++i) {
+            keypt = cv::KeyPoint(kp1.keypoints[i].x, kp1.keypoints[i].y,
+                                kp1.keypoints[i].size, kp1.keypoints[i].angle, kp1.keypoints[i].response,
+                                kp1.keypoints[i].octave, kp1.keypoints[i].classID);
+            kp1vec.push_back(keypt);
+        }
+
+        for (int i = 0; i < kp2.length; ++i) {
+            keypt = cv::KeyPoint(kp2.keypoints[i].x, kp2.keypoints[i].y,
+                                kp2.keypoints[i].size, kp2.keypoints[i].angle, kp2.keypoints[i].response,
+                                kp2.keypoints[i].octave, kp2.keypoints[i].classID);
+            kp2vec.push_back(keypt);
+        }
+
+        cv::Scalar cvmatchescolor = cv::Scalar(matchesColor.val1, matchesColor.val2, matchesColor.val3, matchesColor.val4);
+        cv::Scalar cvpointcolor = cv::Scalar(pointColor.val1, pointColor.val2, pointColor.val3, pointColor.val4);
+
+        std::vector<cv::DMatch> dmatchvec;
+        cv::DMatch dm;
+
+        for (int i = 0; i < matches1to2.length; i++) {
+            dm = cv::DMatch(matches1to2.dmatches[i].queryIdx, matches1to2.dmatches[i].trainIdx,
+                            matches1to2.dmatches[i].imgIdx, matches1to2.dmatches[i].distance);
+            dmatchvec.push_back(dm);
+        }
+
+        std::vector<char> maskvec;
+
+        for (int i = 0; i < matchesMask.length; i++) {
+            maskvec.push_back(matchesMask.data[i]);
+        }
+
+        cv::drawMatches(*img1, kp1vec, *img2, kp2vec, dmatchvec, *outImg, cvmatchescolor, cvpointcolor, maskvec, static_cast<cv::DrawMatchesFlags>(flags));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    for (int i = 0; i < kp2.length; ++i) {
-        keypt = cv::KeyPoint(kp2.keypoints[i].x, kp2.keypoints[i].y,
-                            kp2.keypoints[i].size, kp2.keypoints[i].angle, kp2.keypoints[i].response,
-                            kp2.keypoints[i].octave, kp2.keypoints[i].classID);
-        kp2vec.push_back(keypt);
-    }
-
-    cv::Scalar cvmatchescolor = cv::Scalar(matchesColor.val1, matchesColor.val2, matchesColor.val3, matchesColor.val4);
-    cv::Scalar cvpointcolor = cv::Scalar(pointColor.val1, pointColor.val2, pointColor.val3, pointColor.val4);
-    
-    std::vector<cv::DMatch> dmatchvec;
-    cv::DMatch dm;
-
-    for (int i = 0; i < matches1to2.length; i++) {
-        dm = cv::DMatch(matches1to2.dmatches[i].queryIdx, matches1to2.dmatches[i].trainIdx,
-                        matches1to2.dmatches[i].imgIdx, matches1to2.dmatches[i].distance);
-        dmatchvec.push_back(dm);
-    }
-
-    std::vector<char> maskvec;
-
-    for (int i = 0; i < matchesMask.length; i++) {
-        maskvec.push_back(matchesMask.data[i]);
-    }
-
-    cv::drawMatches(*img1, kp1vec, *img2, kp2vec, dmatchvec, *outImg, cvmatchescolor, cvpointcolor, maskvec, static_cast<cv::DrawMatchesFlags>(flags));
 }

--- a/highgui.cpp
+++ b/highgui.cpp
@@ -1,95 +1,184 @@
 #include "highgui_gocv.h"
 
 void Window_SetMouseCallback(char* winname, mouse_callback on_mouse) {
-    cv::setMouseCallback(winname, on_mouse, (void*)winname);
+    try {
+        cv::setMouseCallback(winname, on_mouse, (void*)winname);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 // Window
 void Window_New(const char* winname, int flags) {
-    cv::namedWindow(winname, flags);
+    try {
+        cv::namedWindow(winname, flags);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Window_Close(const char* winname) {
-    cv::destroyWindow(winname);
+    try {
+        cv::destroyWindow(winname);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Window_IMShow(const char* winname, Mat mat) {
-    cv::imshow(winname, *mat);
+    try {
+        cv::imshow(winname, *mat);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 double Window_GetProperty(const char* winname, int flag) {
-    return cv::getWindowProperty(winname, flag);
+    try {
+        return cv::getWindowProperty(winname, flag);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 void Window_SetProperty(const char* winname, int flag, double value) {
-    cv::setWindowProperty(winname, flag, value);
+    try {
+        cv::setWindowProperty(winname, flag, value);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Window_SetTitle(const char* winname, const char* title) {
-    cv::setWindowTitle(winname, title);
+    try {
+        cv::setWindowTitle(winname, title);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 int Window_WaitKey(int delay = 0) {
-    return cv::waitKey(delay);
+    try {
+        return cv::waitKey(delay);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return -1;
+    }
 }
 
 int Window_WaitKeyEx(int delay = 0) {
-    return cv::waitKeyEx(delay);
+    try {
+        return cv::waitKeyEx(delay);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return -1;
+    }
 }
 
 int Window_PollKey(void) {
-    return cv::pollKey();
+    try {
+        return cv::pollKey();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return -1;
+    }
 }
 
 void Window_Move(const char* winname, int x, int y) {
-    cv::moveWindow(winname, x, y);
+    try {
+        cv::moveWindow(winname, x, y);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Window_Resize(const char* winname, int width, int height) {
-    cv::resizeWindow(winname, width, height);
+    try {
+        cv::resizeWindow(winname, width, height);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 struct Rect Window_SelectROI(const char* winname, Mat img) {
-    cv::Rect bRect = cv::selectROI(winname, *img);
-    Rect r = {bRect.x, bRect.y, bRect.width, bRect.height};
-    return r;
+    try {
+        cv::Rect bRect = cv::selectROI(winname, *img);
+        Rect r = {bRect.x, bRect.y, bRect.width, bRect.height};
+        return r;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Rect r = {0, 0, 0, 0};
+        return r;
+    }
 }
 
 struct Rects Window_SelectROIs(const char* winname, Mat img) {
-    std::vector<cv::Rect> rois;
-    cv::selectROIs(winname, *img, rois);
-    Rect* rects = new Rect[rois.size()];
-
-    for (size_t i = 0; i < rois.size(); ++i) {
-        Rect r = {rois[i].x, rois[i].y, rois[i].width, rois[i].height};
-        rects[i] = r;
+    try {
+        std::vector<cv::Rect> rois;
+        cv::selectROIs(winname, *img, rois);
+        Rect* rects = new Rect[rois.size()];
+    
+        for (size_t i = 0; i < rois.size(); ++i) {
+            Rect r = {rois[i].x, rois[i].y, rois[i].width, rois[i].height};
+            rects[i] = r;
+        }
+    
+        Rects ret = {rects, (int)rois.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Rects ret = {NULL, 0};
+        return ret;
     }
-
-    Rects ret = {rects, (int)rois.size()};
-    return ret;
 }
 
 // Trackbar
 void Trackbar_Create(const char* winname, const char* trackname, int max) {
-    cv::createTrackbar(trackname, winname, NULL, max);
+    try {
+        cv::createTrackbar(trackname, winname, NULL, max);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Trackbar_CreateWithValue(const char* winname, const char* trackname, int* value, int max) {
-    cv::createTrackbar(trackname, winname, value, max);
+    try {
+        cv::createTrackbar(trackname, winname, value, max);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 int Trackbar_GetPos(const char* winname, const char* trackname) {
-    return cv::getTrackbarPos(trackname, winname);
+    try {
+        return cv::getTrackbarPos(trackname, winname);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return -1;
+    }
 }
 
 void Trackbar_SetPos(const char* winname, const char* trackname, int pos) {
-    cv::setTrackbarPos(trackname, winname, pos);
+    try {
+        cv::setTrackbarPos(trackname, winname, pos);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Trackbar_SetMin(const char* winname, const char* trackname, int pos) {
-    cv::setTrackbarMin(trackname, winname, pos);
+    try {
+        cv::setTrackbarMin(trackname, winname, pos);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Trackbar_SetMax(const char* winname, const char* trackname, int pos) {
-    cv::setTrackbarMax(trackname, winname, pos);
+    try {
+        cv::setTrackbarMax(trackname, winname, pos);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }

--- a/highgui.cpp
+++ b/highgui.cpp
@@ -25,11 +25,12 @@ void Window_Close(const char* winname) {
     }
 }
 
-void Window_IMShow(const char* winname, Mat mat) {
+OpenCVResult Window_IMShow(const char* winname, Mat mat) {
     try {
         cv::imshow(winname, *mat);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -42,19 +43,21 @@ double Window_GetProperty(const char* winname, int flag) {
     }
 }
 
-void Window_SetProperty(const char* winname, int flag, double value) {
+OpenCVResult Window_SetProperty(const char* winname, int flag, double value) {
     try {
         cv::setWindowProperty(winname, flag, value);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Window_SetTitle(const char* winname, const char* title) {
+OpenCVResult Window_SetTitle(const char* winname, const char* title) {
     try {
         cv::setWindowTitle(winname, title);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -85,19 +88,21 @@ int Window_PollKey(void) {
     }
 }
 
-void Window_Move(const char* winname, int x, int y) {
+OpenCVResult Window_Move(const char* winname, int x, int y) {
     try {
         cv::moveWindow(winname, x, y);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Window_Resize(const char* winname, int width, int height) {
+OpenCVResult Window_Resize(const char* winname, int width, int height) {
     try {
         cv::resizeWindow(winname, width, height);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 

--- a/highgui.go
+++ b/highgui.go
@@ -139,25 +139,25 @@ func (w *Window) GetWindowProperty(flag WindowPropertyFlag) float64 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dfc/group__highgui.html#ga66e4a6db4d4e06148bcdfe0d70a5df27
-func (w *Window) SetWindowProperty(flag WindowPropertyFlag, value WindowFlag) {
+func (w *Window) SetWindowProperty(flag WindowPropertyFlag, value WindowFlag) error {
 	cName := C.CString(w.name)
 	defer C.free(unsafe.Pointer(cName))
 
-	C.Window_SetProperty(cName, C.int(flag), C.double(value))
+	return OpenCVResult(C.Window_SetProperty(cName, C.int(flag), C.double(value)))
 }
 
 // SetWindowTitle updates window title.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dfc/group__highgui.html#ga56f8849295fd10d0c319724ddb773d96
-func (w *Window) SetWindowTitle(title string) {
+func (w *Window) SetWindowTitle(title string) error {
 	cName := C.CString(w.name)
 	defer C.free(unsafe.Pointer(cName))
 
 	cTitle := C.CString(title)
 	defer C.free(unsafe.Pointer(cTitle))
 
-	C.Window_SetTitle(cName, cTitle)
+	return OpenCVResult(C.Window_SetTitle(cName, cTitle))
 }
 
 // IMShow displays an image Mat in the specified window.
@@ -166,11 +166,11 @@ func (w *Window) SetWindowTitle(title string) {
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d7/dfc/group__highgui.html#ga453d42fe4cb60e5723281a89973ee563
-func (w *Window) IMShow(img Mat) {
+func (w *Window) IMShow(img Mat) error {
 	cName := C.CString(w.name)
 	defer C.free(unsafe.Pointer(cName))
 
-	C.Window_IMShow(cName, img.p)
+	return OpenCVResult(C.Window_IMShow(cName, img.p))
 }
 
 // WaitKey waits for a pressed key.
@@ -217,22 +217,22 @@ func (w *Window) PollKey() int {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dfc/group__highgui.html#ga8d86b207f7211250dbe6e28f76307ffb
-func (w *Window) MoveWindow(x, y int) {
+func (w *Window) MoveWindow(x, y int) error {
 	cName := C.CString(w.name)
 	defer C.free(unsafe.Pointer(cName))
 
-	C.Window_Move(cName, C.int(x), C.int(y))
+	return OpenCVResult(C.Window_Move(cName, C.int(x), C.int(y)))
 }
 
 // ResizeWindow resizes window to the specified size.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dfc/group__highgui.html#ga9e80e080f7ef33f897e415358aee7f7e
-func (w *Window) ResizeWindow(width, height int) {
+func (w *Window) ResizeWindow(width, height int) error {
 	cName := C.CString(w.name)
 	defer C.free(unsafe.Pointer(cName))
 
-	C.Window_Resize(cName, C.int(width), C.int(height))
+	return OpenCVResult(C.Window_Resize(cName, C.int(width), C.int(height)))
 }
 
 // SelectROI selects a Region Of Interest (ROI) on the given image.

--- a/highgui_gocv.h
+++ b/highgui_gocv.h
@@ -20,15 +20,15 @@ void Window_SetMouseCallback(char* winname, mouse_callback on_mouse);
 // Window
 void Window_New(const char* winname, int flags);
 void Window_Close(const char* winname);
-void Window_IMShow(const char* winname, Mat mat);
+OpenCVResult Window_IMShow(const char* winname, Mat mat);
 double Window_GetProperty(const char* winname, int flag);
-void Window_SetProperty(const char* winname, int flag, double value);
-void Window_SetTitle(const char* winname, const char* title);
+OpenCVResult Window_SetProperty(const char* winname, int flag, double value);
+OpenCVResult Window_SetTitle(const char* winname, const char* title);
 int Window_WaitKey(int);
 int Window_WaitKeyEx(int);
 int Window_PollKey(void);
-void Window_Move(const char* winname, int x, int y);
-void Window_Resize(const char* winname, int width, int height);
+OpenCVResult Window_Move(const char* winname, int x, int y);
+OpenCVResult Window_Resize(const char* winname, int width, int height);
 struct Rect Window_SelectROI(const char* winname, Mat img);
 struct Rects Window_SelectROIs(const char* winname, Mat img);
 

--- a/imgcodecs.cpp
+++ b/imgcodecs.cpp
@@ -3,80 +3,122 @@
 
 // Image
 Mat Image_IMRead(const char* filename, int flags) {
-    cv::Mat img = cv::imread(filename, flags);
-    return new cv::Mat(img);
+    try {
+        cv::Mat img = cv::imread(filename, flags);
+        return new cv::Mat(img);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 Mats Image_IMReadMulti(const char* filename, int flags) {
-    std::vector<cv::Mat> dst;
-    Mats m = Mats();
-
-    bool b = cv::imreadmulti(filename, dst, flags);
-    if (b) {
-        m.mats = new Mat[dst.size()];
-        for (size_t i = 0; i < dst.size(); ++i) {
-            m.mats[i] = new cv::Mat(dst[i]);
+    try {
+        std::vector<cv::Mat> dst;
+        Mats m = Mats();
+    
+        bool b = cv::imreadmulti(filename, dst, flags);
+        if (b) {
+            m.mats = new Mat[dst.size()];
+            for (size_t i = 0; i < dst.size(); ++i) {
+                m.mats[i] = new cv::Mat(dst[i]);
+            }
+            m.length = (int)dst.size();        
         }
-        m.length = (int)dst.size();        
+    
+        return m;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return Mats();
     }
-
-    return m;
 }
 
 Mats Image_IMReadMulti_WithParams(const char* filename, int start, int count, int flags) {
-    std::vector<cv::Mat> dst;
-    auto m = Mats();
-    
-    auto b = cv::imreadmulti(filename, dst, start, count, flags);
-    if (b) {
-        m.mats = new Mat[dst.size()];
-        for (size_t i = 0; i < dst.size(); ++i) {
-            m.mats[i] = new cv::Mat(dst[i]);
+    try {
+        std::vector<cv::Mat> dst;
+        auto m = Mats();
+        
+        auto b = cv::imreadmulti(filename, dst, start, count, flags);
+        if (b) {
+            m.mats = new Mat[dst.size()];
+            for (size_t i = 0; i < dst.size(); ++i) {
+                m.mats[i] = new cv::Mat(dst[i]);
+            }
+            m.length = (int)dst.size();        
         }
-        m.length = (int)dst.size();        
+    
+        return m;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return Mats();
     }
-
-    return m;
 }
 
 
 bool Image_IMWrite(const char* filename, Mat img) {
-    return cv::imwrite(filename, *img);
+    try {
+        return cv::imwrite(filename, *img);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 bool Image_IMWrite_WithParams(const char* filename, Mat img, IntVector params) {
-    std::vector<int> compression_params;
+    try {
+        std::vector<int> compression_params;
 
-    for (int i = 0, *v = params.val; i < params.length; ++v, ++i) {
-        compression_params.push_back(*v);
+        for (int i = 0, *v = params.val; i < params.length; ++v, ++i) {
+            compression_params.push_back(*v);
+        }
+    
+        return cv::imwrite(filename, *img, compression_params);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
     }
-
-    return cv::imwrite(filename, *img, compression_params);
 }
 
 void Image_IMEncode(const char* fileExt, Mat img, void* vector) {
-    auto vectorPtr = reinterpret_cast<std::vector<uchar> *>(vector);
-    cv::imencode(fileExt, *img, *vectorPtr);
+    try {
+        auto vectorPtr = reinterpret_cast<std::vector<uchar> *>(vector);
+        cv::imencode(fileExt, *img, *vectorPtr);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Image_IMEncode_WithParams(const char* fileExt, Mat img, IntVector params, void* vector) {
-    auto vectorPtr = reinterpret_cast<std::vector<uchar> *>(vector);
-    std::vector<int> compression_params;
-
-    for (int i = 0, *v = params.val; i < params.length; ++v, ++i) {
-        compression_params.push_back(*v);
+    try {
+        auto vectorPtr = reinterpret_cast<std::vector<uchar> *>(vector);
+        std::vector<int> compression_params;
+    
+        for (int i = 0, *v = params.val; i < params.length; ++v, ++i) {
+            compression_params.push_back(*v);
+        }
+    
+        cv::imencode(fileExt, *img, *vectorPtr, compression_params);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-
-    cv::imencode(fileExt, *img, *vectorPtr, compression_params);
 }
 
 Mat Image_IMDecode(ByteArray buf, int flags) {
-    std::vector<uchar> data(buf.data, buf.data + buf.length);
-    cv::Mat img = cv::imdecode(data, flags);
-    return new cv::Mat(img);
+    try {
+        std::vector<uchar> data(buf.data, buf.data + buf.length);
+        cv::Mat img = cv::imdecode(data, flags);
+        return new cv::Mat(img);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 void Image_IMDecodeIntoMat(ByteArray buf, int flags, Mat dest) {
-    std::vector<uchar> data(buf.data, buf.data + buf.length);
-    cv::imdecode(data, flags, dest);
+    try {
+        std::vector<uchar> data(buf.data, buf.data + buf.length);
+        cv::imdecode(data, flags, dest);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }

--- a/imgcodecs.cpp
+++ b/imgcodecs.cpp
@@ -79,16 +79,17 @@ bool Image_IMWrite_WithParams(const char* filename, Mat img, IntVector params) {
     }
 }
 
-void Image_IMEncode(const char* fileExt, Mat img, void* vector) {
+OpenCVResult Image_IMEncode(const char* fileExt, Mat img, void* vector) {
     try {
         auto vectorPtr = reinterpret_cast<std::vector<uchar> *>(vector);
         cv::imencode(fileExt, *img, *vectorPtr);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Image_IMEncode_WithParams(const char* fileExt, Mat img, IntVector params, void* vector) {
+OpenCVResult Image_IMEncode_WithParams(const char* fileExt, Mat img, IntVector params, void* vector) {
     try {
         auto vectorPtr = reinterpret_cast<std::vector<uchar> *>(vector);
         std::vector<int> compression_params;
@@ -98,8 +99,9 @@ void Image_IMEncode_WithParams(const char* fileExt, Mat img, IntVector params, v
         }
     
         cv::imencode(fileExt, *img, *vectorPtr, compression_params);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -114,11 +116,12 @@ Mat Image_IMDecode(ByteArray buf, int flags) {
     }
 }
 
-void Image_IMDecodeIntoMat(ByteArray buf, int flags, Mat dest) {
+OpenCVResult Image_IMDecodeIntoMat(ByteArray buf, int flags, Mat dest) {
     try {
         std::vector<uchar> data(buf.data, buf.data + buf.length);
         cv::imdecode(data, flags, dest);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }

--- a/imgcodecs.go
+++ b/imgcodecs.go
@@ -250,8 +250,8 @@ func IMEncode(fileExt FileExt, img Mat) (buf *NativeByteBuffer, err error) {
 	defer C.free(unsafe.Pointer(cfileExt))
 
 	buffer := newNativeByteBuffer()
-	C.Image_IMEncode(cfileExt, img.Ptr(), buffer.nativePointer())
-	return buffer, nil
+	res := C.Image_IMEncode(cfileExt, img.Ptr(), buffer.nativePointer())
+	return buffer, OpenCVResult(res)
 }
 
 // IMEncodeWithParams encodes an image Mat into a memory buffer.
@@ -279,8 +279,8 @@ func IMEncodeWithParams(fileExt FileExt, img Mat, params []int) (buf *NativeByte
 	paramsVector.length = (C.int)(len(cparams))
 
 	b := newNativeByteBuffer()
-	C.Image_IMEncode_WithParams(cfileExt, img.Ptr(), paramsVector, b.nativePointer())
-	return b, nil
+	res := C.Image_IMEncode_WithParams(cfileExt, img.Ptr(), paramsVector, b.nativePointer())
+	return b, OpenCVResult(res)
 }
 
 // IMDecode reads an image from a buffer in memory.
@@ -295,7 +295,7 @@ func IMDecode(buf []byte, flags IMReadFlag) (Mat, error) {
 	if err != nil {
 		return Mat{}, err
 	}
-	return newMat(C.Image_IMDecode(*data, C.int(flags))), nil
+	return newMat(C.Image_IMDecode(*data, C.int(flags))), LastExceptionError()
 }
 
 // IMDecodeIntoMat reads an image from a buffer in memory into a matrix.
@@ -310,6 +310,5 @@ func IMDecodeIntoMat(buf []byte, flags IMReadFlag, dest *Mat) error {
 	if err != nil {
 		return err
 	}
-	C.Image_IMDecodeIntoMat(*data, C.int(flags), dest.p)
-	return nil
+	return OpenCVResult(C.Image_IMDecodeIntoMat(*data, C.int(flags), dest.p))
 }

--- a/imgcodecs.h
+++ b/imgcodecs.h
@@ -15,11 +15,10 @@ Mats Image_IMReadMulti(const char* filename, int flags);
 Mats Image_IMReadMulti_WithParams(const char* filename, int start, int count, int flags);
 bool Image_IMWrite(const char* filename, Mat img);
 bool Image_IMWrite_WithParams(const char* filename, Mat img, IntVector params);
-void Image_IMEncode(const char* fileExt, Mat img, void* vector);
-
-void Image_IMEncode_WithParams(const char* fileExt, Mat img, IntVector params, void* vector);
+OpenCVResult Image_IMEncode(const char* fileExt, Mat img, void* vector);
+OpenCVResult Image_IMEncode_WithParams(const char* fileExt, Mat img, IntVector params, void* vector);
 Mat Image_IMDecode(ByteArray buf, int flags);
-void Image_IMDecodeIntoMat(ByteArray buf, int flag, Mat dest);
+OpenCVResult Image_IMDecodeIntoMat(ByteArray buf, int flag, Mat dest);
 
 #ifdef __cplusplus
 }

--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -21,31 +21,34 @@ PointVector ApproxPolyDP(PointVector curve, double epsilon, bool closed) {
     }
 }
 
-void CvtColor(Mat src, Mat dst, int code) {
+OpenCVResult CvtColor(Mat src, Mat dst, int code) {
     try {
         cv::cvtColor(*src, *dst, code);
+        return successResult();
     } catch(const cv::Exception& e) {
-        setExceptionInfo(e.code, e.what());
+        return errorResult(e.code, e.what());
     }
 }
 
-void Demosaicing(Mat src, Mat dst, int code) {
+OpenCVResult Demosaicing(Mat src, Mat dst, int code) {
     try {
         cv::demosaicing(*src, *dst, code);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void EqualizeHist(Mat src, Mat dst) {
+OpenCVResult EqualizeHist(Mat src, Mat dst) {
     try {
         cv::equalizeHist(*src, *dst);
+        return successResult();
     } catch(const cv::Exception& e) {
-        setExceptionInfo(e.code, e.what());
+        return errorResult(e.code, e.what());
     }
 }
 
-void CalcHist(struct Mats mats, IntVector chans, Mat mask, Mat hist, IntVector sz, FloatVector rng, bool acc) {
+OpenCVResult CalcHist(struct Mats mats, IntVector chans, Mat mask, Mat hist, IntVector sz, FloatVector rng, bool acc) {
     std::vector<cv::Mat> images;
 
     for (int i = 0; i < mats.length; ++i) {
@@ -74,12 +77,13 @@ void CalcHist(struct Mats mats, IntVector chans, Mat mask, Mat hist, IntVector s
 
     try {
         cv::calcHist(images, channels, *mask, *hist, histSize, ranges, acc);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void CalcBackProject(struct Mats mats, IntVector chans, Mat hist, Mat backProject, FloatVector rng, bool uniform){
+OpenCVResult CalcBackProject(struct Mats mats, IntVector chans, Mat hist, Mat backProject, FloatVector rng, bool uniform){
     std::vector<cv::Mat> images;
 
     for (int i = 0; i < mats.length; ++i) {
@@ -101,8 +105,9 @@ void CalcBackProject(struct Mats mats, IntVector chans, Mat hist, Mat backProjec
 
     try {
         cv::calcBackProject(images, channels, *hist, *backProject, ranges, uniform);
+        return successResult();
     } catch(const cv::Exception& e) {
-        setExceptionInfo(e.code, e.what());
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -154,118 +159,131 @@ struct RotatedRect FitEllipse(PointVector pts)
     return rotRect;
 }
 
-void ConvexHull(PointVector points, Mat hull, bool clockwise, bool returnPoints) {
+OpenCVResult ConvexHull(PointVector points, Mat hull, bool clockwise, bool returnPoints) {
     try {
         cv::convexHull(*points, *hull, clockwise, returnPoints);
+        return successResult();
     } catch(const cv::Exception& e) {
-        setExceptionInfo(e.code, e.what());
+        return errorResult(e.code, e.what());
     }
 }
 
-void ConvexityDefects(PointVector points, Mat hull, Mat result) {
+OpenCVResult ConvexityDefects(PointVector points, Mat hull, Mat result) {
     try {
         cv::convexityDefects(*points, *hull, *result);
+        return successResult();
     } catch(const cv::Exception& e) {
-        setExceptionInfo(e.code, e.what());
+        return errorResult(e.code, e.what());
     }
 }
 
-void BilateralFilter(Mat src, Mat dst, int d, double sc, double ss) {
+OpenCVResult BilateralFilter(Mat src, Mat dst, int d, double sc, double ss) {
     try {
         cv::bilateralFilter(*src, *dst, d, sc, ss);
+        return successResult();
     } catch(const cv::Exception& e) {
-        setExceptionInfo(e.code, e.what());
+        return errorResult(e.code, e.what());
     }
 }
 
-void Blur(Mat src, Mat dst, Size ps) {
+OpenCVResult Blur(Mat src, Mat dst, Size ps) {
     try {
         cv::Size sz(ps.width, ps.height);
         cv::blur(*src, *dst, sz);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void BoxFilter(Mat src, Mat dst, int ddepth, Size ps) {
+OpenCVResult BoxFilter(Mat src, Mat dst, int ddepth, Size ps) {
     try {
         cv::Size sz(ps.width, ps.height);
         cv::boxFilter(*src, *dst, ddepth, sz);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void SqBoxFilter(Mat src, Mat dst, int ddepth, Size ps) {
+OpenCVResult SqBoxFilter(Mat src, Mat dst, int ddepth, Size ps) {
     try {
         cv::Size sz(ps.width, ps.height);
         cv::sqrBoxFilter(*src, *dst, ddepth, sz);
+        return successResult();
     } catch(const cv::Exception& e) {
-        setExceptionInfo(e.code, e.what());
+        return errorResult(e.code, e.what());
     }
 }
 
-void Dilate(Mat src, Mat dst, Mat kernel) {
+OpenCVResult Dilate(Mat src, Mat dst, Mat kernel) {
     try {
         cv::dilate(*src, *dst, *kernel);
+        return successResult();
     } catch(const cv::Exception& e) {
-        setExceptionInfo(e.code, e.what());
+        return errorResult(e.code, e.what());
     }
 }
 
-void DilateWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType, Scalar borderValue) {
+OpenCVResult DilateWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType, Scalar borderValue) {
     try {
         cv::Point pt1(anchor.x, anchor.y);
         cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
 
         cv::dilate(*src, *dst, *kernel, pt1, iterations, borderType, c);
+        return successResult();
     } catch(const cv::Exception& e) {
-        setExceptionInfo(e.code, e.what());
+        return errorResult(e.code, e.what());
     }
 }
 
-void DistanceTransform(Mat src, Mat dst, Mat labels, int distanceType, int maskSize, int labelType) {
+OpenCVResult DistanceTransform(Mat src, Mat dst, Mat labels, int distanceType, int maskSize, int labelType) {
     try {
         cv::distanceTransform(*src, *dst, *labels, distanceType, maskSize, labelType);
+        return successResult();
     } catch(const cv::Exception& e) {
-        setExceptionInfo(e.code, e.what());
+        return errorResult(e.code, e.what());
     }
 }
 
-void Erode(Mat src, Mat dst, Mat kernel) {
+OpenCVResult Erode(Mat src, Mat dst, Mat kernel) {
     try {
         cv::erode(*src, *dst, *kernel);
+        return successResult();
     } catch(const cv::Exception& e) {
-        setExceptionInfo(e.code, e.what());
+        return errorResult(e.code, e.what());
     }
 }
 
-void ErodeWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType) {
+OpenCVResult ErodeWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType) {
     try {
         cv::Point pt1(anchor.x, anchor.y);
 
         cv::erode(*src, *dst, *kernel, pt1, iterations, borderType, cv::morphologyDefaultBorderValue());
+        return successResult();
     } catch(const cv::Exception& e) {
-        setExceptionInfo(e.code, e.what());
+        return errorResult(e.code, e.what());
     }
 }
 
-void ErodeWithParamsAndBorderValue(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType, Scalar borderValue) {
+OpenCVResult ErodeWithParamsAndBorderValue(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType, Scalar borderValue) {
     try {
         cv::Point pt1(anchor.x, anchor.y);
         cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
 
         cv::erode(*src, *dst, *kernel, pt1, iterations, borderType, c);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void MatchTemplate(Mat image, Mat templ, Mat result, int method, Mat mask) {
+OpenCVResult MatchTemplate(Mat image, Mat templ, Mat result, int method, Mat mask) {
     try {
         cv::matchTemplate(*image, *templ, *result, method, *mask);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -284,21 +302,23 @@ struct Moment Moments(Mat src, bool binaryImage) {
     }
 }
 
-void PyrDown(Mat src, Mat dst, Size size, int borderType) {
+OpenCVResult PyrDown(Mat src, Mat dst, Size size, int borderType) {
     try {
         cv::Size cvSize(size.width, size.height);
         cv::pyrDown(*src, *dst, cvSize, borderType);
+        return successResult();
     } catch(const cv::Exception& e) {
-        setExceptionInfo(e.code, e.what());
+        return errorResult(e.code, e.what());
     }
 }
 
-void PyrUp(Mat src, Mat dst, Size size, int borderType) {
+OpenCVResult PyrUp(Mat src, Mat dst, Size size, int borderType) {
     try {
         cv::Size cvSize(size.width, size.height);
         cv::pyrUp(*src, *dst, cvSize, borderType);
+        return successResult();
     } catch(const cv::Exception& e) {
-        setExceptionInfo(e.code, e.what());
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -315,25 +335,27 @@ struct Rect BoundingRect(PointVector pts) {
     }
 }
 
-void BoxPoints(RotatedRect rect, Mat boxPts){
+OpenCVResult BoxPoints(RotatedRect rect, Mat boxPts){
     try {
         cv::Point2f centerPt(rect.center.x , rect.center.y);
         cv::Size2f rSize(rect.size.width, rect.size.height);
         cv::RotatedRect rotatedRectangle(centerPt, rSize, rect.angle);
         cv::boxPoints(rotatedRectangle, *boxPts);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void BoxPoints2f(RotatedRect2f rect, Mat boxPts){
+OpenCVResult BoxPoints2f(RotatedRect2f rect, Mat boxPts){
     try {
         cv::Point2f centerPt(rect.center.x , rect.center.y);
         cv::Size2f rSize(rect.size.width, rect.size.height);
         cv::RotatedRect rotatedRectangle(centerPt, rSize, rect.angle);
         cv::boxPoints(rotatedRectangle, *boxPts);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -404,14 +426,15 @@ struct RotatedRect2f MinAreaRect2f(PointVector pts){
     }
 }
 
-void MinEnclosingCircle(PointVector pts, Point2f* center, float* radius){
+OpenCVResult MinEnclosingCircle(PointVector pts, Point2f* center, float* radius){
     try {
         cv::Point2f center2f;
         cv::minEnclosingCircle(*pts, center2f, *radius);
         center->x = center2f.x;
         center->y = center2f.y;
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -479,29 +502,32 @@ Scalar MorphologyDefaultBorderValue(){
     }
 }
 
-void MorphologyEx(Mat src, Mat dst, int op, Mat kernel) {
+OpenCVResult MorphologyEx(Mat src, Mat dst, int op, Mat kernel) {
     try {
         cv::morphologyEx(*src, *dst, op, *kernel);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void MorphologyExWithParams(Mat src, Mat dst, int op, Mat kernel, Point pt, int iterations, int borderType) {
+OpenCVResult MorphologyExWithParams(Mat src, Mat dst, int op, Mat kernel, Point pt, int iterations, int borderType) {
     try {
         cv::Point pt1(pt.x, pt.y);
         cv::morphologyEx(*src, *dst, op, *kernel, pt1, iterations, borderType);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GaussianBlur(Mat src, Mat dst, Size ps, double sX, double sY, int bt) {
+OpenCVResult GaussianBlur(Mat src, Mat dst, Size ps, double sX, double sY, int bt) {
     try {
         cv::Size sz(ps.width, ps.height);
         cv::GaussianBlur(*src, *dst, sz, sX, sY, bt);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -514,122 +540,135 @@ Mat GetGaussianKernel(int ksize, double sigma, int ktype){
     }
 }
 
-void Laplacian(Mat src, Mat dst, int dDepth, int kSize, double scale, double delta, int borderType) {
+OpenCVResult Laplacian(Mat src, Mat dst, int dDepth, int kSize, double scale, double delta, int borderType) {
     try {
         cv::Laplacian(*src, *dst, dDepth, kSize, scale, delta, borderType);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Scharr(Mat src, Mat dst, int dDepth, int dx, int dy, double scale, double delta, int borderType) {
+OpenCVResult Scharr(Mat src, Mat dst, int dDepth, int dx, int dy, double scale, double delta, int borderType) {
     try {
         cv::Scharr(*src, *dst, dDepth, dx, dy, scale, delta, borderType);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void MedianBlur(Mat src, Mat dst, int ksize) {
+OpenCVResult MedianBlur(Mat src, Mat dst, int ksize) {
     try {
         cv::medianBlur(*src, *dst, ksize);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Canny(Mat src, Mat edges, double t1, double t2) {
+OpenCVResult Canny(Mat src, Mat edges, double t1, double t2) {
     try {
         cv::Canny(*src, *edges, t1, t2);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void CornerSubPix(Mat img, Mat corners, Size winSize, Size zeroZone, TermCriteria criteria) {
+OpenCVResult CornerSubPix(Mat img, Mat corners, Size winSize, Size zeroZone, TermCriteria criteria) {
     try {
         cv::Size wsz(winSize.width, winSize.height);
         cv::Size zsz(zeroZone.width, zeroZone.height);
         cv::cornerSubPix(*img, *corners, wsz, zsz, *criteria);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GoodFeaturesToTrack(Mat img, Mat corners, int maxCorners, double quality, double minDist) {
+OpenCVResult GoodFeaturesToTrack(Mat img, Mat corners, int maxCorners, double quality, double minDist) {
     try {
         cv::goodFeaturesToTrack(*img, *corners, maxCorners, quality, minDist);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GrabCut(Mat img, Mat mask, Rect r, Mat bgdModel, Mat fgdModel, int iterCount, int mode) {
+OpenCVResult GrabCut(Mat img, Mat mask, Rect r, Mat bgdModel, Mat fgdModel, int iterCount, int mode) {
     try {
         cv::Rect cvRect = cv::Rect(r.x, r.y, r.width, r.height);
         cv::grabCut(*img, *mask, cvRect, *bgdModel, *fgdModel, iterCount, mode);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void HoughCircles(Mat src, Mat circles, int method, double dp, double minDist) {
+OpenCVResult HoughCircles(Mat src, Mat circles, int method, double dp, double minDist) {
     try {
         cv::HoughCircles(*src, *circles, method, dp, minDist);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void HoughCirclesWithParams(Mat src, Mat circles, int method, double dp, double minDist,
+OpenCVResult HoughCirclesWithParams(Mat src, Mat circles, int method, double dp, double minDist,
                             double param1, double param2, int minRadius, int maxRadius) {
     try {
         cv::HoughCircles(*src, *circles, method, dp, minDist, param1, param2, minRadius, maxRadius);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void HoughLines(Mat src, Mat lines, double rho, double theta, int threshold) {
+OpenCVResult HoughLines(Mat src, Mat lines, double rho, double theta, int threshold) {
     try {
         cv::HoughLines(*src, *lines, rho, theta, threshold);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void HoughLinesP(Mat src, Mat lines, double rho, double theta, int threshold) {
+OpenCVResult HoughLinesP(Mat src, Mat lines, double rho, double theta, int threshold) {
     try {
         cv::HoughLinesP(*src, *lines, rho, theta, threshold);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void HoughLinesPWithParams(Mat src, Mat lines, double rho, double theta, int threshold, double minLineLength, double maxLineGap) {
+OpenCVResult HoughLinesPWithParams(Mat src, Mat lines, double rho, double theta, int threshold, double minLineLength, double maxLineGap) {
     try {
         cv::HoughLinesP(*src, *lines, rho, theta, threshold, minLineLength, maxLineGap);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void HoughLinesPointSet(Mat points, Mat lines, int linesMax, int threshold,
+OpenCVResult HoughLinesPointSet(Mat points, Mat lines, int linesMax, int threshold,
                         double minRho, double  maxRho, double rhoStep,
                         double minTheta, double maxTheta, double thetaStep) {
     try {
-        cv::HoughLinesPointSet(*points, *lines, linesMax, threshold,
-            minRho, maxRho, rhoStep, minTheta, maxTheta, thetaStep );
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        cv::HoughLinesPointSet(*points, *lines, linesMax, threshold, minRho, maxRho, rhoStep, minTheta, maxTheta, thetaStep );
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Integral(Mat src, Mat sum, Mat sqsum, Mat tilted) {
+OpenCVResult Integral(Mat src, Mat sum, Mat sqsum, Mat tilted) {
     try {
         cv::integral(*src, *sum, *sqsum, *tilted);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -642,23 +681,25 @@ double Threshold(Mat src, Mat dst, double thresh, double maxvalue, int typ) {
     }
 }
 
-void AdaptiveThreshold(Mat src, Mat dst, double maxValue, int adaptiveMethod, int thresholdType, int blockSize, double c) {
+OpenCVResult AdaptiveThreshold(Mat src, Mat dst, double maxValue, int adaptiveMethod, int thresholdType, int blockSize, double c) {
     try {
         cv::adaptiveThreshold(*src, *dst, maxValue, adaptiveMethod, thresholdType, blockSize, c);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void ArrowedLine(Mat img, Point pt1, Point pt2, Scalar color, int thickness) {
+OpenCVResult ArrowedLine(Mat img, Point pt1, Point pt2, Scalar color, int thickness) {
     try {
         cv::Point p1(pt1.x, pt1.y);
         cv::Point p2(pt2.x, pt2.y);
         cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 
         cv::arrowedLine(*img, p1, p2, c, thickness);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -675,65 +716,70 @@ bool ClipLine(Size imgSize, Point pt1, Point pt2) {
     }
 }
 
-void Circle(Mat img, Point center, int radius, Scalar color, int thickness) {
+OpenCVResult Circle(Mat img, Point center, int radius, Scalar color, int thickness) {
     try {
         cv::Point p1(center.x, center.y);
         cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 
         cv::circle(*img, p1, radius, c, thickness);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void CircleWithParams(Mat img, Point center, int radius, Scalar color, int thickness, int lineType, int shift) {
+OpenCVResult CircleWithParams(Mat img, Point center, int radius, Scalar color, int thickness, int lineType, int shift) {
     try {
         cv::Point p1(center.x, center.y);
         cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 
         cv::circle(*img, p1, radius, c, thickness, lineType, shift);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Ellipse(Mat img, Point center, Point axes, double angle, double startAngle, double endAngle, Scalar color, int thickness) {
+OpenCVResult Ellipse(Mat img, Point center, Point axes, double angle, double startAngle, double endAngle, Scalar color, int thickness) {
     try {
         cv::Point p1(center.x, center.y);
         cv::Point p2(axes.x, axes.y);
         cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 
         cv::ellipse(*img, p1, p2, angle, startAngle, endAngle, c, thickness);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void EllipseWithParams(Mat img, Point center, Point axes, double angle, double startAngle, double endAngle, Scalar color, int thickness, int lineType, int shift) {
+OpenCVResult EllipseWithParams(Mat img, Point center, Point axes, double angle, double startAngle, double endAngle, Scalar color, int thickness, int lineType, int shift) {
     try {
         cv::Point p1(center.x, center.y);
         cv::Point p2(axes.x, axes.y);
         cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 
         cv::ellipse(*img, p1, p2, angle, startAngle, endAngle, c, thickness, lineType, shift);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Line(Mat img, Point pt1, Point pt2, Scalar color, int thickness) {
+OpenCVResult Line(Mat img, Point pt1, Point pt2, Scalar color, int thickness) {
     try {
         cv::Point p1(pt1.x, pt1.y);
         cv::Point p2(pt2.x, pt2.y);
         cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 
         cv::line(*img, p1, p2, c, thickness);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Rectangle(Mat img, Rect r, Scalar color, int thickness) {
+OpenCVResult Rectangle(Mat img, Rect r, Scalar color, int thickness) {
     try {
         cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
         cv::rectangle(
@@ -744,12 +790,13 @@ void Rectangle(Mat img, Rect r, Scalar color, int thickness) {
             thickness,
             cv::LINE_AA
         );
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void RectangleWithParams(Mat img, Rect r, Scalar color, int thickness, int lineType, int shift) {
+OpenCVResult RectangleWithParams(Mat img, Rect r, Scalar color, int thickness, int lineType, int shift) {
     try {
         cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
         cv::rectangle(
@@ -761,38 +808,42 @@ void RectangleWithParams(Mat img, Rect r, Scalar color, int thickness, int lineT
             lineType,
             shift
         );
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void FillPoly(Mat img, PointsVector pts, Scalar color) {
+OpenCVResult FillPoly(Mat img, PointsVector pts, Scalar color) {
     try {
         cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 
         cv::fillPoly(*img, *pts, c);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void FillPolyWithParams(Mat img, PointsVector pts, Scalar color, int lineType, int shift, Point offset) {
+OpenCVResult FillPolyWithParams(Mat img, PointsVector pts, Scalar color, int lineType, int shift, Point offset) {
     try {
         cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 
         cv::fillPoly(*img, *pts, c, lineType, shift, cv::Point(offset.x, offset.y));
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Polylines(Mat img, PointsVector pts, bool isClosed, Scalar color,int thickness) {
+OpenCVResult Polylines(Mat img, PointsVector pts, bool isClosed, Scalar color,int thickness) {
     try {
         cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 
         cv::polylines(*img, *pts, isClosed, c, thickness);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -818,43 +869,47 @@ struct Size GetTextSizeWithBaseline(const char* text, int fontFace, double fontS
     }
 }
 
-void PutText(Mat img, const char* text, Point org, int fontFace, double fontScale, Scalar color, int thickness) {
+OpenCVResult PutText(Mat img, const char* text, Point org, int fontFace, double fontScale, Scalar color, int thickness) {
     try {
         cv::Point pt(org.x, org.y);
         cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
         cv::putText(*img, text, pt, fontFace, fontScale, c, thickness);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void PutTextWithParams(Mat img, const char* text, Point org, int fontFace, double fontScale,
+OpenCVResult PutTextWithParams(Mat img, const char* text, Point org, int fontFace, double fontScale,
                        Scalar color, int thickness, int lineType, bool bottomLeftOrigin) {
     try {
         cv::Point pt(org.x, org.y);
         cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
         cv::putText(*img, text, pt, fontFace, fontScale, c, thickness, lineType, bottomLeftOrigin);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Resize(Mat src, Mat dst, Size dsize, double fx, double fy, int interp) {
+OpenCVResult Resize(Mat src, Mat dst, Size dsize, double fx, double fy, int interp) {
     try {
         cv::Size sz(dsize.width, dsize.height);
         cv::resize(*src, *dst, sz, fx, fy, interp);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void GetRectSubPix(Mat src, Size patchSize, Point center, Mat dst) {
+OpenCVResult GetRectSubPix(Mat src, Size patchSize, Point center, Mat dst) {
     try {
         cv::Size sz(patchSize.width, patchSize.height);
         cv::Point pt(center.x, center.y);
         cv::getRectSubPix(*src, sz, pt, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -868,67 +923,72 @@ Mat GetRotationMatrix2D(Point center, double angle, double scale) {
     }
 }
 
-void WarpAffine(Mat src, Mat dst, Mat m, Size dsize) {
+OpenCVResult WarpAffine(Mat src, Mat dst, Mat m, Size dsize) {
     try {
         cv::Size sz(dsize.width, dsize.height);
         cv::warpAffine(*src, *dst, *m, sz);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void WarpAffineWithParams(Mat src, Mat dst, Mat rot_mat, Size dsize, int flags, int borderMode,
-                          Scalar borderValue) {
+OpenCVResult WarpAffineWithParams(Mat src, Mat dst, Mat rot_mat, Size dsize, int flags, int borderMode, Scalar borderValue) {
     try {
         cv::Size sz(dsize.width, dsize.height);
         cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
         cv::warpAffine(*src, *dst, *rot_mat, sz, flags, borderMode, c);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void WarpPerspective(Mat src, Mat dst, Mat m, Size dsize) {
+OpenCVResult WarpPerspective(Mat src, Mat dst, Mat m, Size dsize) {
     try {
         cv::Size sz(dsize.width, dsize.height);
         cv::warpPerspective(*src, *dst, *m, sz);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void WarpPerspectiveWithParams(Mat src, Mat dst, Mat rot_mat, Size dsize, int flags, int borderMode,
-                               Scalar borderValue) {
+OpenCVResult WarpPerspectiveWithParams(Mat src, Mat dst, Mat rot_mat, Size dsize, int flags, int borderMode, Scalar borderValue) {
     try {
         cv::Size sz(dsize.width, dsize.height);
         cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
         cv::warpPerspective(*src, *dst, *rot_mat, sz, flags, borderMode, c);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Watershed(Mat image, Mat markers) {
+OpenCVResult Watershed(Mat image, Mat markers) {
     try {
         cv::watershed(*image, *markers);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void ApplyColorMap(Mat src, Mat dst, int colormap) {
+OpenCVResult ApplyColorMap(Mat src, Mat dst, int colormap) {
     try {
         cv::applyColorMap(*src, *dst, colormap);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void ApplyCustomColorMap(Mat src, Mat dst, Mat colormap) {
+OpenCVResult ApplyCustomColorMap(Mat src, Mat dst, Mat colormap) {
     try {
         cv::applyColorMap(*src, *dst, *colormap);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -989,16 +1049,17 @@ Mat FindHomography(Mat src, Mat dst, int method, double ransacReprojThreshold, M
     }
 }
 
-void DrawContours(Mat src, PointsVector contours, int contourIdx, Scalar color, int thickness) {
+OpenCVResult DrawContours(Mat src, PointsVector contours, int contourIdx, Scalar color, int thickness) {
     try {
         cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
         cv::drawContours(*src, *contours, contourIdx, c, thickness);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void DrawContoursWithParams(Mat src, PointsVector contours, int contourIdx, Scalar color, int thickness, int lineType, Mat hierarchy, int maxLevel, Point offset) {
+OpenCVResult DrawContoursWithParams(Mat src, PointsVector contours, int contourIdx, Scalar color, int thickness, int lineType, Mat hierarchy, int maxLevel, Point offset) {
     try {
         cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
         cv::Point offsetPt(offset.x, offset.y);
@@ -1010,78 +1071,86 @@ void DrawContoursWithParams(Mat src, PointsVector contours, int contourIdx, Scal
             }
         }
         cv::drawContours(*src, *contours, contourIdx, c, thickness, lineType, vecHierarchy, maxLevel, offsetPt);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Sobel(Mat src, Mat dst, int ddepth, int dx, int dy, int ksize, double scale, double delta, int borderType) {
+OpenCVResult Sobel(Mat src, Mat dst, int ddepth, int dx, int dy, int ksize, double scale, double delta, int borderType) {
     try {
         cv::Sobel(*src, *dst, ddepth, dx, dy, ksize, scale, delta, borderType);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void SpatialGradient(Mat src, Mat dx, Mat dy, int ksize, int borderType) {
+OpenCVResult SpatialGradient(Mat src, Mat dx, Mat dy, int ksize, int borderType) {
     try {
         cv::spatialGradient(*src, *dx, *dy, ksize, borderType);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-
-void Remap(Mat src, Mat dst, Mat map1, Mat map2, int interpolation, int borderMode, Scalar borderValue) {
+OpenCVResult Remap(Mat src, Mat dst, Mat map1, Mat map2, int interpolation, int borderMode, Scalar borderValue) {
     try {
         cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
         cv::remap(*src, *dst, *map1, *map2, interpolation, borderMode, c);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Filter2D(Mat src, Mat dst, int ddepth, Mat kernel, Point anchor, double delta, int borderType) {
+OpenCVResult Filter2D(Mat src, Mat dst, int ddepth, Mat kernel, Point anchor, double delta, int borderType) {
     try {
         cv::Point anchorPt(anchor.x, anchor.y);
         cv::filter2D(*src, *dst, ddepth, *kernel, anchorPt, delta, borderType);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void SepFilter2D(Mat src, Mat dst, int ddepth, Mat kernelX, Mat kernelY, Point anchor, double delta, int borderType) {
+OpenCVResult SepFilter2D(Mat src, Mat dst, int ddepth, Mat kernelX, Mat kernelY, Point anchor, double delta, int borderType) {
     try {
         cv::Point anchorPt(anchor.x, anchor.y);
         cv::sepFilter2D(*src, *dst, ddepth, *kernelX, *kernelY, anchorPt, delta, borderType);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void LogPolar(Mat src, Mat dst, Point center, double m, int flags) {
+OpenCVResult LogPolar(Mat src, Mat dst, Point center, double m, int flags) {
     try {
         cv::Point2f centerPt(center.x, center.y);
         cv::logPolar(*src, *dst, centerPt, m, flags);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void FitLine(PointVector pts, Mat line, int distType, double param, double reps, double aeps) {
+OpenCVResult FitLine(PointVector pts, Mat line, int distType, double param, double reps, double aeps) {
     try {
         cv::fitLine(*pts, *line, distType, param, reps, aeps);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void LinearPolar(Mat src, Mat dst, Point center, double maxRadius, int flags) {
+OpenCVResult LinearPolar(Mat src, Mat dst, Point center, double maxRadius, int flags) {
     try {
         cv::Point2f centerPt(center.x, center.y);
         cv::linearPolar(*src, *dst, centerPt, maxRadius, flags);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -1117,19 +1186,21 @@ void CLAHE_Close(CLAHE c) {
     delete c;
 }
 
-void CLAHE_Apply(CLAHE c, Mat src, Mat dst) {
+OpenCVResult CLAHE_Apply(CLAHE c, Mat src, Mat dst) {
     try {
         (*c)->apply(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void InvertAffineTransform(Mat src, Mat dst) {
+OpenCVResult InvertAffineTransform(Mat src, Mat dst) {
     try {
         cv::invertAffineTransform(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -1152,74 +1223,84 @@ Point2f PhaseCorrelate(Mat src1, Mat src2, Mat window, double* response) {
     }
 }
 
-void CreateHanningWindow(Mat dst, Size size, int typ) {
+OpenCVResult CreateHanningWindow(Mat dst, Size size, int typ) {
     try {
         cv::Size sz(size.width, size.height);
         cv::createHanningWindow(*dst, sz, typ);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_Accumulate(Mat src, Mat dst) {
+OpenCVResult Mat_Accumulate(Mat src, Mat dst) {
     try {
         cv::accumulate(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
-void Mat_AccumulateWithMask(Mat src, Mat dst, Mat mask) {
+
+OpenCVResult Mat_AccumulateWithMask(Mat src, Mat dst, Mat mask) {
     try {
         cv::accumulate(*src, *dst, *mask);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_AccumulateSquare(Mat src, Mat dst) {
+OpenCVResult Mat_AccumulateSquare(Mat src, Mat dst) {
     try {
         cv::accumulateSquare(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_AccumulateSquareWithMask(Mat src, Mat dst, Mat mask) {
+OpenCVResult Mat_AccumulateSquareWithMask(Mat src, Mat dst, Mat mask) {
     try {
         cv::accumulateSquare(*src, *dst, *mask);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_AccumulateProduct(Mat src1, Mat src2, Mat dst) {
+OpenCVResult Mat_AccumulateProduct(Mat src1, Mat src2, Mat dst) {
     try {
         cv::accumulateProduct(*src1, *src2, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_AccumulateProductWithMask(Mat src1, Mat src2, Mat dst, Mat mask) {
+OpenCVResult Mat_AccumulateProductWithMask(Mat src1, Mat src2, Mat dst, Mat mask) {
     try {
         cv::accumulateProduct(*src1, *src2, *dst, *mask);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_AccumulatedWeighted(Mat src, Mat dst, double alpha) {
+OpenCVResult Mat_AccumulatedWeighted(Mat src, Mat dst, double alpha) {
     try {
         cv::accumulateWeighted(*src, *dst, alpha);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Mat_AccumulatedWeightedWithMask(Mat src, Mat dst, double alpha, Mat mask) {
+OpenCVResult Mat_AccumulatedWeightedWithMask(Mat src, Mat dst, double alpha, Mat mask) {
     try {
         cv::accumulateWeighted(*src, *dst, alpha, *mask);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }

--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -1,92 +1,140 @@
 #include "imgproc.h"
 
 double ArcLength(PointVector curve, bool is_closed) {
-    return cv::arcLength(*curve, is_closed);
+    try {
+        return cv::arcLength(*curve, is_closed);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 PointVector ApproxPolyDP(PointVector curve, double epsilon, bool closed) {
-    PointVector approxCurvePts = new std::vector<cv::Point>;
-    cv::approxPolyDP(*curve, *approxCurvePts, epsilon, closed);
+    try {
+        PointVector approxCurvePts = new std::vector<cv::Point>;
+        cv::approxPolyDP(*curve, *approxCurvePts, epsilon, closed);
 
-    return approxCurvePts;
+        return approxCurvePts;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void CvtColor(Mat src, Mat dst, int code) {
-    cv::cvtColor(*src, *dst, code);
+    try {
+        cv::cvtColor(*src, *dst, code);
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Demosaicing(Mat src, Mat dst, int code) {
-    cv::demosaicing(*src, *dst, code);
+    try {
+        cv::demosaicing(*src, *dst, code);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void EqualizeHist(Mat src, Mat dst) {
-    cv::equalizeHist(*src, *dst);
+    try {
+        cv::equalizeHist(*src, *dst);
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void CalcHist(struct Mats mats, IntVector chans, Mat mask, Mat hist, IntVector sz, FloatVector rng, bool acc) {
-        std::vector<cv::Mat> images;
+    std::vector<cv::Mat> images;
 
-        for (int i = 0; i < mats.length; ++i) {
-            images.push_back(*mats.mats[i]);
-        }
+    for (int i = 0; i < mats.length; ++i) {
+        images.push_back(*mats.mats[i]);
+    }
 
-        std::vector<int> channels;
+    std::vector<int> channels;
 
-        for (int i = 0, *v = chans.val; i < chans.length; ++v, ++i) {
-            channels.push_back(*v);
-        }
+    for (int i = 0, *v = chans.val; i < chans.length; ++v, ++i) {
+        channels.push_back(*v);
+    }
 
-        std::vector<int> histSize;
+    std::vector<int> histSize;
 
-        for (int i = 0, *v = sz.val; i < sz.length; ++v, ++i) {
-            histSize.push_back(*v);
-        }
+    for (int i = 0, *v = sz.val; i < sz.length; ++v, ++i) {
+        histSize.push_back(*v);
+    }
 
-        std::vector<float> ranges;
+    std::vector<float> ranges;
 
-        float* f;
-        int i;
-        for (i = 0, f = rng.val; i < rng.length; ++f, ++i) {
-            ranges.push_back(*f);
-        }
+    float* f;
+    int i;
+    for (i = 0, f = rng.val; i < rng.length; ++f, ++i) {
+        ranges.push_back(*f);
+    }
 
+    try {
         cv::calcHist(images, channels, *mask, *hist, histSize, ranges, acc);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void CalcBackProject(struct Mats mats, IntVector chans, Mat hist, Mat backProject, FloatVector rng, bool uniform){
-        std::vector<cv::Mat> images;
+    std::vector<cv::Mat> images;
 
-        for (int i = 0; i < mats.length; ++i) {
-            images.push_back(*mats.mats[i]);
-        }
+    for (int i = 0; i < mats.length; ++i) {
+        images.push_back(*mats.mats[i]);
+    }
 
-        std::vector<int> channels;
-        for (int i = 0, *v = chans.val; i < chans.length; ++v, ++i) {
-            channels.push_back(*v);
-        }
+    std::vector<int> channels;
+    for (int i = 0, *v = chans.val; i < chans.length; ++v, ++i) {
+        channels.push_back(*v);
+    }
 
-        std::vector<float> ranges;
+    std::vector<float> ranges;
 
-        float* f;
-        int i;
-        for (i = 0, f = rng.val; i < rng.length; ++f, ++i) {
-            ranges.push_back(*f);
-        }
+    float* f;
+    int i;
+    for (i = 0, f = rng.val; i < rng.length; ++f, ++i) {
+        ranges.push_back(*f);
+    }
 
+    try {
         cv::calcBackProject(images, channels, *hist, *backProject, ranges, uniform);
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 double CompareHist(Mat hist1, Mat hist2, int method) {
-    return cv::compareHist(*hist1, *hist2, method);
+    try {
+        return cv::compareHist(*hist1, *hist2, method);
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 float EMD(Mat sig1, Mat sig2, int distType) {
-    return cv::EMD(*sig1, *sig2, distType);
+    try {
+        return cv::EMD(*sig1, *sig2, distType);
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 struct RotatedRect FitEllipse(PointVector pts)
 {
-    cv::RotatedRect bRect = cv::fitEllipse(*pts);
+    cv::RotatedRect bRect;
+    try {
+        bRect = cv::fitEllipse(*pts);
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+
+        RotatedRect emptyRect;
+        return emptyRect;
+    }
 
     Rect r = {bRect.boundingRect().x, bRect.boundingRect().y, bRect.boundingRect().width, bRect.boundingRect().height};
     Point centrpt = {int(lroundf(bRect.center.x)), int(lroundf(bRect.center.y))};
@@ -107,564 +155,962 @@ struct RotatedRect FitEllipse(PointVector pts)
 }
 
 void ConvexHull(PointVector points, Mat hull, bool clockwise, bool returnPoints) {
-    cv::convexHull(*points, *hull, clockwise, returnPoints);
+    try {
+        cv::convexHull(*points, *hull, clockwise, returnPoints);
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void ConvexityDefects(PointVector points, Mat hull, Mat result) {
-    cv::convexityDefects(*points, *hull, *result);
+    try {
+        cv::convexityDefects(*points, *hull, *result);
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void BilateralFilter(Mat src, Mat dst, int d, double sc, double ss) {
-    cv::bilateralFilter(*src, *dst, d, sc, ss);
+    try {
+        cv::bilateralFilter(*src, *dst, d, sc, ss);
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Blur(Mat src, Mat dst, Size ps) {
-    cv::Size sz(ps.width, ps.height);
-    cv::blur(*src, *dst, sz);
+    try {
+        cv::Size sz(ps.width, ps.height);
+        cv::blur(*src, *dst, sz);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void BoxFilter(Mat src, Mat dst, int ddepth, Size ps) {
-    cv::Size sz(ps.width, ps.height);
-    cv::boxFilter(*src, *dst, ddepth, sz);
+    try {
+        cv::Size sz(ps.width, ps.height);
+        cv::boxFilter(*src, *dst, ddepth, sz);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void SqBoxFilter(Mat src, Mat dst, int ddepth, Size ps) {
-    cv::Size sz(ps.width, ps.height);
-    cv::sqrBoxFilter(*src, *dst, ddepth, sz);
+    try {
+        cv::Size sz(ps.width, ps.height);
+        cv::sqrBoxFilter(*src, *dst, ddepth, sz);
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Dilate(Mat src, Mat dst, Mat kernel) {
-    cv::dilate(*src, *dst, *kernel);
+    try {
+        cv::dilate(*src, *dst, *kernel);
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void DilateWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType, Scalar borderValue) {
-    cv::Point pt1(anchor.x, anchor.y);
-    cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
+    try {
+        cv::Point pt1(anchor.x, anchor.y);
+        cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
 
-    cv::dilate(*src, *dst, *kernel, pt1, iterations, borderType, c);
+        cv::dilate(*src, *dst, *kernel, pt1, iterations, borderType, c);
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void DistanceTransform(Mat src, Mat dst, Mat labels, int distanceType, int maskSize, int labelType) {
-    cv::distanceTransform(*src, *dst, *labels, distanceType, maskSize, labelType);
+    try {
+        cv::distanceTransform(*src, *dst, *labels, distanceType, maskSize, labelType);
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Erode(Mat src, Mat dst, Mat kernel) {
-    cv::erode(*src, *dst, *kernel);
+    try {
+        cv::erode(*src, *dst, *kernel);
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void ErodeWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType) {
-    cv::Point pt1(anchor.x, anchor.y);
+    try {
+        cv::Point pt1(anchor.x, anchor.y);
 
-    cv::erode(*src, *dst, *kernel, pt1, iterations, borderType, cv::morphologyDefaultBorderValue());
+        cv::erode(*src, *dst, *kernel, pt1, iterations, borderType, cv::morphologyDefaultBorderValue());
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void ErodeWithParamsAndBorderValue(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType, Scalar borderValue) {
-    cv::Point pt1(anchor.x, anchor.y);
-    cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
+    try {
+        cv::Point pt1(anchor.x, anchor.y);
+        cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
 
-    cv::erode(*src, *dst, *kernel, pt1, iterations, borderType, c);
+        cv::erode(*src, *dst, *kernel, pt1, iterations, borderType, c);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
-
 void MatchTemplate(Mat image, Mat templ, Mat result, int method, Mat mask) {
-    cv::matchTemplate(*image, *templ, *result, method, *mask);
+    try {
+        cv::matchTemplate(*image, *templ, *result, method, *mask);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 struct Moment Moments(Mat src, bool binaryImage) {
-    cv::Moments m = cv::moments(*src, binaryImage);
-    Moment mom = {m.m00, m.m10, m.m01, m.m20, m.m11, m.m02, m.m30, m.m21, m.m12, m.m03,
-                  m.mu20, m.mu11, m.mu02, m.mu30, m.mu21, m.mu12, m.mu03,
-                  m.nu20, m.nu11, m.nu02, m.nu30, m.nu21, m.nu12, m.nu03
-                 };
-    return mom;
+    try {
+        cv::Moments m = cv::moments(*src, binaryImage);
+        Moment mom = {m.m00, m.m10, m.m01, m.m20, m.m11, m.m02, m.m30, m.m21, m.m12, m.m03,
+                      m.mu20, m.mu11, m.mu02, m.mu30, m.mu21, m.mu12, m.mu03,
+                      m.nu20, m.nu11, m.nu02, m.nu30, m.nu21, m.nu12, m.nu03
+                     };
+        return mom;
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+        Moment mom;
+        return mom;
+    }
 }
 
 void PyrDown(Mat src, Mat dst, Size size, int borderType) {
-    cv::Size cvSize(size.width, size.height);
-    cv::pyrDown(*src, *dst, cvSize, borderType);
+    try {
+        cv::Size cvSize(size.width, size.height);
+        cv::pyrDown(*src, *dst, cvSize, borderType);
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void PyrUp(Mat src, Mat dst, Size size, int borderType) {
-    cv::Size cvSize(size.width, size.height);
-    cv::pyrUp(*src, *dst, cvSize, borderType);
+    try {
+        cv::Size cvSize(size.width, size.height);
+        cv::pyrUp(*src, *dst, cvSize, borderType);
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 struct Rect BoundingRect(PointVector pts) {
-    cv::Rect bRect = cv::boundingRect(*pts);
-    Rect r = {bRect.x, bRect.y, bRect.width, bRect.height};
-    return r;
+    cv::Rect bRect;
+    try {
+        bRect = cv::boundingRect(*pts);
+        Rect r = {bRect.x, bRect.y, bRect.width, bRect.height};
+        return r;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Rect r;
+        return r;
+    }
 }
 
 void BoxPoints(RotatedRect rect, Mat boxPts){
-    cv::Point2f centerPt(rect.center.x , rect.center.y);
-    cv::Size2f rSize(rect.size.width, rect.size.height);
-    cv::RotatedRect rotatedRectangle(centerPt, rSize, rect.angle);
-    cv::boxPoints(rotatedRectangle, *boxPts);
+    try {
+        cv::Point2f centerPt(rect.center.x , rect.center.y);
+        cv::Size2f rSize(rect.size.width, rect.size.height);
+        cv::RotatedRect rotatedRectangle(centerPt, rSize, rect.angle);
+        cv::boxPoints(rotatedRectangle, *boxPts);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void BoxPoints2f(RotatedRect2f rect, Mat boxPts){
-    cv::Point2f centerPt(rect.center.x , rect.center.y);
-    cv::Size2f rSize(rect.size.width, rect.size.height);
-    cv::RotatedRect rotatedRectangle(centerPt, rSize, rect.angle);
-    cv::boxPoints(rotatedRectangle, *boxPts);
+    try {
+        cv::Point2f centerPt(rect.center.x , rect.center.y);
+        cv::Size2f rSize(rect.size.width, rect.size.height);
+        cv::RotatedRect rotatedRectangle(centerPt, rSize, rect.angle);
+        cv::boxPoints(rotatedRectangle, *boxPts);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 double ContourArea(PointVector pts) {
-    return cv::contourArea(*pts);
+    try {
+        return cv::contourArea(*pts);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 struct RotatedRect MinAreaRect(PointVector pts){
-    cv::RotatedRect cvrect = cv::minAreaRect(*pts);
+    try {
+        cv::RotatedRect cvrect = cv::minAreaRect(*pts);
 
-    Point* rpts = new Point[4];
-    cv::Point2f* pts4 = new cv::Point2f[4];
-    cvrect.points(pts4);
+        Point* rpts = new Point[4];
+        cv::Point2f* pts4 = new cv::Point2f[4];
+        cvrect.points(pts4);
 
-    for (size_t j = 0; j < 4; j++) {
-        Point pt = {int(lroundf(pts4[j].x)), int(lroundf(pts4[j].y))};
-        rpts[j] = pt;
+        for (size_t j = 0; j < 4; j++) {
+            Point pt = {int(lroundf(pts4[j].x)), int(lroundf(pts4[j].y))};
+            rpts[j] = pt;
+        }
+
+        delete[] pts4;
+
+        cv::Rect bRect = cvrect.boundingRect();
+        Rect r = {bRect.x, bRect.y, bRect.width, bRect.height};
+        Point centrpt = {int(lroundf(cvrect.center.x)), int(lroundf(cvrect.center.y))};
+        Size szsz = {int(lroundf(cvrect.size.width)), int(lroundf(cvrect.size.height))};
+
+        RotatedRect retrect = {(Contour){rpts, 4}, r, centrpt, szsz, cvrect.angle};
+        return retrect;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        RotatedRect retrect;
+        return retrect;
     }
-
-    delete[] pts4;
-
-    cv::Rect bRect = cvrect.boundingRect();
-    Rect r = {bRect.x, bRect.y, bRect.width, bRect.height};
-    Point centrpt = {int(lroundf(cvrect.center.x)), int(lroundf(cvrect.center.y))};
-    Size szsz = {int(lroundf(cvrect.size.width)), int(lroundf(cvrect.size.height))};
-
-    RotatedRect retrect = {(Contour){rpts, 4}, r, centrpt, szsz, cvrect.angle};
-    return retrect;
 }
 
 struct RotatedRect2f MinAreaRect2f(PointVector pts){
-    cv::RotatedRect cvrect = cv::minAreaRect(*pts);
+    try {
+        cv::RotatedRect cvrect = cv::minAreaRect(*pts);
 
-    Point2f* rpts = new Point2f[4];
-    cv::Point2f* pts4 = new cv::Point2f[4];
-    cvrect.points(pts4);
+        Point2f* rpts = new Point2f[4];
+        cv::Point2f* pts4 = new cv::Point2f[4];
+        cvrect.points(pts4);
 
-    for (size_t j = 0; j < 4; j++) {
-        Point2f pt = {pts4[j].x, pts4[j].y};
-        rpts[j] = pt;
+        for (size_t j = 0; j < 4; j++) {
+            Point2f pt = {pts4[j].x, pts4[j].y};
+            rpts[j] = pt;
+        }
+
+        delete[] pts4;
+
+        cv::Rect bRect = cvrect.boundingRect();
+        Rect r = {bRect.x, bRect.y, bRect.width, bRect.height};
+        Point2f centrpt = {cvrect.center.x, cvrect.center.y};
+        Size2f szsz = {cvrect.size.width, cvrect.size.height};
+
+        RotatedRect2f retrect = {(Contour2f){rpts, 4}, r, centrpt, szsz, cvrect.angle};
+        return retrect;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        RotatedRect2f retrect;
+        return retrect;
     }
-
-    delete[] pts4;
-
-    cv::Rect bRect = cvrect.boundingRect();
-    Rect r = {bRect.x, bRect.y, bRect.width, bRect.height};
-    Point2f centrpt = {cvrect.center.x, cvrect.center.y};
-    Size2f szsz = {cvrect.size.width, cvrect.size.height};
-
-    RotatedRect2f retrect = {(Contour2f){rpts, 4}, r, centrpt, szsz, cvrect.angle};
-    return retrect;
 }
 
 void MinEnclosingCircle(PointVector pts, Point2f* center, float* radius){
-    cv::Point2f center2f;
-    cv::minEnclosingCircle(*pts, center2f, *radius);
-    center->x = center2f.x;
-    center->y = center2f.y;
+    try {
+        cv::Point2f center2f;
+        cv::minEnclosingCircle(*pts, center2f, *radius);
+        center->x = center2f.x;
+        center->y = center2f.y;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 PointsVector FindContours(Mat src, Mat hierarchy, int mode, int method) {
-    PointsVector contours = new std::vector<std::vector<cv::Point> >;
-    cv::findContours(*src, *contours, *hierarchy, mode, method);
+    try {
+        PointsVector contours = new std::vector<std::vector<cv::Point> >;
+        cv::findContours(*src, *contours, *hierarchy, mode, method);
 
-    return contours;
+        return contours;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 double PointPolygonTest(PointVector pts, Point pt, bool measureDist) {
-	cv::Point2f pt1(pt.x, pt.y);
+    try {
+        cv::Point2f pt1(pt.x, pt.y);
 
-  return cv::pointPolygonTest(*pts, pt1, measureDist);
+        return cv::pointPolygonTest(*pts, pt1, measureDist);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 int ConnectedComponents(Mat src, Mat labels, int connectivity, int ltype, int ccltype){
-    return cv::connectedComponents(*src, *labels, connectivity, ltype, ccltype);
+    try {
+        return cv::connectedComponents(*src, *labels, connectivity, ltype, ccltype);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 
 int ConnectedComponentsWithStats(Mat src, Mat labels, Mat stats, Mat centroids,
-    int connectivity, int ltype, int ccltype){
-    return cv::connectedComponentsWithStats(*src, *labels, *stats, *centroids, connectivity, ltype, ccltype);
+    int connectivity, int ltype, int ccltype) {
+    try {
+        return cv::connectedComponentsWithStats(*src, *labels, *stats, *centroids, connectivity, ltype, ccltype);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 Mat GetStructuringElement(int shape, Size ksize) {
-    cv::Size sz(ksize.width, ksize.height);
-    return new cv::Mat(cv::getStructuringElement(shape, sz));
+    try {
+        cv::Size sz(ksize.width, ksize.height);
+        return new cv::Mat(cv::getStructuringElement(shape, sz));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 Scalar MorphologyDefaultBorderValue(){
-    cv::Scalar cs = cv::morphologyDefaultBorderValue();
-    return (Scalar){cs[0],cs[1],cs[2],cs[3]};
+    try {
+        cv::Scalar cs = cv::morphologyDefaultBorderValue();
+        return (Scalar){cs[0],cs[1],cs[2],cs[3]};
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Scalar scal = Scalar();
+        return scal;
+    }
 }
 
 void MorphologyEx(Mat src, Mat dst, int op, Mat kernel) {
-    cv::morphologyEx(*src, *dst, op, *kernel);
+    try {
+        cv::morphologyEx(*src, *dst, op, *kernel);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void MorphologyExWithParams(Mat src, Mat dst, int op, Mat kernel, Point pt, int iterations, int borderType) {
-    cv::Point pt1(pt.x, pt.y);
-    cv::morphologyEx(*src, *dst, op, *kernel, pt1, iterations, borderType);
+    try {
+        cv::Point pt1(pt.x, pt.y);
+        cv::morphologyEx(*src, *dst, op, *kernel, pt1, iterations, borderType);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void GaussianBlur(Mat src, Mat dst, Size ps, double sX, double sY, int bt) {
-    cv::Size sz(ps.width, ps.height);
-    cv::GaussianBlur(*src, *dst, sz, sX, sY, bt);
+    try {
+        cv::Size sz(ps.width, ps.height);
+        cv::GaussianBlur(*src, *dst, sz, sX, sY, bt);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 Mat GetGaussianKernel(int ksize, double sigma, int ktype){
-    return new cv::Mat(cv::getGaussianKernel(ksize, sigma, ktype));
+    try {
+        return new cv::Mat(cv::getGaussianKernel(ksize, sigma, ktype));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
-void Laplacian(Mat src, Mat dst, int dDepth, int kSize, double scale, double delta,
-               int borderType) {
-    cv::Laplacian(*src, *dst, dDepth, kSize, scale, delta, borderType);
+void Laplacian(Mat src, Mat dst, int dDepth, int kSize, double scale, double delta, int borderType) {
+    try {
+        cv::Laplacian(*src, *dst, dDepth, kSize, scale, delta, borderType);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
-void Scharr(Mat src, Mat dst, int dDepth, int dx, int dy, double scale, double delta,
-            int borderType) {
-    cv::Scharr(*src, *dst, dDepth, dx, dy, scale, delta, borderType);
+void Scharr(Mat src, Mat dst, int dDepth, int dx, int dy, double scale, double delta, int borderType) {
+    try {
+        cv::Scharr(*src, *dst, dDepth, dx, dy, scale, delta, borderType);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void MedianBlur(Mat src, Mat dst, int ksize) {
-    cv::medianBlur(*src, *dst, ksize);
+    try {
+        cv::medianBlur(*src, *dst, ksize);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Canny(Mat src, Mat edges, double t1, double t2) {
-    cv::Canny(*src, *edges, t1, t2);
+    try {
+        cv::Canny(*src, *edges, t1, t2);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void CornerSubPix(Mat img, Mat corners, Size winSize, Size zeroZone, TermCriteria criteria) {
-    cv::Size wsz(winSize.width, winSize.height);
-    cv::Size zsz(zeroZone.width, zeroZone.height);
-    cv::cornerSubPix(*img, *corners, wsz, zsz, *criteria);
+    try {
+        cv::Size wsz(winSize.width, winSize.height);
+        cv::Size zsz(zeroZone.width, zeroZone.height);
+        cv::cornerSubPix(*img, *corners, wsz, zsz, *criteria);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void GoodFeaturesToTrack(Mat img, Mat corners, int maxCorners, double quality, double minDist) {
-    cv::goodFeaturesToTrack(*img, *corners, maxCorners, quality, minDist);
+    try {
+        cv::goodFeaturesToTrack(*img, *corners, maxCorners, quality, minDist);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void GrabCut(Mat img, Mat mask, Rect r, Mat bgdModel, Mat fgdModel, int iterCount, int mode) {
-    cv::Rect cvRect = cv::Rect(r.x, r.y, r.width, r.height);
-    cv::grabCut(*img, *mask, cvRect, *bgdModel, *fgdModel, iterCount, mode);
+    try {
+        cv::Rect cvRect = cv::Rect(r.x, r.y, r.width, r.height);
+        cv::grabCut(*img, *mask, cvRect, *bgdModel, *fgdModel, iterCount, mode);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void HoughCircles(Mat src, Mat circles, int method, double dp, double minDist) {
-    cv::HoughCircles(*src, *circles, method, dp, minDist);
+    try {
+        cv::HoughCircles(*src, *circles, method, dp, minDist);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void HoughCirclesWithParams(Mat src, Mat circles, int method, double dp, double minDist,
                             double param1, double param2, int minRadius, int maxRadius) {
-    cv::HoughCircles(*src, *circles, method, dp, minDist, param1, param2, minRadius, maxRadius);
+    try {
+        cv::HoughCircles(*src, *circles, method, dp, minDist, param1, param2, minRadius, maxRadius);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void HoughLines(Mat src, Mat lines, double rho, double theta, int threshold) {
-    cv::HoughLines(*src, *lines, rho, theta, threshold);
+    try {
+        cv::HoughLines(*src, *lines, rho, theta, threshold);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void HoughLinesP(Mat src, Mat lines, double rho, double theta, int threshold) {
-    cv::HoughLinesP(*src, *lines, rho, theta, threshold);
+    try {
+        cv::HoughLinesP(*src, *lines, rho, theta, threshold);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void HoughLinesPWithParams(Mat src, Mat lines, double rho, double theta, int threshold, double minLineLength, double maxLineGap) {
-    cv::HoughLinesP(*src, *lines, rho, theta, threshold, minLineLength, maxLineGap);
+    try {
+        cv::HoughLinesP(*src, *lines, rho, theta, threshold, minLineLength, maxLineGap);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void HoughLinesPointSet(Mat points, Mat lines, int linesMax, int threshold,
                         double minRho, double  maxRho, double rhoStep,
                         double minTheta, double maxTheta, double thetaStep) {
-    cv::HoughLinesPointSet(*points, *lines, linesMax, threshold,
-                           minRho, maxRho, rhoStep, minTheta, maxTheta, thetaStep );
+    try {
+        cv::HoughLinesPointSet(*points, *lines, linesMax, threshold,
+            minRho, maxRho, rhoStep, minTheta, maxTheta, thetaStep );
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Integral(Mat src, Mat sum, Mat sqsum, Mat tilted) {
-    cv::integral(*src, *sum, *sqsum, *tilted);
+    try {
+        cv::integral(*src, *sum, *sqsum, *tilted);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 double Threshold(Mat src, Mat dst, double thresh, double maxvalue, int typ) {
-    return cv::threshold(*src, *dst, thresh, maxvalue, typ);
+    try {
+        return cv::threshold(*src, *dst, thresh, maxvalue, typ);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
-void AdaptiveThreshold(Mat src, Mat dst, double maxValue, int adaptiveMethod, int thresholdType,
-                       int blockSize, double c) {
-    cv::adaptiveThreshold(*src, *dst, maxValue, adaptiveMethod, thresholdType, blockSize, c);
+void AdaptiveThreshold(Mat src, Mat dst, double maxValue, int adaptiveMethod, int thresholdType, int blockSize, double c) {
+    try {
+        cv::adaptiveThreshold(*src, *dst, maxValue, adaptiveMethod, thresholdType, blockSize, c);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void ArrowedLine(Mat img, Point pt1, Point pt2, Scalar color, int thickness) {
-    cv::Point p1(pt1.x, pt1.y);
-    cv::Point p2(pt2.x, pt2.y);
-    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+    try {
+        cv::Point p1(pt1.x, pt1.y);
+        cv::Point p2(pt2.x, pt2.y);
+        cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 
-    cv::arrowedLine(*img, p1, p2, c, thickness);
+        cv::arrowedLine(*img, p1, p2, c, thickness);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 bool ClipLine(Size imgSize, Point pt1, Point pt2) {
-	cv::Size sz(imgSize.width, imgSize.height);
-	cv::Point p1(pt1.x, pt1.y);
-	cv::Point p2(pt2.x, pt2.y);
+    try {
+        cv::Size sz(imgSize.width, imgSize.height);
+        cv::Point p1(pt1.x, pt1.y);
+        cv::Point p2(pt2.x, pt2.y);
 
-	return	cv::clipLine(sz, p1, p2);
+        return cv::clipLine(sz, p1, p2);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 void Circle(Mat img, Point center, int radius, Scalar color, int thickness) {
-    cv::Point p1(center.x, center.y);
-    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+    try {
+        cv::Point p1(center.x, center.y);
+        cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 
-    cv::circle(*img, p1, radius, c, thickness);
+        cv::circle(*img, p1, radius, c, thickness);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void CircleWithParams(Mat img, Point center, int radius, Scalar color, int thickness, int lineType, int shift) {
-    cv::Point p1(center.x, center.y);
-    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+    try {
+        cv::Point p1(center.x, center.y);
+        cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 
-    cv::circle(*img, p1, radius, c, thickness, lineType, shift);
+        cv::circle(*img, p1, radius, c, thickness, lineType, shift);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
-void Ellipse(Mat img, Point center, Point axes, double angle, double
-             startAngle, double endAngle, Scalar color, int thickness) {
-    cv::Point p1(center.x, center.y);
-    cv::Point p2(axes.x, axes.y);
-    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+void Ellipse(Mat img, Point center, Point axes, double angle, double startAngle, double endAngle, Scalar color, int thickness) {
+    try {
+        cv::Point p1(center.x, center.y);
+        cv::Point p2(axes.x, axes.y);
+        cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 
-    cv::ellipse(*img, p1, p2, angle, startAngle, endAngle, c, thickness);
+        cv::ellipse(*img, p1, p2, angle, startAngle, endAngle, c, thickness);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
-void EllipseWithParams(Mat img, Point center, Point axes, double angle, double
-             startAngle, double endAngle, Scalar color, int thickness, int lineType, int shift) {
-    cv::Point p1(center.x, center.y);
-    cv::Point p2(axes.x, axes.y);
-    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+void EllipseWithParams(Mat img, Point center, Point axes, double angle, double startAngle, double endAngle, Scalar color, int thickness, int lineType, int shift) {
+    try {
+        cv::Point p1(center.x, center.y);
+        cv::Point p2(axes.x, axes.y);
+        cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 
-    cv::ellipse(*img, p1, p2, angle, startAngle, endAngle, c, thickness, lineType, shift);
+        cv::ellipse(*img, p1, p2, angle, startAngle, endAngle, c, thickness, lineType, shift);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Line(Mat img, Point pt1, Point pt2, Scalar color, int thickness) {
-    cv::Point p1(pt1.x, pt1.y);
-    cv::Point p2(pt2.x, pt2.y);
-    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+    try {
+        cv::Point p1(pt1.x, pt1.y);
+        cv::Point p2(pt2.x, pt2.y);
+        cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 
-    cv::line(*img, p1, p2, c, thickness);
+        cv::line(*img, p1, p2, c, thickness);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Rectangle(Mat img, Rect r, Scalar color, int thickness) {
-    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
-    cv::rectangle(
-        *img,
-        cv::Point(r.x, r.y),
-        cv::Point(r.x + r.width, r.y + r.height),
-        c,
-        thickness,
-        cv::LINE_AA
-    );
+    try {
+        cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+        cv::rectangle(
+            *img,
+            cv::Point(r.x, r.y),
+            cv::Point(r.x + r.width, r.y + r.height),
+            c,
+            thickness,
+            cv::LINE_AA
+        );
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void RectangleWithParams(Mat img, Rect r, Scalar color, int thickness, int lineType, int shift) {
-    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
-    cv::rectangle(
-        *img,
-        cv::Point(r.x, r.y),
-        cv::Point(r.x + r.width, r.y + r.height),
-        c,
-        thickness,
-        lineType,
-        shift
-    );
+    try {
+        cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+        cv::rectangle(
+            *img,
+            cv::Point(r.x, r.y),
+            cv::Point(r.x + r.width, r.y + r.height),
+            c,
+            thickness,
+            lineType,
+            shift
+        );
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void FillPoly(Mat img, PointsVector pts, Scalar color) {
-    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+    try {
+        cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 
-    cv::fillPoly(*img, *pts, c);
+        cv::fillPoly(*img, *pts, c);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void FillPolyWithParams(Mat img, PointsVector pts, Scalar color, int lineType, int shift, Point offset) {
-    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+    try {
+        cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 
-    cv::fillPoly(*img, *pts, c, lineType, shift, cv::Point(offset.x, offset.y));
+        cv::fillPoly(*img, *pts, c, lineType, shift, cv::Point(offset.x, offset.y));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Polylines(Mat img, PointsVector pts, bool isClosed, Scalar color,int thickness) {
-    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+    try {
+        cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
 
-    cv::polylines(*img, *pts, isClosed, c, thickness);
+        cv::polylines(*img, *pts, isClosed, c, thickness);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 struct Size GetTextSize(const char* text, int fontFace, double fontScale, int thickness) {
-    return GetTextSizeWithBaseline(text, fontFace, fontScale, thickness, NULL);
+    try {
+        return GetTextSizeWithBaseline(text, fontFace, fontScale, thickness, NULL);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Size size = {0, 0};
+        return size;
+    }
 }
 
 struct Size GetTextSizeWithBaseline(const char* text, int fontFace, double fontScale, int thickness, int* baesline) {
-    cv::Size sz = cv::getTextSize(text, fontFace, fontScale, thickness, baesline);
-    Size size = {sz.width, sz.height};
-    return size;
+    try {
+        cv::Size sz = cv::getTextSize(text, fontFace, fontScale, thickness, baesline);
+        Size size = {sz.width, sz.height};
+        return size;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Size size = {0, 0};
+        return size;
+    }
 }
 
-void PutText(Mat img, const char* text, Point org, int fontFace, double fontScale,
-             Scalar color, int thickness) {
-    cv::Point pt(org.x, org.y);
-    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
-    cv::putText(*img, text, pt, fontFace, fontScale, c, thickness);
+void PutText(Mat img, const char* text, Point org, int fontFace, double fontScale, Scalar color, int thickness) {
+    try {
+        cv::Point pt(org.x, org.y);
+        cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+        cv::putText(*img, text, pt, fontFace, fontScale, c, thickness);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void PutTextWithParams(Mat img, const char* text, Point org, int fontFace, double fontScale,
                        Scalar color, int thickness, int lineType, bool bottomLeftOrigin) {
-    cv::Point pt(org.x, org.y);
-    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
-    cv::putText(*img, text, pt, fontFace, fontScale, c, thickness, lineType, bottomLeftOrigin);
+    try {
+        cv::Point pt(org.x, org.y);
+        cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+        cv::putText(*img, text, pt, fontFace, fontScale, c, thickness, lineType, bottomLeftOrigin);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Resize(Mat src, Mat dst, Size dsize, double fx, double fy, int interp) {
-    cv::Size sz(dsize.width, dsize.height);
-    cv::resize(*src, *dst, sz, fx, fy, interp);
+    try {
+        cv::Size sz(dsize.width, dsize.height);
+        cv::resize(*src, *dst, sz, fx, fy, interp);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void GetRectSubPix(Mat src, Size patchSize, Point center, Mat dst) {
-    cv::Size sz(patchSize.width, patchSize.height);
-    cv::Point pt(center.x, center.y);
-    cv::getRectSubPix(*src, sz, pt, *dst);
+    try {
+        cv::Size sz(patchSize.width, patchSize.height);
+        cv::Point pt(center.x, center.y);
+        cv::getRectSubPix(*src, sz, pt, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 Mat GetRotationMatrix2D(Point center, double angle, double scale) {
-    cv::Point pt(center.x, center.y);
-    return new  cv::Mat(cv::getRotationMatrix2D(pt, angle, scale));
+    try {
+        cv::Point pt(center.x, center.y);
+        return new cv::Mat(cv::getRotationMatrix2D(pt, angle, scale));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 void WarpAffine(Mat src, Mat dst, Mat m, Size dsize) {
-    cv::Size sz(dsize.width, dsize.height);
-    cv::warpAffine(*src, *dst, *m, sz);
+    try {
+        cv::Size sz(dsize.width, dsize.height);
+        cv::warpAffine(*src, *dst, *m, sz);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void WarpAffineWithParams(Mat src, Mat dst, Mat rot_mat, Size dsize, int flags, int borderMode,
                           Scalar borderValue) {
-    cv::Size sz(dsize.width, dsize.height);
-    cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
-    cv::warpAffine(*src, *dst, *rot_mat, sz, flags, borderMode, c);
+    try {
+        cv::Size sz(dsize.width, dsize.height);
+        cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
+        cv::warpAffine(*src, *dst, *rot_mat, sz, flags, borderMode, c);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void WarpPerspective(Mat src, Mat dst, Mat m, Size dsize) {
-    cv::Size sz(dsize.width, dsize.height);
-    cv::warpPerspective(*src, *dst, *m, sz);
+    try {
+        cv::Size sz(dsize.width, dsize.height);
+        cv::warpPerspective(*src, *dst, *m, sz);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void WarpPerspectiveWithParams(Mat src, Mat dst, Mat rot_mat, Size dsize, int flags, int borderMode,
                                Scalar borderValue) {
-    cv::Size sz(dsize.width, dsize.height);
-    cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
-    cv::warpPerspective(*src, *dst, *rot_mat, sz, flags, borderMode, c);
+    try {
+        cv::Size sz(dsize.width, dsize.height);
+        cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
+        cv::warpPerspective(*src, *dst, *rot_mat, sz, flags, borderMode, c);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Watershed(Mat image, Mat markers) {
-    cv::watershed(*image, *markers);
+    try {
+        cv::watershed(*image, *markers);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void ApplyColorMap(Mat src, Mat dst, int colormap) {
-    cv::applyColorMap(*src, *dst, colormap);
+    try {
+        cv::applyColorMap(*src, *dst, colormap);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void ApplyCustomColorMap(Mat src, Mat dst, Mat colormap) {
-    cv::applyColorMap(*src, *dst, *colormap);
+    try {
+        cv::applyColorMap(*src, *dst, *colormap);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 Mat GetPerspectiveTransform(PointVector src, PointVector dst) {
-    std::vector<cv::Point2f> src_pts;
-    copyPointVectorToPoint2fVector(src, &src_pts);
+    try {
+        std::vector<cv::Point2f> src_pts;
+        copyPointVectorToPoint2fVector(src, &src_pts);
 
-    std::vector<cv::Point2f> dst_pts;
-    copyPointVectorToPoint2fVector(dst, &dst_pts);
+        std::vector<cv::Point2f> dst_pts;
+        copyPointVectorToPoint2fVector(dst, &dst_pts);
 
-    return new cv::Mat(cv::getPerspectiveTransform(src_pts, dst_pts));
+        return new cv::Mat(cv::getPerspectiveTransform(src_pts, dst_pts));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 Mat GetPerspectiveTransform2f(Point2fVector src, Point2fVector dst) {
-    return new cv::Mat(cv::getPerspectiveTransform(*src, *dst));
+    try {
+        return new cv::Mat(cv::getPerspectiveTransform(*src, *dst));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 Mat GetAffineTransform(PointVector src, PointVector dst) {
-    std::vector<cv::Point2f> src_pts;
-    copyPointVectorToPoint2fVector(src, &src_pts);
+    try {
+        std::vector<cv::Point2f> src_pts;
+        copyPointVectorToPoint2fVector(src, &src_pts);
 
-    std::vector<cv::Point2f> dst_pts;
-    copyPointVectorToPoint2fVector(dst, &dst_pts);
+        std::vector<cv::Point2f> dst_pts;
+        copyPointVectorToPoint2fVector(dst, &dst_pts);
 
-    return new cv::Mat(cv::getAffineTransform(src_pts, dst_pts));
+        return new cv::Mat(cv::getAffineTransform(src_pts, dst_pts));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 Mat GetAffineTransform2f(Point2fVector src, Point2fVector dst) {
-    return new cv::Mat(cv::getAffineTransform(*src, *dst));
+    try {
+        return new cv::Mat(cv::getAffineTransform(*src, *dst));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 Mat FindHomography(Mat src, Mat dst, int method, double ransacReprojThreshold, Mat mask, const int maxIters, const double confidence) {
-    return new cv::Mat(cv::findHomography(*src, *dst, method, ransacReprojThreshold, *mask, maxIters, confidence));
+    try {
+        return new cv::Mat(cv::findHomography(*src, *dst, method, ransacReprojThreshold, *mask, maxIters, confidence));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 void DrawContours(Mat src, PointsVector contours, int contourIdx, Scalar color, int thickness) {
-    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
-    cv::drawContours(*src, *contours, contourIdx, c, thickness);
+    try {
+        cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+        cv::drawContours(*src, *contours, contourIdx, c, thickness);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void DrawContoursWithParams(Mat src, PointsVector contours, int contourIdx, Scalar color, int thickness, int lineType, Mat hierarchy, int maxLevel, Point offset) {
-    cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
-    cv::Point offsetPt(offset.x, offset.y);
+    try {
+        cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);
+        cv::Point offsetPt(offset.x, offset.y);
 
-    std::vector<cv::Vec4i> vecHierarchy;
-    if (hierarchy->empty() == 0) {
-        for (int j = 0; j < hierarchy->cols; ++j) {
-            vecHierarchy.push_back(hierarchy->at<cv::Vec4i>(0, j));
+        std::vector<cv::Vec4i> vecHierarchy;
+        if (hierarchy->empty() == 0) {
+            for (int j = 0; j < hierarchy->cols; ++j) {
+                vecHierarchy.push_back(hierarchy->at<cv::Vec4i>(0, j));
+            }
         }
+        cv::drawContours(*src, *contours, contourIdx, c, thickness, lineType, vecHierarchy, maxLevel, offsetPt);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
-    cv::drawContours(*src, *contours, contourIdx, c, thickness, lineType, vecHierarchy, maxLevel, offsetPt);
 }
 
 void Sobel(Mat src, Mat dst, int ddepth, int dx, int dy, int ksize, double scale, double delta, int borderType) {
-	cv::Sobel(*src, *dst, ddepth, dx, dy, ksize, scale, delta, borderType);
+    try {
+        cv::Sobel(*src, *dst, ddepth, dx, dy, ksize, scale, delta, borderType);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void SpatialGradient(Mat src, Mat dx, Mat dy, int ksize, int borderType) {
-	cv::spatialGradient(*src, *dx, *dy, ksize, borderType);
+    try {
+        cv::spatialGradient(*src, *dx, *dy, ksize, borderType);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 
 void Remap(Mat src, Mat dst, Mat map1, Mat map2, int interpolation, int borderMode, Scalar borderValue) {
+    try {
         cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
         cv::remap(*src, *dst, *map1, *map2, interpolation, borderMode, c);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Filter2D(Mat src, Mat dst, int ddepth, Mat kernel, Point anchor, double delta, int borderType) {
+    try {
         cv::Point anchorPt(anchor.x, anchor.y);
         cv::filter2D(*src, *dst, ddepth, *kernel, anchorPt, delta, borderType);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void SepFilter2D(Mat src, Mat dst, int ddepth, Mat kernelX, Mat kernelY, Point anchor, double delta, int borderType) {
-	cv::Point anchorPt(anchor.x, anchor.y);
-	cv::sepFilter2D(*src, *dst, ddepth, *kernelX, *kernelY, anchorPt, delta, borderType);
+    try {
+        cv::Point anchorPt(anchor.x, anchor.y);
+        cv::sepFilter2D(*src, *dst, ddepth, *kernelX, *kernelY, anchorPt, delta, borderType);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void LogPolar(Mat src, Mat dst, Point center, double m, int flags) {
-	cv::Point2f centerPt(center.x, center.y);
-	cv::logPolar(*src, *dst, centerPt, m, flags);
+    try {
+        cv::Point2f centerPt(center.x, center.y);
+        cv::logPolar(*src, *dst, centerPt, m, flags);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void FitLine(PointVector pts, Mat line, int distType, double param, double reps, double aeps) {
-	cv::fitLine(*pts, *line, distType, param, reps, aeps);
+    try {
+        cv::fitLine(*pts, *line, distType, param, reps, aeps);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void LinearPolar(Mat src, Mat dst, Point center, double maxRadius, int flags) {
-	cv::Point2f centerPt(center.x, center.y);
-	cv::linearPolar(*src, *dst, centerPt, maxRadius, flags);
+    try {
+        cv::Point2f centerPt(center.x, center.y);
+        cv::linearPolar(*src, *dst, centerPt, maxRadius, flags);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 double MatchShapes(PointVector contour1, PointVector contour2, int method, double parameter) {
-    return cv::matchShapes(*contour1, *contour2, method, parameter);
+    try {
+        return cv::matchShapes(*contour1, *contour2, method, parameter);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 CLAHE CLAHE_Create() {
-    return new cv::Ptr<cv::CLAHE>(cv::createCLAHE());
+    try {
+        return new cv::Ptr<cv::CLAHE>(cv::createCLAHE());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 CLAHE CLAHE_CreateWithParams(double clipLimit, Size tileGridSize) {
-    cv::Size sz(tileGridSize.width, tileGridSize.height);
-    return new cv::Ptr<cv::CLAHE>(cv::createCLAHE(clipLimit, sz));
+    try {
+        cv::Size sz(tileGridSize.width, tileGridSize.height);
+        return new cv::Ptr<cv::CLAHE>(cv::createCLAHE(clipLimit, sz));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void CLAHE_Close(CLAHE c) {
@@ -672,55 +1118,108 @@ void CLAHE_Close(CLAHE c) {
 }
 
 void CLAHE_Apply(CLAHE c, Mat src, Mat dst) {
-    (*c)->apply(*src, *dst);
+    try {
+        (*c)->apply(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void InvertAffineTransform(Mat src, Mat dst) {
-	cv::invertAffineTransform(*src, *dst);
+    try {
+        cv::invertAffineTransform(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 Point2f PhaseCorrelate(Mat src1, Mat src2, Mat window, double* response) {
-    cv::Point2d result = cv::phaseCorrelate(*src1, *src2, *window, response);
+    try {
+        cv::Point2d result = cv::phaseCorrelate(*src1, *src2, *window, response);
 
-    Point2f result2f = {
-        .x = float(result.x),
-        .y = float(result.y),
-    };
-    return result2f;
+        Point2f result2f = {
+            .x = float(result.x),
+            .y = float(result.y),
+        };
+        return result2f;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Point2f result2f = {
+            .x = 0.0,
+            .y = 0.0,
+        };
+        return result2f;
+    }
 }
 
 void CreateHanningWindow(Mat dst, Size size, int typ) {
-    cv::Size sz(size.width, size.height);
-    cv::createHanningWindow(*dst, sz, typ);
+    try {
+        cv::Size sz(size.width, size.height);
+        cv::createHanningWindow(*dst, sz, typ);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_Accumulate(Mat src, Mat dst) {
-    cv::accumulate(*src, *dst);
+    try {
+        cv::accumulate(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 void Mat_AccumulateWithMask(Mat src, Mat dst, Mat mask) {
-    cv::accumulate(*src, *dst, *mask);
+    try {
+        cv::accumulate(*src, *dst, *mask);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_AccumulateSquare(Mat src, Mat dst) {
-    cv::accumulateSquare(*src, *dst);
+    try {
+        cv::accumulateSquare(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_AccumulateSquareWithMask(Mat src, Mat dst, Mat mask) {
-    cv::accumulateSquare(*src, *dst, *mask);
+    try {
+        cv::accumulateSquare(*src, *dst, *mask);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_AccumulateProduct(Mat src1, Mat src2, Mat dst) {
-    cv::accumulateProduct(*src1, *src2, *dst);
+    try {
+        cv::accumulateProduct(*src1, *src2, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_AccumulateProductWithMask(Mat src1, Mat src2, Mat dst, Mat mask) {
-    cv::accumulateProduct(*src1, *src2, *dst, *mask);
+    try {
+        cv::accumulateProduct(*src1, *src2, *dst, *mask);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_AccumulatedWeighted(Mat src, Mat dst, double alpha) {
-    cv::accumulateWeighted(*src, *dst, alpha);
+    try {
+        cv::accumulateWeighted(*src, *dst, alpha);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Mat_AccumulatedWeightedWithMask(Mat src, Mat dst, double alpha, Mat mask) {
-    cv::accumulateWeighted(*src, *dst, alpha, *mask);
+    try {
+        cv::accumulateWeighted(*src, *dst, alpha, *mask);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }

--- a/imgproc.go
+++ b/imgproc.go
@@ -35,16 +35,16 @@ func ApproxPolyDP(curve PointVector, epsilon float64, closed bool) PointVector {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/dc0/group__imgproc__shape.html#ga014b28e56cb8854c0de4a211cb2be656
-func ConvexHull(points PointVector, hull *Mat, clockwise bool, returnPoints bool) {
-	C.ConvexHull(points.p, hull.p, C.bool(clockwise), C.bool(returnPoints))
+func ConvexHull(points PointVector, hull *Mat, clockwise bool, returnPoints bool) error {
+	return OpenCVResult(C.ConvexHull(points.p, hull.p, C.bool(clockwise), C.bool(returnPoints)))
 }
 
 // ConvexityDefects finds the convexity defects of a contour.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/dc0/group__imgproc__shape.html#gada4437098113fd8683c932e0567f47ba
-func ConvexityDefects(contour PointVector, hull Mat, result *Mat) {
-	C.ConvexityDefects(contour.p, hull.p, result.p)
+func ConvexityDefects(contour PointVector, hull Mat, result *Mat) error {
+	return OpenCVResult(C.ConvexityDefects(contour.p, hull.p, result.p))
 }
 
 // CvtColor converts an image from one color space to another.
@@ -53,8 +53,8 @@ func ConvexityDefects(contour PointVector, hull Mat, result *Mat) {
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d7/d1b/group__imgproc__misc.html#ga4e0972be5de079fed4e3a10e24ef5ef0
-func CvtColor(src Mat, dst *Mat, code ColorConversionCode) {
-	C.CvtColor(src.p, dst.p, C.int(code))
+func CvtColor(src Mat, dst *Mat, code ColorConversionCode) error {
+	return OpenCVResult(C.CvtColor(src.p, dst.p, C.int(code)))
 }
 
 // Demosaicing converts an image from Bayer pattern to RGB or grayscale.
@@ -63,23 +63,23 @@ func CvtColor(src Mat, dst *Mat, code ColorConversionCode) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/d1b/group__imgproc__color__conversions.html#ga57261f12fccf872a2b2d66daf29d5bd0
-func Demosaicing(src Mat, dst *Mat, code ColorConversionCode) {
-	C.Demosaicing(src.p, dst.p, C.int(code))
+func Demosaicing(src Mat, dst *Mat, code ColorConversionCode) error {
+	return OpenCVResult(C.Demosaicing(src.p, dst.p, C.int(code)))
 }
 
 // EqualizeHist normalizes the brightness and increases the contrast of the image.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/dc7/group__imgproc__hist.html#ga7e54091f0c937d49bf84152a16f76d6e
-func EqualizeHist(src Mat, dst *Mat) {
-	C.EqualizeHist(src.p, dst.p)
+func EqualizeHist(src Mat, dst *Mat) error {
+	return OpenCVResult(C.EqualizeHist(src.p, dst.p))
 }
 
 // CalcHist Calculates a histogram of a set of images
 //
 // For futher details, please see:
 // https://docs.opencv.org/master/d6/dc7/group__imgproc__hist.html#ga6ca1876785483836f72a77ced8ea759a
-func CalcHist(src []Mat, channels []int, mask Mat, hist *Mat, size []int, ranges []float64, acc bool) {
+func CalcHist(src []Mat, channels []int, mask Mat, hist *Mat, size []int, ranges []float64, acc bool) error {
 	cMatArray := make([]C.Mat, len(src))
 	for i, r := range src {
 		cMatArray[i] = r.p
@@ -114,14 +114,14 @@ func CalcHist(src []Mat, channels []int, mask Mat, hist *Mat, size []int, ranges
 	rangeVector.val = (*C.float)(&rangeFloats[0])
 	rangeVector.length = (C.int)(len(rangeFloats))
 
-	C.CalcHist(cMats, chansVector, mask.p, hist.p, sizeVector, rangeVector, C.bool(acc))
+	return OpenCVResult(C.CalcHist(cMats, chansVector, mask.p, hist.p, sizeVector, rangeVector, C.bool(acc)))
 }
 
 // CalcBackProject calculates the back projection of a histogram.
 //
 // For futher details, please see:
 // https://docs.opencv.org/3.4/d6/dc7/group__imgproc__hist.html#ga3a0af640716b456c3d14af8aee12e3ca
-func CalcBackProject(src []Mat, channels []int, hist Mat, backProject *Mat, ranges []float64, uniform bool) {
+func CalcBackProject(src []Mat, channels []int, hist Mat, backProject *Mat, ranges []float64, uniform bool) error {
 	cMatArray := make([]C.Mat, len(src))
 	for i, r := range src {
 		cMatArray[i] = r.p
@@ -148,7 +148,7 @@ func CalcBackProject(src []Mat, channels []int, hist Mat, backProject *Mat, rang
 	rangeVector.val = (*C.float)(&rangeFloats[0])
 	rangeVector.length = (C.int)(len(rangeFloats))
 
-	C.CalcBackProject(cMats, chansVector, hist.p, backProject.p, rangeVector, C.bool(uniform))
+	return OpenCVResult(C.CalcBackProject(cMats, chansVector, hist.p, backProject.p, rangeVector, C.bool(uniform)))
 }
 
 // HistCompMethod is the method for Histogram comparison
@@ -226,60 +226,60 @@ func ClipLine(imgSize image.Point, pt1 image.Point, pt2 image.Point) bool {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#ga9d7064d478c95d60003cf839430737ed
-func BilateralFilter(src Mat, dst *Mat, diameter int, sigmaColor float64, sigmaSpace float64) {
-	C.BilateralFilter(src.p, dst.p, C.int(diameter), C.double(sigmaColor), C.double(sigmaSpace))
+func BilateralFilter(src Mat, dst *Mat, diameter int, sigmaColor float64, sigmaSpace float64) error {
+	return OpenCVResult(C.BilateralFilter(src.p, dst.p, C.int(diameter), C.double(sigmaColor), C.double(sigmaSpace)))
 }
 
 // Blur blurs an image Mat using a normalized box filter.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#ga8c45db9afe636703801b0b2e440fce37
-func Blur(src Mat, dst *Mat, ksize image.Point) {
+func Blur(src Mat, dst *Mat, ksize image.Point) error {
 	pSize := C.struct_Size{
 		width:  C.int(ksize.X),
 		height: C.int(ksize.Y),
 	}
 
-	C.Blur(src.p, dst.p, pSize)
+	return OpenCVResult(C.Blur(src.p, dst.p, pSize))
 }
 
 // BoxFilter blurs an image using the box filter.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#gad533230ebf2d42509547d514f7d3fbc3
-func BoxFilter(src Mat, dst *Mat, depth int, ksize image.Point) {
+func BoxFilter(src Mat, dst *Mat, depth int, ksize image.Point) error {
 	pSize := C.struct_Size{
 		height: C.int(ksize.X),
 		width:  C.int(ksize.Y),
 	}
-	C.BoxFilter(src.p, dst.p, C.int(depth), pSize)
+	return OpenCVResult(C.BoxFilter(src.p, dst.p, C.int(depth), pSize))
 }
 
 // SqBoxFilter calculates the normalized sum of squares of the pixel values overlapping the filter.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#ga045028184a9ef65d7d2579e5c4bff6c0
-func SqBoxFilter(src Mat, dst *Mat, depth int, ksize image.Point) {
+func SqBoxFilter(src Mat, dst *Mat, depth int, ksize image.Point) error {
 	pSize := C.struct_Size{
 		height: C.int(ksize.X),
 		width:  C.int(ksize.Y),
 	}
-	C.SqBoxFilter(src.p, dst.p, C.int(depth), pSize)
+	return OpenCVResult(C.SqBoxFilter(src.p, dst.p, C.int(depth), pSize))
 }
 
 // Dilate dilates an image by using a specific structuring element.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#ga4ff0f3318642c4f469d0e11f242f3b6c
-func Dilate(src Mat, dst *Mat, kernel Mat) {
-	C.Dilate(src.p, dst.p, kernel.p)
+func Dilate(src Mat, dst *Mat, kernel Mat) error {
+	return OpenCVResult(C.Dilate(src.p, dst.p, kernel.p))
 }
 
 // DilateWithParams dilates an image by using a specific structuring element.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#ga4ff0f3318642c4f469d0e11f242f3b6c
-func DilateWithParams(src Mat, dst *Mat, kernel Mat, anchor image.Point, iterations, borderType BorderType, borderValue color.RGBA) {
+func DilateWithParams(src Mat, dst *Mat, kernel Mat, anchor image.Point, iterations, borderType BorderType, borderValue color.RGBA) error {
 	cAnchor := C.struct_Point{
 		x: C.int(anchor.X),
 		y: C.int(anchor.Y),
@@ -292,7 +292,7 @@ func DilateWithParams(src Mat, dst *Mat, kernel Mat, anchor image.Point, iterati
 		val4: C.double(borderValue.A),
 	}
 
-	C.DilateWithParams(src.p, dst.p, kernel.p, cAnchor, C.int(iterations), C.int(borderType), bv)
+	return OpenCVResult(C.DilateWithParams(src.p, dst.p, kernel.p, cAnchor, C.int(iterations), C.int(borderType), bv))
 }
 
 // DistanceTransformLabelTypes are the types of the DistanceTransform algorithm flag
@@ -325,29 +325,29 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/d1b/group__imgproc__misc.html#ga8a0b7fdfcb7a13dde018988ba3a43042
-func DistanceTransform(src Mat, dst *Mat, labels *Mat, distType DistanceTypes, maskSize DistanceTransformMasks, labelType DistanceTransformLabelTypes) {
-	C.DistanceTransform(src.p, dst.p, labels.p, C.int(distType), C.int(maskSize), C.int(labelType))
+func DistanceTransform(src Mat, dst *Mat, labels *Mat, distType DistanceTypes, maskSize DistanceTransformMasks, labelType DistanceTransformLabelTypes) error {
+	return OpenCVResult(C.DistanceTransform(src.p, dst.p, labels.p, C.int(distType), C.int(maskSize), C.int(labelType)))
 }
 
 // Erode erodes an image by using a specific structuring element.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#gaeb1e0c1033e3f6b891a25d0511362aeb
-func Erode(src Mat, dst *Mat, kernel Mat) {
-	C.Erode(src.p, dst.p, kernel.p)
+func Erode(src Mat, dst *Mat, kernel Mat) error {
+	return OpenCVResult(C.Erode(src.p, dst.p, kernel.p))
 }
 
 // ErodeWithParams erodes an image by using a specific structuring element.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#gaeb1e0c1033e3f6b891a25d0511362aeb
-func ErodeWithParams(src Mat, dst *Mat, kernel Mat, anchor image.Point, iterations, borderType int) {
+func ErodeWithParams(src Mat, dst *Mat, kernel Mat, anchor image.Point, iterations, borderType int) error {
 	cAnchor := C.struct_Point{
 		x: C.int(anchor.X),
 		y: C.int(anchor.Y),
 	}
 
-	C.ErodeWithParams(src.p, dst.p, kernel.p, cAnchor, C.int(iterations), C.int(borderType))
+	return OpenCVResult(C.ErodeWithParams(src.p, dst.p, kernel.p, cAnchor, C.int(iterations), C.int(borderType)))
 }
 
 // ErodeWithParamsAndBorderValue erodes an image by using a specific structuring
@@ -356,7 +356,7 @@ func ErodeWithParams(src Mat, dst *Mat, kernel Mat, anchor image.Point, iteratio
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#gaeb1e0c1033e3f6b891a25d0511362aeb
-func ErodeWithParamsAndBorderValue(src Mat, dst *Mat, kernel Mat, anchor image.Point, iterations, borderType int, borderValue Scalar) {
+func ErodeWithParamsAndBorderValue(src Mat, dst *Mat, kernel Mat, anchor image.Point, iterations, borderType int, borderValue Scalar) error {
 	cAnchor := C.struct_Point{
 		x: C.int(anchor.X),
 		y: C.int(anchor.Y),
@@ -369,7 +369,7 @@ func ErodeWithParamsAndBorderValue(src Mat, dst *Mat, kernel Mat, anchor image.P
 		val4: C.double(borderValue.Val4),
 	}
 
-	C.ErodeWithParamsAndBorderValue(src.p, dst.p, kernel.p, cAnchor, C.int(iterations), C.int(borderType), bv)
+	return OpenCVResult(C.ErodeWithParamsAndBorderValue(src.p, dst.p, kernel.p, cAnchor, C.int(iterations), C.int(borderType), bv))
 }
 
 // RetrievalMode is the mode of the contour retrieval algorithm.
@@ -437,7 +437,7 @@ func BoundingRect(contour PointVector) image.Rectangle {
 //
 // For further Details, please see:
 // https://docs.opencv.org/3.3.0/d3/dc0/group__imgproc__shape.html#gaf78d467e024b4d7936cf9397185d2f5c
-func BoxPoints(rect RotatedRect, pts *Mat) {
+func BoxPoints(rect RotatedRect, pts *Mat) error {
 	rPoints := toCPoints(rect.Points)
 
 	rRect := C.struct_Rect{
@@ -465,14 +465,14 @@ func BoxPoints(rect RotatedRect, pts *Mat) {
 		angle:        C.double(rect.Angle),
 	}
 
-	C.BoxPoints(r, pts.p)
+	return OpenCVResult(C.BoxPoints(r, pts.p))
 }
 
 // BoxPoints finds the four vertices of a rotated rect. Useful to draw the rotated rectangle.
 //
 // For further Details, please see:
 // https://docs.opencv.org/3.3.0/d3/dc0/group__imgproc__shape.html#gaf78d467e024b4d7936cf9397185d2f5c
-func BoxPoints2f(rect RotatedRect2f, pts *Mat) {
+func BoxPoints2f(rect RotatedRect2f, pts *Mat) error {
 	rPoints := toCPoints2f(rect.Points)
 
 	rRect := C.struct_Rect{
@@ -500,7 +500,7 @@ func BoxPoints2f(rect RotatedRect2f, pts *Mat) {
 		angle:        C.double(rect.Angle),
 	}
 
-	C.BoxPoints2f(r, pts.p)
+	return OpenCVResult(C.BoxPoints2f(r, pts.p))
 }
 
 // ContourArea calculates a contour area.
@@ -762,8 +762,8 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/df/dfb/group__imgproc__object.html#ga586ebfb0a7fb604b35a23d85391329be
-func MatchTemplate(image Mat, templ Mat, result *Mat, method TemplateMatchMode, mask Mat) {
-	C.MatchTemplate(image.p, templ.p, result.p, C.int(method), mask.p)
+func MatchTemplate(image Mat, templ Mat, result *Mat, method TemplateMatchMode, mask Mat) error {
+	return OpenCVResult(C.MatchTemplate(image.p, templ.p, result.p, C.int(method), mask.p))
 }
 
 // Moments calculates all of the moments up to the third order of a polygon
@@ -807,24 +807,24 @@ func Moments(src Mat, binaryImage bool) map[string]float64 {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#gaf9bba239dfca11654cb7f50f889fc2ff
-func PyrDown(src Mat, dst *Mat, ksize image.Point, borderType BorderType) {
+func PyrDown(src Mat, dst *Mat, ksize image.Point, borderType BorderType) error {
 	pSize := C.struct_Size{
 		height: C.int(ksize.X),
 		width:  C.int(ksize.Y),
 	}
-	C.PyrDown(src.p, dst.p, pSize, C.int(borderType))
+	return OpenCVResult(C.PyrDown(src.p, dst.p, pSize, C.int(borderType)))
 }
 
 // PyrUp upsamples an image and then blurs it.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#gada75b59bdaaca411ed6fee10085eb784
-func PyrUp(src Mat, dst *Mat, ksize image.Point, borderType BorderType) {
+func PyrUp(src Mat, dst *Mat, ksize image.Point, borderType BorderType) error {
 	pSize := C.struct_Size{
 		height: C.int(ksize.X),
 		width:  C.int(ksize.Y),
 	}
-	C.PyrUp(src.p, dst.p, pSize, C.int(borderType))
+	return OpenCVResult(C.PyrUp(src.p, dst.p, pSize, C.int(borderType)))
 }
 
 // MorphologyDefaultBorder returns "magic" border value for erosion and dilation.
@@ -841,20 +841,20 @@ func MorphologyDefaultBorderValue() Scalar {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#ga67493776e3ad1a3df63883829375201f
-func MorphologyEx(src Mat, dst *Mat, op MorphType, kernel Mat) {
-	C.MorphologyEx(src.p, dst.p, C.int(op), kernel.p)
+func MorphologyEx(src Mat, dst *Mat, op MorphType, kernel Mat) error {
+	return OpenCVResult(C.MorphologyEx(src.p, dst.p, C.int(op), kernel.p))
 }
 
 // MorphologyExWithParams performs advanced morphological transformations.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#ga67493776e3ad1a3df63883829375201f
-func MorphologyExWithParams(src Mat, dst *Mat, op MorphType, kernel Mat, iterations int, borderType BorderType) {
+func MorphologyExWithParams(src Mat, dst *Mat, op MorphType, kernel Mat, iterations int, borderType BorderType) error {
 	pt := C.struct_Point{
 		x: C.int(-1),
 		y: C.int(-1),
 	}
-	C.MorphologyExWithParams(src.p, dst.p, C.int(op), kernel.p, pt, C.int(iterations), C.int(borderType))
+	return OpenCVResult(C.MorphologyExWithParams(src.p, dst.p, C.int(op), kernel.p, pt, C.int(iterations), C.int(borderType)))
 }
 
 // MorphShape is the shape of the structuring element used for Morphing operations.
@@ -950,13 +950,13 @@ const (
 // For further details, please see:
 // http://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#gaabe8c836e97159a9193fb0b11ac52cf1
 func GaussianBlur(src Mat, dst *Mat, ksize image.Point, sigmaX float64,
-	sigmaY float64, borderType BorderType) {
+	sigmaY float64, borderType BorderType) error {
 	pSize := C.struct_Size{
 		width:  C.int(ksize.X),
 		height: C.int(ksize.Y),
 	}
 
-	C.GaussianBlur(src.p, dst.p, pSize, C.double(sigmaX), C.double(sigmaY), C.int(borderType))
+	return OpenCVResult(C.GaussianBlur(src.p, dst.p, pSize, C.double(sigmaX), C.double(sigmaY), C.int(borderType)))
 }
 
 // GetGaussianKernel returns Gaussian filter coefficients.
@@ -979,16 +979,16 @@ func GetGaussianKernelWithParams(ksize int, sigma float64, ktype MatType) Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#gacea54f142e81b6758cb6f375ce782c8d
-func Sobel(src Mat, dst *Mat, ddepth MatType, dx, dy, ksize int, scale, delta float64, borderType BorderType) {
-	C.Sobel(src.p, dst.p, C.int(ddepth), C.int(dx), C.int(dy), C.int(ksize), C.double(scale), C.double(delta), C.int(borderType))
+func Sobel(src Mat, dst *Mat, ddepth MatType, dx, dy, ksize int, scale, delta float64, borderType BorderType) error {
+	return OpenCVResult(C.Sobel(src.p, dst.p, C.int(ddepth), C.int(dx), C.int(dy), C.int(ksize), C.double(scale), C.double(delta), C.int(borderType)))
 }
 
 // SpatialGradient calculates the first order image derivative in both x and y using a Sobel operator.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#ga405d03b20c782b65a4daf54d233239a2
-func SpatialGradient(src Mat, dx, dy *Mat, ksize MatType, borderType BorderType) {
-	C.SpatialGradient(src.p, dx.p, dy.p, C.int(ksize), C.int(borderType))
+func SpatialGradient(src Mat, dx, dy *Mat, ksize MatType, borderType BorderType) error {
+	return OpenCVResult(C.SpatialGradient(src.p, dx.p, dy.p, C.int(ksize), C.int(borderType)))
 }
 
 // Laplacian calculates the Laplacian of an image.
@@ -996,8 +996,8 @@ func SpatialGradient(src Mat, dx, dy *Mat, ksize MatType, borderType BorderType)
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#gad78703e4c8fe703d479c1860d76429e6
 func Laplacian(src Mat, dst *Mat, dDepth MatType, size int, scale float64,
-	delta float64, borderType BorderType) {
-	C.Laplacian(src.p, dst.p, C.int(dDepth), C.int(size), C.double(scale), C.double(delta), C.int(borderType))
+	delta float64, borderType BorderType) error {
+	return OpenCVResult(C.Laplacian(src.p, dst.p, C.int(dDepth), C.int(size), C.double(scale), C.double(delta), C.int(borderType)))
 }
 
 // Scharr calculates the first x- or y- image derivative using Scharr operator.
@@ -1005,16 +1005,16 @@ func Laplacian(src Mat, dst *Mat, dDepth MatType, size int, scale float64,
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#gaa13106761eedf14798f37aa2d60404c9
 func Scharr(src Mat, dst *Mat, dDepth MatType, dx int, dy int, scale float64,
-	delta float64, borderType BorderType) {
-	C.Scharr(src.p, dst.p, C.int(dDepth), C.int(dx), C.int(dy), C.double(scale), C.double(delta), C.int(borderType))
+	delta float64, borderType BorderType) error {
+	return OpenCVResult(C.Scharr(src.p, dst.p, C.int(dDepth), C.int(dx), C.int(dy), C.double(scale), C.double(delta), C.int(borderType)))
 }
 
 // MedianBlur blurs an image using the median filter.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#ga564869aa33e58769b4469101aac458f9
-func MedianBlur(src Mat, dst *Mat, ksize int) {
-	C.MedianBlur(src.p, dst.p, C.int(ksize))
+func MedianBlur(src Mat, dst *Mat, ksize int) error {
+	return OpenCVResult(C.MedianBlur(src.p, dst.p, C.int(ksize)))
 }
 
 // Canny finds edges in an image using the Canny algorithm.
@@ -1027,8 +1027,8 @@ func MedianBlur(src Mat, dst *Mat, ksize int) {
 //
 // For further details, please see:
 // http://docs.opencv.org/master/dd/d1a/group__imgproc__feature.html#ga04723e007ed888ddf11d9ba04e2232de
-func Canny(src Mat, edges *Mat, t1 float32, t2 float32) {
-	C.Canny(src.p, edges.p, C.double(t1), C.double(t2))
+func Canny(src Mat, edges *Mat, t1 float32, t2 float32) error {
+	return OpenCVResult(C.Canny(src.p, edges.p, C.double(t1), C.double(t2)))
 }
 
 // CornerSubPix Refines the corner locations. The function iterates to find
@@ -1036,7 +1036,7 @@ func Canny(src Mat, edges *Mat, t1 float32, t2 float32) {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dd/d1a/group__imgproc__feature.html#ga354e0d7c86d0d9da75de9b9701a9a87e
-func CornerSubPix(img Mat, corners *Mat, winSize image.Point, zeroZone image.Point, criteria TermCriteria) {
+func CornerSubPix(img Mat, corners *Mat, winSize image.Point, zeroZone image.Point, criteria TermCriteria) error {
 	winSz := C.struct_Size{
 		width:  C.int(winSize.X),
 		height: C.int(winSize.Y),
@@ -1047,8 +1047,7 @@ func CornerSubPix(img Mat, corners *Mat, winSize image.Point, zeroZone image.Poi
 		height: C.int(zeroZone.Y),
 	}
 
-	C.CornerSubPix(img.p, corners.p, winSz, zeroSz, criteria.p)
-	return
+	return OpenCVResult(C.CornerSubPix(img.p, corners.p, winSz, zeroSz, criteria.p))
 }
 
 // GoodFeaturesToTrack determines strong corners on an image. The function
@@ -1056,8 +1055,8 @@ func CornerSubPix(img Mat, corners *Mat, winSize image.Point, zeroZone image.Poi
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dd/d1a/group__imgproc__feature.html#ga1d6bb77486c8f92d79c8793ad995d541
-func GoodFeaturesToTrack(img Mat, corners *Mat, maxCorners int, quality float64, minDist float64) {
-	C.GoodFeaturesToTrack(img.p, corners.p, C.int(maxCorners), C.double(quality), C.double(minDist))
+func GoodFeaturesToTrack(img Mat, corners *Mat, maxCorners int, quality float64, minDist float64) error {
+	return OpenCVResult(C.GoodFeaturesToTrack(img.p, corners.p, C.int(maxCorners), C.double(quality), C.double(minDist)))
 }
 
 // GrabCutMode is the flag for GrabCut algorithm.
@@ -1082,7 +1081,7 @@ const (
 // The function implements the GrabCut image segmentation algorithm.
 // For further details, please see:
 // https://docs.opencv.org/master/d7/d1b/group__imgproc__misc.html#ga909c1dda50efcbeaa3ce126be862b37f
-func GrabCut(img Mat, mask *Mat, r image.Rectangle, bgdModel *Mat, fgdModel *Mat, iterCount int, mode GrabCutMode) {
+func GrabCut(img Mat, mask *Mat, r image.Rectangle, bgdModel *Mat, fgdModel *Mat, iterCount int, mode GrabCutMode) error {
 	cRect := C.struct_Rect{
 		x:      C.int(r.Min.X),
 		y:      C.int(r.Min.Y),
@@ -1090,7 +1089,7 @@ func GrabCut(img Mat, mask *Mat, r image.Rectangle, bgdModel *Mat, fgdModel *Mat
 		height: C.int(r.Size().Y),
 	}
 
-	C.GrabCut(img.p, mask.p, cRect, bgdModel.p, fgdModel.p, C.int(iterCount), C.int(mode))
+	return OpenCVResult(C.GrabCut(img.p, mask.p, cRect, bgdModel.p, fgdModel.p, C.int(iterCount), C.int(mode)))
 }
 
 // HoughMode is the type for Hough transform variants.
@@ -1118,8 +1117,8 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dd/d1a/group__imgproc__feature.html#ga47849c3be0d0406ad3ca45db65a25d2d
-func HoughCircles(src Mat, circles *Mat, method HoughMode, dp, minDist float64) {
-	C.HoughCircles(src.p, circles.p, C.int(method), C.double(dp), C.double(minDist))
+func HoughCircles(src Mat, circles *Mat, method HoughMode, dp, minDist float64) error {
+	return OpenCVResult(C.HoughCircles(src.p, circles.p, C.int(method), C.double(dp), C.double(minDist)))
 }
 
 // HoughCirclesWithParams finds circles in a grayscale image using the Hough
@@ -1127,8 +1126,8 @@ func HoughCircles(src Mat, circles *Mat, method HoughMode, dp, minDist float64) 
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dd/d1a/group__imgproc__feature.html#ga47849c3be0d0406ad3ca45db65a25d2d
-func HoughCirclesWithParams(src Mat, circles *Mat, method HoughMode, dp, minDist, param1, param2 float64, minRadius, maxRadius int) {
-	C.HoughCirclesWithParams(src.p, circles.p, C.int(method), C.double(dp), C.double(minDist), C.double(param1), C.double(param2), C.int(minRadius), C.int(maxRadius))
+func HoughCirclesWithParams(src Mat, circles *Mat, method HoughMode, dp, minDist, param1, param2 float64, minRadius, maxRadius int) error {
+	return OpenCVResult(C.HoughCirclesWithParams(src.p, circles.p, C.int(method), C.double(dp), C.double(minDist), C.double(param1), C.double(param2), C.int(minRadius), C.int(maxRadius)))
 }
 
 // HoughLines implements the standard or standard multi-scale Hough transform
@@ -1137,8 +1136,8 @@ func HoughCirclesWithParams(src Mat, circles *Mat, method HoughMode, dp, minDist
 //
 // For further details, please see:
 // http://docs.opencv.org/master/dd/d1a/group__imgproc__feature.html#ga46b4e588934f6c8dfd509cc6e0e4545a
-func HoughLines(src Mat, lines *Mat, rho float32, theta float32, threshold int) {
-	C.HoughLines(src.p, lines.p, C.double(rho), C.double(theta), C.int(threshold))
+func HoughLines(src Mat, lines *Mat, rho float32, theta float32, threshold int) error {
+	return OpenCVResult(C.HoughLines(src.p, lines.p, C.double(rho), C.double(theta), C.int(threshold)))
 }
 
 // HoughLinesP implements the probabilistic Hough transform
@@ -1147,11 +1146,12 @@ func HoughLines(src Mat, lines *Mat, rho float32, theta float32, threshold int) 
 //
 // For further details, please see:
 // http://docs.opencv.org/master/dd/d1a/group__imgproc__feature.html#ga8618180a5948286384e3b7ca02f6feeb
-func HoughLinesP(src Mat, lines *Mat, rho float32, theta float32, threshold int) {
-	C.HoughLinesP(src.p, lines.p, C.double(rho), C.double(theta), C.int(threshold))
+func HoughLinesP(src Mat, lines *Mat, rho float32, theta float32, threshold int) error {
+	return OpenCVResult(C.HoughLinesP(src.p, lines.p, C.double(rho), C.double(theta), C.int(threshold)))
 }
-func HoughLinesPWithParams(src Mat, lines *Mat, rho float32, theta float32, threshold int, minLineLength float32, maxLineGap float32) {
-	C.HoughLinesPWithParams(src.p, lines.p, C.double(rho), C.double(theta), C.int(threshold), C.double(minLineLength), C.double(maxLineGap))
+
+func HoughLinesPWithParams(src Mat, lines *Mat, rho float32, theta float32, threshold int, minLineLength float32, maxLineGap float32) error {
+	return OpenCVResult(C.HoughLinesPWithParams(src.p, lines.p, C.double(rho), C.double(theta), C.int(threshold), C.double(minLineLength), C.double(maxLineGap)))
 }
 
 // HoughLinesPointSet implements the Hough transform algorithm for line
@@ -1162,17 +1162,17 @@ func HoughLinesPWithParams(src Mat, lines *Mat, rho float32, theta float32, thre
 // https://docs.opencv.org/master/dd/d1a/group__imgproc__feature.html#ga2858ef61b4e47d1919facac2152a160e
 func HoughLinesPointSet(points Mat, lines *Mat, linesMax int, threshold int,
 	minRho float32, maxRho float32, rhoStep float32,
-	minTheta float32, maxTheta float32, thetaStep float32) {
-	C.HoughLinesPointSet(points.p, lines.p, C.int(linesMax), C.int(threshold),
+	minTheta float32, maxTheta float32, thetaStep float32) error {
+	return OpenCVResult(C.HoughLinesPointSet(points.p, lines.p, C.int(linesMax), C.int(threshold),
 		C.double(minRho), C.double(maxRho), C.double(rhoStep),
-		C.double(minTheta), C.double(maxTheta), C.double(thetaStep))
+		C.double(minTheta), C.double(maxTheta), C.double(thetaStep)))
 }
 
 // Integral calculates one or more integral images for the source image.
 // For further details, please see:
 // https://docs.opencv.org/master/d7/d1b/group__imgproc__misc.html#ga97b87bec26908237e8ba0f6e96d23e28
-func Integral(src Mat, sum *Mat, sqsum *Mat, tilted *Mat) {
-	C.Integral(src.p, sum.p, sqsum.p, tilted.p)
+func Integral(src Mat, sum *Mat, sqsum *Mat, tilted *Mat) error {
+	return OpenCVResult(C.Integral(src.p, sum.p, sqsum.p, tilted.p))
 }
 
 // ThresholdType type of threshold operation.
@@ -1227,8 +1227,8 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/d1b/group__imgproc__misc.html#ga72b913f352e4a1b1b397736707afcde3
-func AdaptiveThreshold(src Mat, dst *Mat, maxValue float32, adaptiveTyp AdaptiveThresholdType, typ ThresholdType, blockSize int, c float32) {
-	C.AdaptiveThreshold(src.p, dst.p, C.double(maxValue), C.int(adaptiveTyp), C.int(typ), C.int(blockSize), C.double(c))
+func AdaptiveThreshold(src Mat, dst *Mat, maxValue float32, adaptiveTyp AdaptiveThresholdType, typ ThresholdType, blockSize int, c float32) error {
+	return OpenCVResult(C.AdaptiveThreshold(src.p, dst.p, C.double(maxValue), C.int(adaptiveTyp), C.int(typ), C.int(blockSize), C.double(c)))
 }
 
 // ArrowedLine draws a arrow segment pointing from the first point
@@ -1236,7 +1236,7 @@ func AdaptiveThreshold(src Mat, dst *Mat, maxValue float32, adaptiveTyp Adaptive
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#ga0a165a3ca093fd488ac709fdf10c05b2
-func ArrowedLine(img *Mat, pt1 image.Point, pt2 image.Point, c color.RGBA, thickness int) {
+func ArrowedLine(img *Mat, pt1 image.Point, pt2 image.Point, c color.RGBA, thickness int) error {
 	sp1 := C.struct_Point{
 		x: C.int(pt1.X),
 		y: C.int(pt1.Y),
@@ -1254,14 +1254,14 @@ func ArrowedLine(img *Mat, pt1 image.Point, pt2 image.Point, c color.RGBA, thick
 		val4: C.double(c.A),
 	}
 
-	C.ArrowedLine(img.p, sp1, sp2, sColor, C.int(thickness))
+	return OpenCVResult(C.ArrowedLine(img.p, sp1, sp2, sColor, C.int(thickness)))
 }
 
 // Circle draws a circle.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#gaf10604b069374903dbd0f0488cb43670
-func Circle(img *Mat, center image.Point, radius int, c color.RGBA, thickness int) {
+func Circle(img *Mat, center image.Point, radius int, c color.RGBA, thickness int) error {
 	pc := C.struct_Point{
 		x: C.int(center.X),
 		y: C.int(center.Y),
@@ -1274,14 +1274,14 @@ func Circle(img *Mat, center image.Point, radius int, c color.RGBA, thickness in
 		val4: C.double(c.A),
 	}
 
-	C.Circle(img.p, pc, C.int(radius), sColor, C.int(thickness))
+	return OpenCVResult(C.Circle(img.p, pc, C.int(radius), sColor, C.int(thickness)))
 }
 
 // CircleWithParams draws a circle.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#gaf10604b069374903dbd0f0488cb43670
-func CircleWithParams(img *Mat, center image.Point, radius int, c color.RGBA, thickness int, lineType LineType, shift int) {
+func CircleWithParams(img *Mat, center image.Point, radius int, c color.RGBA, thickness int, lineType LineType, shift int) error {
 	pc := C.struct_Point{
 		x: C.int(center.X),
 		y: C.int(center.Y),
@@ -1294,14 +1294,14 @@ func CircleWithParams(img *Mat, center image.Point, radius int, c color.RGBA, th
 		val4: C.double(c.A),
 	}
 
-	C.CircleWithParams(img.p, pc, C.int(radius), sColor, C.int(thickness), C.int(lineType), C.int(shift))
+	return OpenCVResult(C.CircleWithParams(img.p, pc, C.int(radius), sColor, C.int(thickness), C.int(lineType), C.int(shift)))
 }
 
 // Ellipse draws a simple or thick elliptic arc or fills an ellipse sector.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#ga28b2267d35786f5f890ca167236cbc69
-func Ellipse(img *Mat, center, axes image.Point, angle, startAngle, endAngle float64, c color.RGBA, thickness int) {
+func Ellipse(img *Mat, center, axes image.Point, angle, startAngle, endAngle float64, c color.RGBA, thickness int) error {
 	pc := C.struct_Point{
 		x: C.int(center.X),
 		y: C.int(center.Y),
@@ -1318,14 +1318,14 @@ func Ellipse(img *Mat, center, axes image.Point, angle, startAngle, endAngle flo
 		val4: C.double(c.A),
 	}
 
-	C.Ellipse(img.p, pc, pa, C.double(angle), C.double(startAngle), C.double(endAngle), sColor, C.int(thickness))
+	return OpenCVResult(C.Ellipse(img.p, pc, pa, C.double(angle), C.double(startAngle), C.double(endAngle), sColor, C.int(thickness)))
 }
 
 // Ellipse draws a simple or thick elliptic arc or fills an ellipse sector.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#ga28b2267d35786f5f890ca167236cbc69
-func EllipseWithParams(img *Mat, center, axes image.Point, angle, startAngle, endAngle float64, c color.RGBA, thickness int, lineType LineType, shift int) {
+func EllipseWithParams(img *Mat, center, axes image.Point, angle, startAngle, endAngle float64, c color.RGBA, thickness int, lineType LineType, shift int) error {
 	pc := C.struct_Point{
 		x: C.int(center.X),
 		y: C.int(center.Y),
@@ -1342,14 +1342,14 @@ func EllipseWithParams(img *Mat, center, axes image.Point, angle, startAngle, en
 		val4: C.double(c.A),
 	}
 
-	C.EllipseWithParams(img.p, pc, pa, C.double(angle), C.double(startAngle), C.double(endAngle), sColor, C.int(thickness), C.int(lineType), C.int(shift))
+	return OpenCVResult(C.EllipseWithParams(img.p, pc, pa, C.double(angle), C.double(startAngle), C.double(endAngle), sColor, C.int(thickness), C.int(lineType), C.int(shift)))
 }
 
 // Line draws a line segment connecting two points.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#ga7078a9fae8c7e7d13d24dac2520ae4a2
-func Line(img *Mat, pt1 image.Point, pt2 image.Point, c color.RGBA, thickness int) {
+func Line(img *Mat, pt1 image.Point, pt2 image.Point, c color.RGBA, thickness int) error {
 	sp1 := C.struct_Point{
 		x: C.int(pt1.X),
 		y: C.int(pt1.Y),
@@ -1367,7 +1367,7 @@ func Line(img *Mat, pt1 image.Point, pt2 image.Point, c color.RGBA, thickness in
 		val4: C.double(c.A),
 	}
 
-	C.Line(img.p, sp1, sp2, sColor, C.int(thickness))
+	return OpenCVResult(C.Line(img.p, sp1, sp2, sColor, C.int(thickness)))
 }
 
 // Rectangle draws a simple, thick, or filled up-right rectangle.
@@ -1375,7 +1375,7 @@ func Line(img *Mat, pt1 image.Point, pt2 image.Point, c color.RGBA, thickness in
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#ga346ac30b5c74e9b5137576c9ee9e0e8c
-func Rectangle(img *Mat, r image.Rectangle, c color.RGBA, thickness int) {
+func Rectangle(img *Mat, r image.Rectangle, c color.RGBA, thickness int) error {
 	cRect := C.struct_Rect{
 		x:      C.int(r.Min.X),
 		y:      C.int(r.Min.Y),
@@ -1390,7 +1390,7 @@ func Rectangle(img *Mat, r image.Rectangle, c color.RGBA, thickness int) {
 		val4: C.double(c.A),
 	}
 
-	C.Rectangle(img.p, cRect, sColor, C.int(thickness))
+	return OpenCVResult(C.Rectangle(img.p, cRect, sColor, C.int(thickness)))
 }
 
 // RectangleWithParams draws a simple, thick, or filled up-right rectangle.
@@ -1398,7 +1398,7 @@ func Rectangle(img *Mat, r image.Rectangle, c color.RGBA, thickness int) {
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#ga346ac30b5c74e9b5137576c9ee9e0e8c
-func RectangleWithParams(img *Mat, r image.Rectangle, c color.RGBA, thickness int, lineType LineType, shift int) {
+func RectangleWithParams(img *Mat, r image.Rectangle, c color.RGBA, thickness int, lineType LineType, shift int) error {
 	cRect := C.struct_Rect{
 		x:      C.int(r.Min.X),
 		y:      C.int(r.Min.Y),
@@ -1413,14 +1413,14 @@ func RectangleWithParams(img *Mat, r image.Rectangle, c color.RGBA, thickness in
 		val4: C.double(c.A),
 	}
 
-	C.RectangleWithParams(img.p, cRect, sColor, C.int(thickness), C.int(lineType), C.int(shift))
+	return OpenCVResult(C.RectangleWithParams(img.p, cRect, sColor, C.int(thickness), C.int(lineType), C.int(shift)))
 }
 
 // FillPoly fills the area bounded by one or more polygons.
 //
 // For more information, see:
 // https://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#gaf30888828337aa4c6b56782b5dfbd4b7
-func FillPoly(img *Mat, pts PointsVector, c color.RGBA) {
+func FillPoly(img *Mat, pts PointsVector, c color.RGBA) error {
 	sColor := C.struct_Scalar{
 		val1: C.double(c.B),
 		val2: C.double(c.G),
@@ -1428,14 +1428,14 @@ func FillPoly(img *Mat, pts PointsVector, c color.RGBA) {
 		val4: C.double(c.A),
 	}
 
-	C.FillPoly(img.p, pts.p, sColor)
+	return OpenCVResult(C.FillPoly(img.p, pts.p, sColor))
 }
 
 // FillPolyWithParams fills the area bounded by one or more polygons.
 //
 // For more information, see:
 // https://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#gaf30888828337aa4c6b56782b5dfbd4b7
-func FillPolyWithParams(img *Mat, pts PointsVector, c color.RGBA, lineType LineType, shift int, offset image.Point) {
+func FillPolyWithParams(img *Mat, pts PointsVector, c color.RGBA, lineType LineType, shift int, offset image.Point) error {
 	offsetP := C.struct_Point{
 		x: C.int(offset.X),
 		y: C.int(offset.Y),
@@ -1448,14 +1448,14 @@ func FillPolyWithParams(img *Mat, pts PointsVector, c color.RGBA, lineType LineT
 		val4: C.double(c.A),
 	}
 
-	C.FillPolyWithParams(img.p, pts.p, sColor, C.int(lineType), C.int(shift), offsetP)
+	return OpenCVResult(C.FillPolyWithParams(img.p, pts.p, sColor, C.int(lineType), C.int(shift), offsetP))
 }
 
 // Polylines draws several polygonal curves.
 //
 // For more information, see:
 // https://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#ga1ea127ffbbb7e0bfc4fd6fd2eb64263c
-func Polylines(img *Mat, pts PointsVector, isClosed bool, c color.RGBA, thickness int) {
+func Polylines(img *Mat, pts PointsVector, isClosed bool, c color.RGBA, thickness int) error {
 	sColor := C.struct_Scalar{
 		val1: C.double(c.B),
 		val2: C.double(c.G),
@@ -1463,7 +1463,7 @@ func Polylines(img *Mat, pts PointsVector, isClosed bool, c color.RGBA, thicknes
 		val4: C.double(c.A),
 	}
 
-	C.Polylines(img.p, pts.p, C.bool(isClosed), sColor, C.int(thickness))
+	return OpenCVResult(C.Polylines(img.p, pts.p, C.bool(isClosed), sColor, C.int(thickness)))
 }
 
 // HersheyFont are the font libraries included in OpenCV.
@@ -1549,7 +1549,7 @@ func GetTextSizeWithBaseline(text string, fontFace HersheyFont, fontScale float6
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#ga5126f47f883d730f633d74f07456c576
-func PutText(img *Mat, text string, org image.Point, fontFace HersheyFont, fontScale float64, c color.RGBA, thickness int) {
+func PutText(img *Mat, text string, org image.Point, fontFace HersheyFont, fontScale float64, c color.RGBA, thickness int) error {
 	cText := C.CString(text)
 	defer C.free(unsafe.Pointer(cText))
 
@@ -1565,8 +1565,7 @@ func PutText(img *Mat, text string, org image.Point, fontFace HersheyFont, fontS
 		val4: C.double(c.A),
 	}
 
-	C.PutText(img.p, cText, pOrg, C.int(fontFace), C.double(fontScale), sColor, C.int(thickness))
-	return
+	return OpenCVResult(C.PutText(img.p, cText, pOrg, C.int(fontFace), C.double(fontScale), sColor, C.int(thickness)))
 }
 
 // PutTextWithParams draws a text string.
@@ -1576,7 +1575,7 @@ func PutText(img *Mat, text string, org image.Point, fontFace HersheyFont, fontS
 //
 // For further details, please see:
 // http://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#ga5126f47f883d730f633d74f07456c576
-func PutTextWithParams(img *Mat, text string, org image.Point, fontFace HersheyFont, fontScale float64, c color.RGBA, thickness int, lineType LineType, bottomLeftOrigin bool) {
+func PutTextWithParams(img *Mat, text string, org image.Point, fontFace HersheyFont, fontScale float64, c color.RGBA, thickness int, lineType LineType, bottomLeftOrigin bool) error {
 	cText := C.CString(text)
 	defer C.free(unsafe.Pointer(cText))
 
@@ -1592,8 +1591,7 @@ func PutTextWithParams(img *Mat, text string, org image.Point, fontFace HersheyF
 		val4: C.double(c.A),
 	}
 
-	C.PutTextWithParams(img.p, cText, pOrg, C.int(fontFace), C.double(fontScale), sColor, C.int(thickness), C.int(lineType), C.bool(bottomLeftOrigin))
-	return
+	return OpenCVResult(C.PutTextWithParams(img.p, cText, pOrg, C.int(fontFace), C.double(fontScale), sColor, C.int(thickness), C.int(lineType), C.bool(bottomLeftOrigin)))
 }
 
 // InterpolationFlags are bit flags that control the interpolation algorithm
@@ -1639,21 +1637,20 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/da/d54/group__imgproc__transform.html#ga47a974309e9102f5f08231edc7e7529d
-func Resize(src Mat, dst *Mat, sz image.Point, fx, fy float64, interp InterpolationFlags) {
+func Resize(src Mat, dst *Mat, sz image.Point, fx, fy float64, interp InterpolationFlags) error {
 	pSize := C.struct_Size{
 		width:  C.int(sz.X),
 		height: C.int(sz.Y),
 	}
 
-	C.Resize(src.p, dst.p, pSize, C.double(fx), C.double(fy), C.int(interp))
-	return
+	return OpenCVResult(C.Resize(src.p, dst.p, pSize, C.double(fx), C.double(fy), C.int(interp)))
 }
 
 // GetRectSubPix retrieves a pixel rectangle from an image with sub-pixel accuracy.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/da/d54/group__imgproc__transform.html#ga77576d06075c1a4b6ba1a608850cd614
-func GetRectSubPix(src Mat, patchSize image.Point, center image.Point, dst *Mat) {
+func GetRectSubPix(src Mat, patchSize image.Point, center image.Point, dst *Mat) error {
 	sz := C.struct_Size{
 		width:  C.int(patchSize.X),
 		height: C.int(patchSize.Y),
@@ -1662,7 +1659,7 @@ func GetRectSubPix(src Mat, patchSize image.Point, center image.Point, dst *Mat)
 		x: C.int(center.X),
 		y: C.int(center.Y),
 	}
-	C.GetRectSubPix(src.p, sz, pt, dst.p)
+	return OpenCVResult(C.GetRectSubPix(src.p, sz, pt, dst.p))
 }
 
 // GetRotationMatrix2D calculates an affine matrix of 2D rotation.
@@ -1681,20 +1678,20 @@ func GetRotationMatrix2D(center image.Point, angle, scale float64) Mat {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/da/d54/group__imgproc__transform.html#ga0203d9ee5fcd28d40dbc4a1ea4451983
-func WarpAffine(src Mat, dst *Mat, m Mat, sz image.Point) {
+func WarpAffine(src Mat, dst *Mat, m Mat, sz image.Point) error {
 	pSize := C.struct_Size{
 		width:  C.int(sz.X),
 		height: C.int(sz.Y),
 	}
 
-	C.WarpAffine(src.p, dst.p, m.p, pSize)
+	return OpenCVResult(C.WarpAffine(src.p, dst.p, m.p, pSize))
 }
 
 // WarpAffineWithParams applies an affine transformation to an image.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/da/d54/group__imgproc__transform.html#ga0203d9ee5fcd28d40dbc4a1ea4451983
-func WarpAffineWithParams(src Mat, dst *Mat, m Mat, sz image.Point, flags InterpolationFlags, borderType BorderType, borderValue color.RGBA) {
+func WarpAffineWithParams(src Mat, dst *Mat, m Mat, sz image.Point, flags InterpolationFlags, borderType BorderType, borderValue color.RGBA) error {
 	pSize := C.struct_Size{
 		width:  C.int(sz.X),
 		height: C.int(sz.Y),
@@ -1705,7 +1702,7 @@ func WarpAffineWithParams(src Mat, dst *Mat, m Mat, sz image.Point, flags Interp
 		val3: C.double(borderValue.R),
 		val4: C.double(borderValue.A),
 	}
-	C.WarpAffineWithParams(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv)
+	return OpenCVResult(C.WarpAffineWithParams(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv))
 }
 
 // WarpPerspective applies a perspective transformation to an image.
@@ -1713,20 +1710,20 @@ func WarpAffineWithParams(src Mat, dst *Mat, m Mat, sz image.Point, flags Interp
 //
 // For further details, please see:
 // https://docs.opencv.org/master/da/d54/group__imgproc__transform.html#gaf73673a7e8e18ec6963e3774e6a94b87
-func WarpPerspective(src Mat, dst *Mat, m Mat, sz image.Point) {
+func WarpPerspective(src Mat, dst *Mat, m Mat, sz image.Point) error {
 	pSize := C.struct_Size{
 		width:  C.int(sz.X),
 		height: C.int(sz.Y),
 	}
 
-	C.WarpPerspective(src.p, dst.p, m.p, pSize)
+	return OpenCVResult(C.WarpPerspective(src.p, dst.p, m.p, pSize))
 }
 
 // WarpPerspectiveWithParams applies a perspective transformation to an image.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/da/d54/group__imgproc__transform.html#gaf73673a7e8e18ec6963e3774e6a94b87
-func WarpPerspectiveWithParams(src Mat, dst *Mat, m Mat, sz image.Point, flags InterpolationFlags, borderType BorderType, borderValue color.RGBA) {
+func WarpPerspectiveWithParams(src Mat, dst *Mat, m Mat, sz image.Point, flags InterpolationFlags, borderType BorderType, borderValue color.RGBA) error {
 	pSize := C.struct_Size{
 		width:  C.int(sz.X),
 		height: C.int(sz.Y),
@@ -1737,15 +1734,15 @@ func WarpPerspectiveWithParams(src Mat, dst *Mat, m Mat, sz image.Point, flags I
 		val3: C.double(borderValue.R),
 		val4: C.double(borderValue.A),
 	}
-	C.WarpPerspectiveWithParams(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv)
+	return OpenCVResult(C.WarpPerspectiveWithParams(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType), bv))
 }
 
 // Watershed performs a marker-based image segmentation using the watershed algorithm.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/d1b/group__imgproc__misc.html#ga3267243e4d3f95165d55a618c65ac6e1
-func Watershed(image Mat, markers *Mat) {
-	C.Watershed(image.p, markers.p)
+func Watershed(image Mat, markers *Mat) error {
+	return OpenCVResult(C.Watershed(image.p, markers.p))
 }
 
 // ColormapTypes are the 12 GNU Octave/MATLAB equivalent colormaps.
@@ -1778,16 +1775,16 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/d50/group__imgproc__colormap.html#gadf478a5e5ff49d8aa24e726ea6f65d15
-func ApplyColorMap(src Mat, dst *Mat, colormapType ColormapTypes) {
-	C.ApplyColorMap(src.p, dst.p, C.int(colormapType))
+func ApplyColorMap(src Mat, dst *Mat, colormapType ColormapTypes) error {
+	return OpenCVResult(C.ApplyColorMap(src.p, dst.p, C.int(colormapType)))
 }
 
 // ApplyCustomColorMap applies a custom defined colormap on a given image.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/d50/group__imgproc__colormap.html#gacb22288ddccc55f9bd9e6d492b409cae
-func ApplyCustomColorMap(src Mat, dst *Mat, customColormap Mat) {
-	C.ApplyCustomColorMap(src.p, dst.p, customColormap.p)
+func ApplyCustomColorMap(src Mat, dst *Mat, customColormap Mat) error {
+	return OpenCVResult(C.ApplyCustomColorMap(src.p, dst.p, customColormap.p))
 }
 
 // GetPerspectiveTransform returns 3x3 perspective transformation for the
@@ -1847,7 +1844,7 @@ func FindHomography(srcPoints Mat, targetPoints Mat, method HomographyMethod, ra
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#ga746c0625f1781f1ffc9056259103edbc
-func DrawContours(img *Mat, contours PointsVector, contourIdx int, c color.RGBA, thickness int) {
+func DrawContours(img *Mat, contours PointsVector, contourIdx int, c color.RGBA, thickness int) error {
 	sColor := C.struct_Scalar{
 		val1: C.double(c.B),
 		val2: C.double(c.G),
@@ -1855,14 +1852,14 @@ func DrawContours(img *Mat, contours PointsVector, contourIdx int, c color.RGBA,
 		val4: C.double(c.A),
 	}
 
-	C.DrawContours(img.p, contours.p, C.int(contourIdx), sColor, C.int(thickness))
+	return OpenCVResult(C.DrawContours(img.p, contours.p, C.int(contourIdx), sColor, C.int(thickness)))
 }
 
 // DrawContoursWithParams draws contours outlines or filled contours.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/d6e/group__imgproc__draw.html#ga746c0625f1781f1ffc9056259103edbc
-func DrawContoursWithParams(img *Mat, contours PointsVector, contourIdx int, c color.RGBA, thickness int, lineType LineType, hierarchy Mat, maxLevel int, offset image.Point) {
+func DrawContoursWithParams(img *Mat, contours PointsVector, contourIdx int, c color.RGBA, thickness int, lineType LineType, hierarchy Mat, maxLevel int, offset image.Point) error {
 	sColor := C.struct_Scalar{
 		val1: C.double(c.B),
 		val2: C.double(c.G),
@@ -1874,69 +1871,69 @@ func DrawContoursWithParams(img *Mat, contours PointsVector, contourIdx int, c c
 		y: C.int(offset.Y),
 	}
 
-	C.DrawContoursWithParams(img.p, contours.p, C.int(contourIdx), sColor, C.int(thickness), C.int(lineType), hierarchy.p, C.int(maxLevel), offsetP)
+	return OpenCVResult(C.DrawContoursWithParams(img.p, contours.p, C.int(contourIdx), sColor, C.int(thickness), C.int(lineType), hierarchy.p, C.int(maxLevel), offsetP))
 }
 
 // Remap applies a generic geometrical transformation to an image.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/da/d54/group__imgproc__transform.html#gab75ef31ce5cdfb5c44b6da5f3b908ea4
-func Remap(src Mat, dst, map1, map2 *Mat, interpolation InterpolationFlags, borderMode BorderType, borderValue color.RGBA) {
+func Remap(src Mat, dst, map1, map2 *Mat, interpolation InterpolationFlags, borderMode BorderType, borderValue color.RGBA) error {
 	bv := C.struct_Scalar{
 		val1: C.double(borderValue.B),
 		val2: C.double(borderValue.G),
 		val3: C.double(borderValue.R),
 		val4: C.double(borderValue.A),
 	}
-	C.Remap(src.p, dst.p, map1.p, map2.p, C.int(interpolation), C.int(borderMode), bv)
+	return OpenCVResult(C.Remap(src.p, dst.p, map1.p, map2.p, C.int(interpolation), C.int(borderMode), bv))
 }
 
 // Filter2D applies an arbitrary linear filter to an image.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#ga27c049795ce870216ddfb366086b5a04
-func Filter2D(src Mat, dst *Mat, ddepth MatType, kernel Mat, anchor image.Point, delta float64, borderType BorderType) {
+func Filter2D(src Mat, dst *Mat, ddepth MatType, kernel Mat, anchor image.Point, delta float64, borderType BorderType) error {
 	anchorP := C.struct_Point{
 		x: C.int(anchor.X),
 		y: C.int(anchor.Y),
 	}
-	C.Filter2D(src.p, dst.p, C.int(ddepth), kernel.p, anchorP, C.double(delta), C.int(borderType))
+	return OpenCVResult(C.Filter2D(src.p, dst.p, C.int(ddepth), kernel.p, anchorP, C.double(delta), C.int(borderType)))
 }
 
 // SepFilter2D applies a separable linear filter to the image.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#ga910e29ff7d7b105057d1625a4bf6318d
-func SepFilter2D(src Mat, dst *Mat, ddepth MatType, kernelX, kernelY Mat, anchor image.Point, delta float64, borderType BorderType) {
+func SepFilter2D(src Mat, dst *Mat, ddepth MatType, kernelX, kernelY Mat, anchor image.Point, delta float64, borderType BorderType) error {
 	anchorP := C.struct_Point{
 		x: C.int(anchor.X),
 		y: C.int(anchor.Y),
 	}
-	C.SepFilter2D(src.p, dst.p, C.int(ddepth), kernelX.p, kernelY.p, anchorP, C.double(delta), C.int(borderType))
+	return OpenCVResult(C.SepFilter2D(src.p, dst.p, C.int(ddepth), kernelX.p, kernelY.p, anchorP, C.double(delta), C.int(borderType)))
 }
 
 // LogPolar remaps an image to semilog-polar coordinates space.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/da/d54/group__imgproc__transform.html#gaec3a0b126a85b5ca2c667b16e0ae022d
-func LogPolar(src Mat, dst *Mat, center image.Point, m float64, flags InterpolationFlags) {
+func LogPolar(src Mat, dst *Mat, center image.Point, m float64, flags InterpolationFlags) error {
 	centerP := C.struct_Point{
 		x: C.int(center.X),
 		y: C.int(center.Y),
 	}
-	C.LogPolar(src.p, dst.p, centerP, C.double(m), C.int(flags))
+	return OpenCVResult(C.LogPolar(src.p, dst.p, centerP, C.double(m), C.int(flags)))
 }
 
 // LinearPolar remaps an image to polar coordinates space.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/da/d54/group__imgproc__transform.html#gaa38a6884ac8b6e0b9bed47939b5362f3
-func LinearPolar(src Mat, dst *Mat, center image.Point, maxRadius float64, flags InterpolationFlags) {
+func LinearPolar(src Mat, dst *Mat, center image.Point, maxRadius float64, flags InterpolationFlags) error {
 	centerP := C.struct_Point{
 		x: C.int(center.X),
 		y: C.int(center.Y),
 	}
-	C.LinearPolar(src.p, dst.p, centerP, C.double(maxRadius), C.int(flags))
+	return OpenCVResult(C.LinearPolar(src.p, dst.p, centerP, C.double(maxRadius), C.int(flags)))
 }
 
 // DistanceTypes types for Distance Transform and M-estimatorss
@@ -1960,8 +1957,8 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/dc0/group__imgproc__shape.html#gaf849da1fdafa67ee84b1e9a23b93f91f
-func FitLine(pts PointVector, line *Mat, distType DistanceTypes, param, reps, aeps float64) {
-	C.FitLine(pts.p, line.p, C.int(distType), C.double(param), C.double(reps), C.double(aeps))
+func FitLine(pts PointVector, line *Mat, distType DistanceTypes, param, reps, aeps float64) error {
+	return OpenCVResult(C.FitLine(pts.p, line.p, C.int(distType), C.double(param), C.double(reps), C.double(aeps)))
 }
 
 // Shape matching methods.
@@ -2021,12 +2018,12 @@ func (c *CLAHE) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d6/db6/classcv_1_1CLAHE.html#a4e92e0e427de21be8d1fae8dcd862c5e
-func (c *CLAHE) Apply(src Mat, dst *Mat) {
-	C.CLAHE_Apply((C.CLAHE)(c.p), src.p, dst.p)
+func (c *CLAHE) Apply(src Mat, dst *Mat) error {
+	return OpenCVResult(C.CLAHE_Apply((C.CLAHE)(c.p), src.p, dst.p))
 }
 
-func InvertAffineTransform(src Mat, dst *Mat) {
-	C.InvertAffineTransform(src.p, dst.p)
+func InvertAffineTransform(src Mat, dst *Mat) error {
+	return OpenCVResult(C.InvertAffineTransform(src.p, dst.p))
 }
 
 // Apply phaseCorrelate.
@@ -2047,13 +2044,13 @@ func PhaseCorrelate(src1, src2, window Mat) (phaseShift Point2f, response float6
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d7/df3/group__imgproc__motion.html#ga80e5c3de52f6bab3a7c1e60e89308e1b
-func CreateHanningWindow(img *Mat, size image.Point, typ MatType) {
+func CreateHanningWindow(img *Mat, size image.Point, typ MatType) error {
 	sz := C.struct_Size{
 		width:  C.int(size.X),
 		height: C.int(size.Y),
 	}
 
-	C.CreateHanningWindow(img.p, sz, C.int(typ))
+	return OpenCVResult(C.CreateHanningWindow(img.p, sz, C.int(typ)))
 }
 
 // ToImage converts a Mat to a image.Image.
@@ -2253,62 +2250,62 @@ func ImageGrayToMatGray(img *image.Gray) (Mat, error) {
 // https://docs.opencv.org/master/d7/df3/group__imgproc__motion.html#ga1a567a79901513811ff3b9976923b199
 //
 
-func Accumulate(src Mat, dst *Mat) {
-	C.Mat_Accumulate(src.p, dst.p)
+func Accumulate(src Mat, dst *Mat) error {
+	return OpenCVResult(C.Mat_Accumulate(src.p, dst.p))
 }
 
 // Adds an image to the accumulator image with mask.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/df3/group__imgproc__motion.html#ga1a567a79901513811ff3b9976923b199
-func AccumulateWithMask(src Mat, dst *Mat, mask Mat) {
-	C.Mat_AccumulateWithMask(src.p, dst.p, mask.p)
+func AccumulateWithMask(src Mat, dst *Mat, mask Mat) error {
+	return OpenCVResult(C.Mat_AccumulateWithMask(src.p, dst.p, mask.p))
 }
 
 // Adds the square of a source image to the accumulator image.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/df3/group__imgproc__motion.html#gacb75e7ffb573227088cef9ceaf80be8c
-func AccumulateSquare(src Mat, dst *Mat) {
-	C.Mat_AccumulateSquare(src.p, dst.p)
+func AccumulateSquare(src Mat, dst *Mat) error {
+	return OpenCVResult(C.Mat_AccumulateSquare(src.p, dst.p))
 }
 
 // Adds the square of a source image to the accumulator image with mask.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/df3/group__imgproc__motion.html#gacb75e7ffb573227088cef9ceaf80be8c
-func AccumulateSquareWithMask(src Mat, dst *Mat, mask Mat) {
-	C.Mat_AccumulateSquareWithMask(src.p, dst.p, mask.p)
+func AccumulateSquareWithMask(src Mat, dst *Mat, mask Mat) error {
+	return OpenCVResult(C.Mat_AccumulateSquareWithMask(src.p, dst.p, mask.p))
 }
 
 // Adds the per-element product of two input images to the accumulator image.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/df3/group__imgproc__motion.html#ga82518a940ecfda49460f66117ac82520
-func AccumulateProduct(src1 Mat, src2 Mat, dst *Mat) {
-	C.Mat_AccumulateProduct(src1.p, src2.p, dst.p)
+func AccumulateProduct(src1 Mat, src2 Mat, dst *Mat) error {
+	return OpenCVResult(C.Mat_AccumulateProduct(src1.p, src2.p, dst.p))
 }
 
 // Adds the per-element product of two input images to the accumulator image with mask.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/df3/group__imgproc__motion.html#ga82518a940ecfda49460f66117ac82520
-func AccumulateProductWithMask(src1 Mat, src2 Mat, dst *Mat, mask Mat) {
-	C.Mat_AccumulateProductWithMask(src1.p, src2.p, dst.p, mask.p)
+func AccumulateProductWithMask(src1 Mat, src2 Mat, dst *Mat, mask Mat) error {
+	return OpenCVResult(C.Mat_AccumulateProductWithMask(src1.p, src2.p, dst.p, mask.p))
 }
 
 // Updates a running average.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/df3/group__imgproc__motion.html#ga4f9552b541187f61f6818e8d2d826bc7
-func AccumulatedWeighted(src Mat, dst *Mat, alpha float64) {
-	C.Mat_AccumulatedWeighted(src.p, dst.p, C.double(alpha))
+func AccumulatedWeighted(src Mat, dst *Mat, alpha float64) error {
+	return OpenCVResult(C.Mat_AccumulatedWeighted(src.p, dst.p, C.double(alpha)))
 }
 
 // Updates a running average with mask.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/df3/group__imgproc__motion.html#ga4f9552b541187f61f6818e8d2d826bc7
-func AccumulatedWeightedWithMask(src Mat, dst *Mat, alpha float64, mask Mat) {
-	C.Mat_AccumulatedWeightedWithMask(src.p, dst.p, C.double(alpha), mask.p)
+func AccumulatedWeightedWithMask(src Mat, dst *Mat, alpha float64, mask Mat) error {
+	return OpenCVResult(C.Mat_AccumulatedWeightedWithMask(src.p, dst.p, C.double(alpha), mask.p))
 }

--- a/imgproc.h
+++ b/imgproc.h
@@ -18,134 +18,133 @@ typedef void* CLAHE;
 
 double ArcLength(PointVector curve, bool is_closed);
 PointVector ApproxPolyDP(PointVector curve, double epsilon, bool closed);
-void CvtColor(Mat src, Mat dst, int code);
-void Demosaicing(Mat src, Mat dst, int code);
-void EqualizeHist(Mat src, Mat dst);
-void CalcHist(struct Mats mats, IntVector chans, Mat mask, Mat hist, IntVector sz, FloatVector rng, bool acc);
-void CalcBackProject(struct Mats mats, IntVector chans, Mat hist, Mat backProject, FloatVector rng, bool uniform);
+OpenCVResult CvtColor(Mat src, Mat dst, int code);
+OpenCVResult Demosaicing(Mat src, Mat dst, int code);
+OpenCVResult EqualizeHist(Mat src, Mat dst);
+OpenCVResult CalcHist(struct Mats mats, IntVector chans, Mat mask, Mat hist, IntVector sz, FloatVector rng, bool acc);
+OpenCVResult CalcBackProject(struct Mats mats, IntVector chans, Mat hist, Mat backProject, FloatVector rng, bool uniform);
 double CompareHist(Mat hist1, Mat hist2, int method);
 float EMD(Mat sig1, Mat sig2, int distType);
-void ConvexHull(PointVector points, Mat hull, bool clockwise, bool returnPoints);
-void ConvexityDefects(PointVector points, Mat hull, Mat result);
-void BilateralFilter(Mat src, Mat dst, int d, double sc, double ss);
-void Blur(Mat src, Mat dst, Size ps);
-void BoxFilter(Mat src, Mat dst, int ddepth, Size ps);
-void SqBoxFilter(Mat src, Mat dst, int ddepth, Size ps);
-void Dilate(Mat src, Mat dst, Mat kernel);
-void DilateWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType, Scalar borderValue);
-void DistanceTransform(Mat src, Mat dst, Mat labels, int distanceType, int maskSize, int labelType);
-void Erode(Mat src, Mat dst, Mat kernel);
-void ErodeWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType);
-void ErodeWithParamsAndBorderValue(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType, Scalar borderValue);
-void MatchTemplate(Mat image, Mat templ, Mat result, int method, Mat mask);
+OpenCVResult ConvexHull(PointVector points, Mat hull, bool clockwise, bool returnPoints);
+OpenCVResult ConvexityDefects(PointVector points, Mat hull, Mat result);
+OpenCVResult BilateralFilter(Mat src, Mat dst, int d, double sc, double ss);
+OpenCVResult Blur(Mat src, Mat dst, Size ps);
+OpenCVResult BoxFilter(Mat src, Mat dst, int ddepth, Size ps);
+OpenCVResult SqBoxFilter(Mat src, Mat dst, int ddepth, Size ps);
+OpenCVResult Dilate(Mat src, Mat dst, Mat kernel);
+OpenCVResult DilateWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType, Scalar borderValue);
+OpenCVResult DistanceTransform(Mat src, Mat dst, Mat labels, int distanceType, int maskSize, int labelType);
+OpenCVResult Erode(Mat src, Mat dst, Mat kernel);
+OpenCVResult ErodeWithParams(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType);
+OpenCVResult ErodeWithParamsAndBorderValue(Mat src, Mat dst, Mat kernel, Point anchor, int iterations, int borderType, Scalar borderValue);
+OpenCVResult MatchTemplate(Mat image, Mat templ, Mat result, int method, Mat mask);
 struct Moment Moments(Mat src, bool binaryImage);
-void PyrDown(Mat src, Mat dst, Size dstsize, int borderType);
-void PyrUp(Mat src, Mat dst, Size dstsize, int borderType);
+OpenCVResult PyrDown(Mat src, Mat dst, Size dstsize, int borderType);
+OpenCVResult PyrUp(Mat src, Mat dst, Size dstsize, int borderType);
 struct Rect BoundingRect(PointVector pts);
-void BoxPoints(RotatedRect rect, Mat boxPts);
-void BoxPoints2f(RotatedRect2f rect, Mat boxPts);
+OpenCVResult BoxPoints(RotatedRect rect, Mat boxPts);
+OpenCVResult BoxPoints2f(RotatedRect2f rect, Mat boxPts);
 double ContourArea(PointVector pts);
 struct RotatedRect MinAreaRect(PointVector pts);
 struct RotatedRect2f MinAreaRect2f(PointVector pts);
 struct RotatedRect FitEllipse(PointVector pts);
-void MinEnclosingCircle(PointVector pts, Point2f* center, float* radius);
+OpenCVResult MinEnclosingCircle(PointVector pts, Point2f* center, float* radius);
 PointsVector FindContours(Mat src, Mat hierarchy, int mode, int method);
 double PointPolygonTest(PointVector pts, Point pt, bool measureDist);
 int ConnectedComponents(Mat src, Mat dst, int connectivity, int ltype, int ccltype);
 int ConnectedComponentsWithStats(Mat src, Mat labels, Mat stats, Mat centroids, int connectivity, int ltype, int ccltype);
 
-void GaussianBlur(Mat src, Mat dst, Size ps, double sX, double sY, int bt);
+OpenCVResult GaussianBlur(Mat src, Mat dst, Size ps, double sX, double sY, int bt);
 Mat GetGaussianKernel(int ksize, double sigma, int ktype);
-void Laplacian(Mat src, Mat dst, int dDepth, int kSize, double scale, double delta, int borderType);
-void Scharr(Mat src, Mat dst, int dDepth, int dx, int dy, double scale, double delta,
+OpenCVResult Laplacian(Mat src, Mat dst, int dDepth, int kSize, double scale, double delta, int borderType);
+OpenCVResult Scharr(Mat src, Mat dst, int dDepth, int dx, int dy, double scale, double delta,
             int borderType);
 Mat GetStructuringElement(int shape, Size ksize);
 Scalar MorphologyDefaultBorderValue();
-void MorphologyEx(Mat src, Mat dst, int op, Mat kernel);
-void MorphologyExWithParams(Mat src, Mat dst, int op, Mat kernel, Point pt, int iterations, int borderType);
-void MedianBlur(Mat src, Mat dst, int ksize);
+OpenCVResult MorphologyEx(Mat src, Mat dst, int op, Mat kernel);
+OpenCVResult MorphologyExWithParams(Mat src, Mat dst, int op, Mat kernel, Point pt, int iterations, int borderType);
+OpenCVResult MedianBlur(Mat src, Mat dst, int ksize);
 
-void Canny(Mat src, Mat edges, double t1, double t2);
-void CornerSubPix(Mat img, Mat corners, Size winSize, Size zeroZone, TermCriteria criteria);
-void GoodFeaturesToTrack(Mat img, Mat corners, int maxCorners, double quality, double minDist);
-void GrabCut(Mat img, Mat mask, Rect rect, Mat bgdModel, Mat fgdModel, int iterCount, int mode);
-void HoughCircles(Mat src, Mat circles, int method, double dp, double minDist);
-void HoughCirclesWithParams(Mat src, Mat circles, int method, double dp, double minDist,
+OpenCVResult Canny(Mat src, Mat edges, double t1, double t2);
+OpenCVResult CornerSubPix(Mat img, Mat corners, Size winSize, Size zeroZone, TermCriteria criteria);
+OpenCVResult GoodFeaturesToTrack(Mat img, Mat corners, int maxCorners, double quality, double minDist);
+OpenCVResult GrabCut(Mat img, Mat mask, Rect rect, Mat bgdModel, Mat fgdModel, int iterCount, int mode);
+OpenCVResult HoughCircles(Mat src, Mat circles, int method, double dp, double minDist);
+OpenCVResult HoughCirclesWithParams(Mat src, Mat circles, int method, double dp, double minDist,
                             double param1, double param2, int minRadius, int maxRadius);
-void HoughLines(Mat src, Mat lines, double rho, double theta, int threshold);
-void HoughLinesP(Mat src, Mat lines, double rho, double theta, int threshold);
-void HoughLinesPWithParams(Mat src, Mat lines, double rho, double theta, int threshold, double minLineLength, double maxLineGap);
-void HoughLinesPointSet(Mat points, Mat lines, int lines_max, int threshold,
+OpenCVResult HoughLines(Mat src, Mat lines, double rho, double theta, int threshold);
+OpenCVResult HoughLinesP(Mat src, Mat lines, double rho, double theta, int threshold);
+OpenCVResult HoughLinesPWithParams(Mat src, Mat lines, double rho, double theta, int threshold, double minLineLength, double maxLineGap);
+OpenCVResult HoughLinesPointSet(Mat points, Mat lines, int lines_max, int threshold,
                         double min_rho, double  max_rho, double rho_step,
                         double min_theta, double max_theta, double theta_step);
-void Integral(Mat src, Mat sum, Mat sqsum, Mat tilted);
+OpenCVResult Integral(Mat src, Mat sum, Mat sqsum, Mat tilted);
 double Threshold(Mat src, Mat dst, double thresh, double maxvalue, int typ);
-void AdaptiveThreshold(Mat src, Mat dst, double maxValue, int adaptiveTyp, int typ, int blockSize,
+OpenCVResult AdaptiveThreshold(Mat src, Mat dst, double maxValue, int adaptiveTyp, int typ, int blockSize,
                        double c);
 
-void ArrowedLine(Mat img, Point pt1, Point pt2, Scalar color, int thickness);
-void Circle(Mat img, Point center, int radius, Scalar color, int thickness);
-void CircleWithParams(Mat img, Point center, int radius, Scalar color, int thickness, int lineType, int shift);
-void Ellipse(Mat img, Point center, Point axes, double angle, double
+OpenCVResult ArrowedLine(Mat img, Point pt1, Point pt2, Scalar color, int thickness);
+OpenCVResult Circle(Mat img, Point center, int radius, Scalar color, int thickness);
+OpenCVResult CircleWithParams(Mat img, Point center, int radius, Scalar color, int thickness, int lineType, int shift);
+OpenCVResult Ellipse(Mat img, Point center, Point axes, double angle, double
              startAngle, double endAngle, Scalar color, int thickness);
-void EllipseWithParams(Mat img, Point center, Point axes, double angle, double
+OpenCVResult EllipseWithParams(Mat img, Point center, Point axes, double angle, double
              startAngle, double endAngle, Scalar color, int thickness, int lineType, int shift);
-void Line(Mat img, Point pt1, Point pt2, Scalar color, int thickness);
-void Rectangle(Mat img, Rect rect, Scalar color, int thickness);
-void RectangleWithParams(Mat img, Rect rect, Scalar color, int thickness, int lineType, int shift);
-void FillPoly(Mat img, PointsVector points, Scalar color);
-void FillPolyWithParams(Mat img, PointsVector points, Scalar color, int lineType, int shift, Point offset);
-void Polylines(Mat img, PointsVector points, bool isClosed, Scalar color, int thickness);
+OpenCVResult Line(Mat img, Point pt1, Point pt2, Scalar color, int thickness);
+OpenCVResult Rectangle(Mat img, Rect rect, Scalar color, int thickness);
+OpenCVResult RectangleWithParams(Mat img, Rect rect, Scalar color, int thickness, int lineType, int shift);
+OpenCVResult FillPoly(Mat img, PointsVector points, Scalar color);
+OpenCVResult FillPolyWithParams(Mat img, PointsVector points, Scalar color, int lineType, int shift, Point offset);
+OpenCVResult Polylines(Mat img, PointsVector points, bool isClosed, Scalar color, int thickness);
 struct Size GetTextSize(const char* text, int fontFace, double fontScale, int thickness);
 struct Size GetTextSizeWithBaseline(const char* text, int fontFace, double fontScale, int thickness, int* baseline);
-void PutText(Mat img, const char* text, Point org, int fontFace, double fontScale,
-             Scalar color, int thickness);
-void PutTextWithParams(Mat img, const char* text, Point org, int fontFace, double fontScale,
-                         Scalar color, int thickness, int lineType, bool bottomLeftOrigin);
-void Resize(Mat src, Mat dst, Size sz, double fx, double fy, int interp);
-void GetRectSubPix(Mat src, Size patchSize, Point center, Mat dst);
+OpenCVResult PutText(Mat img, const char* text, Point org, int fontFace, double fontScale,
+            Scalar color, int thickness);
+OpenCVResult PutTextWithParams(Mat img, const char* text, Point org, int fontFace, double fontScale,
+            Scalar color, int thickness, int lineType, bool bottomLeftOrigin);
+OpenCVResult Resize(Mat src, Mat dst, Size sz, double fx, double fy, int interp);
+OpenCVResult GetRectSubPix(Mat src, Size patchSize, Point center, Mat dst);
 Mat GetRotationMatrix2D(Point center, double angle, double scale);
-void WarpAffine(Mat src, Mat dst, Mat rot_mat, Size dsize);
-void WarpAffineWithParams(Mat src, Mat dst, Mat rot_mat, Size dsize, int flags, int borderMode,
-                          Scalar borderValue);
-void WarpPerspective(Mat src, Mat dst, Mat m, Size dsize);
-void WarpPerspectiveWithParams(Mat src, Mat dst, Mat rot_mat, Size dsize, int flags, int borderMode,
+OpenCVResult WarpAffine(Mat src, Mat dst, Mat rot_mat, Size dsize);
+OpenCVResult WarpAffineWithParams(Mat src, Mat dst, Mat rot_mat, Size dsize, int flags, int borderMode, Scalar borderValue);
+OpenCVResult WarpPerspective(Mat src, Mat dst, Mat m, Size dsize);
+OpenCVResult WarpPerspectiveWithParams(Mat src, Mat dst, Mat rot_mat, Size dsize, int flags, int borderMode,
                                Scalar borderValue);
-void Watershed(Mat image, Mat markers);
-void ApplyColorMap(Mat src, Mat dst, int colormap);
-void ApplyCustomColorMap(Mat src, Mat dst, Mat colormap);
+OpenCVResult Watershed(Mat image, Mat markers);
+OpenCVResult ApplyColorMap(Mat src, Mat dst, int colormap);
+OpenCVResult ApplyCustomColorMap(Mat src, Mat dst, Mat colormap);
 Mat GetPerspectiveTransform(PointVector src, PointVector dst);
 Mat GetPerspectiveTransform2f(Point2fVector src, Point2fVector dst);
 Mat GetAffineTransform(PointVector src, PointVector dst);
 Mat GetAffineTransform2f(Point2fVector src, Point2fVector dst);
 Mat FindHomography(Mat src, Mat dst, int method, double ransacReprojThreshold, Mat mask, const int maxIters, const double confidence) ;
-void DrawContours(Mat src, PointsVector contours, int contourIdx, Scalar color, int thickness);
-void DrawContoursWithParams(Mat src, PointsVector contours, int contourIdx, Scalar color, int thickness, int lineType, Mat hierarchy, int maxLevel, Point offset);
-void Sobel(Mat src, Mat dst, int ddepth, int dx, int dy, int ksize, double scale, double delta, int borderType);
-void SpatialGradient(Mat src, Mat dx, Mat dy, int ksize, int borderType);
-void Remap(Mat src, Mat dst, Mat map1, Mat map2, int interpolation, int borderMode, Scalar borderValue);
-void Filter2D(Mat src, Mat dst, int ddepth, Mat kernel, Point anchor, double delta, int borderType);
-void SepFilter2D(Mat src, Mat dst, int ddepth, Mat kernelX, Mat kernelY, Point anchor, double delta, int borderType);
-void LogPolar(Mat src, Mat dst, Point center, double m, int flags);
-void FitLine(PointVector pts, Mat line, int distType, double param, double reps, double aeps);
-void LinearPolar(Mat src, Mat dst, Point center, double maxRadius, int flags);
+OpenCVResult DrawContours(Mat src, PointsVector contours, int contourIdx, Scalar color, int thickness);
+OpenCVResult DrawContoursWithParams(Mat src, PointsVector contours, int contourIdx, Scalar color, int thickness, int lineType, Mat hierarchy, int maxLevel, Point offset);
+OpenCVResult Sobel(Mat src, Mat dst, int ddepth, int dx, int dy, int ksize, double scale, double delta, int borderType);
+OpenCVResult SpatialGradient(Mat src, Mat dx, Mat dy, int ksize, int borderType);
+OpenCVResult Remap(Mat src, Mat dst, Mat map1, Mat map2, int interpolation, int borderMode, Scalar borderValue);
+OpenCVResult Filter2D(Mat src, Mat dst, int ddepth, Mat kernel, Point anchor, double delta, int borderType);
+OpenCVResult SepFilter2D(Mat src, Mat dst, int ddepth, Mat kernelX, Mat kernelY, Point anchor, double delta, int borderType);
+OpenCVResult LogPolar(Mat src, Mat dst, Point center, double m, int flags);
+OpenCVResult FitLine(PointVector pts, Mat line, int distType, double param, double reps, double aeps);
+OpenCVResult LinearPolar(Mat src, Mat dst, Point center, double maxRadius, int flags);
 double MatchShapes(PointVector contour1, PointVector contour2, int method, double parameter);
 bool ClipLine(Size imgSize, Point pt1, Point pt2);
 CLAHE CLAHE_Create();
 CLAHE CLAHE_CreateWithParams(double clipLimit, Size tileGridSize);
 void CLAHE_Close(CLAHE c);
-void CLAHE_Apply(CLAHE c, Mat src, Mat dst);
-void InvertAffineTransform(Mat src, Mat dst);
+OpenCVResult CLAHE_Apply(CLAHE c, Mat src, Mat dst);
+OpenCVResult InvertAffineTransform(Mat src, Mat dst);
 Point2f PhaseCorrelate(Mat src1, Mat src2, Mat window, double* response);
-void CreateHanningWindow(Mat dst, Size size, int typ);
-void Mat_Accumulate(Mat src, Mat dst);
-void Mat_AccumulateWithMask(Mat src, Mat dst, Mat mask);
-void Mat_AccumulateSquare(Mat src, Mat dst);
-void Mat_AccumulateSquareWithMask(Mat src, Mat dst, Mat mask);
-void Mat_AccumulateProduct(Mat src1, Mat src2, Mat dst);
-void Mat_AccumulateProductWithMask(Mat src1, Mat src2, Mat dst, Mat mask);
-void Mat_AccumulatedWeighted(Mat src, Mat dst, double alpha);
-void Mat_AccumulatedWeightedWithMask(Mat src, Mat dst, double alpha, Mat mask);
+OpenCVResult CreateHanningWindow(Mat dst, Size size, int typ);
+OpenCVResult Mat_Accumulate(Mat src, Mat dst);
+OpenCVResult Mat_AccumulateWithMask(Mat src, Mat dst, Mat mask);
+OpenCVResult Mat_AccumulateSquare(Mat src, Mat dst);
+OpenCVResult Mat_AccumulateSquareWithMask(Mat src, Mat dst, Mat mask);
+OpenCVResult Mat_AccumulateProduct(Mat src1, Mat src2, Mat dst);
+OpenCVResult Mat_AccumulateProductWithMask(Mat src1, Mat src2, Mat dst, Mat mask);
+OpenCVResult Mat_AccumulatedWeighted(Mat src, Mat dst, double alpha);
+OpenCVResult Mat_AccumulatedWeightedWithMask(Mat src, Mat dst, double alpha, Mat mask);
 #ifdef __cplusplus
 }
 #endif

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -128,11 +128,12 @@ func TestCvtColorException(t *testing.T) {
 	dest := NewMat()
 	defer dest.Close()
 
-	CvtColor(img, &dest, ColorBGRAToGray)
-	defer ClearLastException()
-
-	if GetLastException() == 0 || GetLastExceptionMessage() == "" {
+	err := CvtColor(img, &dest, ColorBGRAToGray)
+	if err == nil {
 		t.Error("Expected exception in test")
+	}
+	if len(err.Error()) == 0 {
+		t.Error("Expected exception message in test")
 	}
 }
 

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -121,6 +121,21 @@ func TestCvtColor(t *testing.T) {
 	}
 }
 
+func TestCvtColorException(t *testing.T) {
+	img := NewMat()
+	defer img.Close()
+
+	dest := NewMat()
+	defer dest.Close()
+
+	CvtColor(img, &dest, ColorBGRAToGray)
+	defer ClearLastException()
+
+	if GetLastException() == 0 || GetLastExceptionMessage() == "" {
+		t.Error("Expected exception in test")
+	}
+}
+
 func NewBayerFromMat(src Mat, pattern string) (Mat, error) {
 	dest := NewMatWithSize(src.Rows(), src.Cols(), MatTypeCV8UC1)
 

--- a/objdetect.cpp
+++ b/objdetect.cpp
@@ -3,7 +3,12 @@
 // CascadeClassifier
 
 CascadeClassifier CascadeClassifier_New() {
-    return new cv::CascadeClassifier();
+    try {
+        return new cv::CascadeClassifier();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void CascadeClassifier_Close(CascadeClassifier cs) {
@@ -11,46 +16,67 @@ void CascadeClassifier_Close(CascadeClassifier cs) {
 }
 
 int CascadeClassifier_Load(CascadeClassifier cs, const char* name) {
-    return cs->load(name);
+    try {
+        return cs->load(name);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 struct Rects CascadeClassifier_DetectMultiScale(CascadeClassifier cs, Mat img) {
-    std::vector<cv::Rect> detected;
-    cs->detectMultiScale(*img, detected); // uses all default parameters
-    Rect* rects = new Rect[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        Rect r = {detected[i].x, detected[i].y, detected[i].width, detected[i].height};
-        rects[i] = r;
+    try {
+        std::vector<cv::Rect> detected;
+        cs->detectMultiScale(*img, detected); // uses all default parameters
+        Rect* rects = new Rect[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            Rect r = {detected[i].x, detected[i].y, detected[i].width, detected[i].height};
+            rects[i] = r;
+        }
+    
+        Rects ret = {rects, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Rects ret = {NULL, 0};
+        return ret;
     }
-
-    Rects ret = {rects, (int)detected.size()};
-    return ret;
 }
 
 struct Rects CascadeClassifier_DetectMultiScaleWithParams(CascadeClassifier cs, Mat img,
         double scale, int minNeighbors, int flags, Size minSize, Size maxSize) {
-
-    cv::Size minSz(minSize.width, minSize.height);
-    cv::Size maxSz(maxSize.width, maxSize.height);
-
-    std::vector<cv::Rect> detected;
-    cs->detectMultiScale(*img, detected, scale, minNeighbors, flags, minSz, maxSz);
-    Rect* rects = new Rect[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        Rect r = {detected[i].x, detected[i].y, detected[i].width, detected[i].height};
-        rects[i] = r;
+    try {
+        cv::Size minSz(minSize.width, minSize.height);
+        cv::Size maxSz(maxSize.width, maxSize.height);
+    
+        std::vector<cv::Rect> detected;
+        cs->detectMultiScale(*img, detected, scale, minNeighbors, flags, minSz, maxSz);
+        Rect* rects = new Rect[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            Rect r = {detected[i].x, detected[i].y, detected[i].width, detected[i].height};
+            rects[i] = r;
+        }
+    
+        Rects ret = {rects, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Rects ret = {NULL, 0};
+        return ret;
     }
-
-    Rects ret = {rects, (int)detected.size()};
-    return ret;
 }
 
 // HOGDescriptor
 
 HOGDescriptor HOGDescriptor_New() {
-    return new cv::HOGDescriptor();
+    try {
+        return new cv::HOGDescriptor();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void HOGDescriptor_Close(HOGDescriptor hog) {
@@ -58,78 +84,115 @@ void HOGDescriptor_Close(HOGDescriptor hog) {
 }
 
 int HOGDescriptor_Load(HOGDescriptor hog, const char* name) {
-    return hog->load(name);
+    try {
+        return hog->load(name);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 struct Rects HOGDescriptor_DetectMultiScale(HOGDescriptor hog, Mat img) {
-    std::vector<cv::Rect> detected;
-    hog->detectMultiScale(*img, detected);
-    Rect* rects = new Rect[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        Rect r = {detected[i].x, detected[i].y, detected[i].width, detected[i].height};
-        rects[i] = r;
+    try {
+        std::vector<cv::Rect> detected;
+        hog->detectMultiScale(*img, detected);
+        Rect* rects = new Rect[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            Rect r = {detected[i].x, detected[i].y, detected[i].width, detected[i].height};
+            rects[i] = r;
+        }
+    
+        Rects ret = {rects, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Rects ret = {NULL, 0};
+        return ret;
     }
-
-    Rects ret = {rects, (int)detected.size()};
-    return ret;
 }
 
 struct Rects HOGDescriptor_DetectMultiScaleWithParams(HOGDescriptor hog, Mat img,
         double hitThresh, Size winStride, Size padding, double scale, double finalThresh,
         bool useMeanshiftGrouping) {
 
-    cv::Size wSz(winStride.width, winStride.height);
-    cv::Size pSz(padding.width, padding.height);
-
-    std::vector<cv::Rect> detected;
-    hog->detectMultiScale(*img, detected, hitThresh, wSz, pSz, scale, finalThresh,
-                          useMeanshiftGrouping);
-    Rect* rects = new Rect[detected.size()];
-
-    for (size_t i = 0; i < detected.size(); ++i) {
-        Rect r = {detected[i].x, detected[i].y, detected[i].width, detected[i].height};
-        rects[i] = r;
+    try {
+        cv::Size wSz(winStride.width, winStride.height);
+        cv::Size pSz(padding.width, padding.height);
+    
+        std::vector<cv::Rect> detected;
+        hog->detectMultiScale(*img, detected, hitThresh, wSz, pSz, scale, finalThresh,
+                              useMeanshiftGrouping);
+        Rect* rects = new Rect[detected.size()];
+    
+        for (size_t i = 0; i < detected.size(); ++i) {
+            Rect r = {detected[i].x, detected[i].y, detected[i].width, detected[i].height};
+            rects[i] = r;
+        }
+    
+        Rects ret = {rects, (int)detected.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Rects ret = {NULL, 0};
+        return ret;
     }
-
-    Rects ret = {rects, (int)detected.size()};
-    return ret;
 }
 
 Mat HOG_GetDefaultPeopleDetector() {
-    return new cv::Mat(cv::HOGDescriptor::getDefaultPeopleDetector());
+    try {
+        return new cv::Mat(cv::HOGDescriptor::getDefaultPeopleDetector());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
+    }
 }
 
 void HOGDescriptor_SetSVMDetector(HOGDescriptor hog, Mat det) {
-    hog->setSVMDetector(*det);
+    try {
+        hog->setSVMDetector(*det);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 struct Rects GroupRectangles(struct Rects rects, int groupThreshold, double eps) {
-    std::vector<cv::Rect> vRect;
+    try {
+        std::vector<cv::Rect> vRect;
 
-    for (int i = 0; i < rects.length; ++i) {
-        cv::Rect r = cv::Rect(rects.rects[i].x, rects.rects[i].y, rects.rects[i].width,
-                              rects.rects[i].height);
-        vRect.push_back(r);
+        for (int i = 0; i < rects.length; ++i) {
+            cv::Rect r = cv::Rect(rects.rects[i].x, rects.rects[i].y, rects.rects[i].width,
+                                  rects.rects[i].height);
+            vRect.push_back(r);
+        }
+    
+        cv::groupRectangles(vRect, groupThreshold, eps);
+    
+        Rect* results = new Rect[vRect.size()];
+    
+        for (size_t i = 0; i < vRect.size(); ++i) {
+            Rect r = {vRect[i].x, vRect[i].y, vRect[i].width, vRect[i].height};
+            results[i] = r;
+        }
+    
+        Rects ret = {results, (int)vRect.size()};
+        return ret;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Rects ret = {NULL, 0};
+        return ret;
     }
-
-    cv::groupRectangles(vRect, groupThreshold, eps);
-
-    Rect* results = new Rect[vRect.size()];
-
-    for (size_t i = 0; i < vRect.size(); ++i) {
-        Rect r = {vRect[i].x, vRect[i].y, vRect[i].width, vRect[i].height};
-        results[i] = r;
-    }
-
-    Rects ret = {results, (int)vRect.size()};
-    return ret;
 }
 
 // QRCodeDetector
 
 QRCodeDetector QRCodeDetector_New() {
-    return new cv::QRCodeDetector();
+    try {
+        return new cv::QRCodeDetector();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void QRCodeDetector_Close(QRCodeDetector qr) {
@@ -137,102 +200,146 @@ void QRCodeDetector_Close(QRCodeDetector qr) {
 }
 
 const char* QRCodeDetector_DetectAndDecode(QRCodeDetector qr, Mat input,Mat points,Mat straight_qrcode) {
-  cv::String *str = new cv::String(qr->detectAndDecode(*input,*points,*straight_qrcode)); 
-  return str->c_str();
+    try {
+        cv::String *str = new cv::String(qr->detectAndDecode(*input,*points,*straight_qrcode)); 
+        return str->c_str();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return "";
+    }
 }
 
 bool QRCodeDetector_Detect(QRCodeDetector qr, Mat input,Mat points) {
-  return qr->detect(*input,*points); 
+    try {
+        return qr->detect(*input,*points); 
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 const char* QRCodeDetector_Decode(QRCodeDetector qr, Mat input,Mat inputPoints,Mat straight_qrcode) {
-  cv::String *str = new cv::String(qr->detectAndDecode(*input,*inputPoints,*straight_qrcode)); 
-  return str->c_str();
+    try {
+        cv::String *str = new cv::String(qr->detectAndDecode(*input,*inputPoints,*straight_qrcode)); 
+        return str->c_str();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return "";
+    }
 }
 
 bool QRCodeDetector_DetectMulti(QRCodeDetector qr, Mat input, Mat points) {
-  return qr->detectMulti(*input,*points);
+    try {
+        return qr->detectMulti(*input,*points);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 bool QRCodeDetector_DetectAndDecodeMulti(QRCodeDetector qr, Mat input, CStrings* decoded, Mat points, struct Mats* qrCodes) {
-  std::vector<cv::String> decodedCodes;
-  std::vector<cv::Mat> straightQrCodes;
-  bool res = qr->detectAndDecodeMulti(*input, decodedCodes, *points, straightQrCodes);
-  if (!res) {
-    return res;
-  }
-
-  qrCodes->mats = new Mat[straightQrCodes.size()];
-  qrCodes->length = straightQrCodes.size();
-  for (size_t i = 0; i < straightQrCodes.size(); i++) {
-     qrCodes->mats[i] = new cv::Mat(straightQrCodes[i]);
-  }
-
-  const char **strs = new const char*[decodedCodes.size()];
-  for (size_t i = 0; i < decodedCodes.size(); ++i) {
-      strs[i] = decodedCodes[i].c_str();
-  }
-  decoded->length = decodedCodes.size();
-  decoded->strs = strs;
-  return res;
+    try {
+        std::vector<cv::String> decodedCodes;
+        std::vector<cv::Mat> straightQrCodes;
+        bool res = qr->detectAndDecodeMulti(*input, decodedCodes, *points, straightQrCodes);
+        if (!res) {
+            return res;
+        }
+    
+        qrCodes->mats = new Mat[straightQrCodes.size()];
+        qrCodes->length = straightQrCodes.size();
+        for (size_t i = 0; i < straightQrCodes.size(); i++) {
+            qrCodes->mats[i] = new cv::Mat(straightQrCodes[i]);
+        }
+    
+        const char **strs = new const char*[decodedCodes.size()];
+        for (size_t i = 0; i < decodedCodes.size(); ++i) {
+            strs[i] = decodedCodes[i].c_str();
+        }
+        decoded->length = decodedCodes.size();
+        decoded->strs = strs;
+        return res;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return false;
+    }
 }
 
 FaceDetectorYN FaceDetectorYN_Create(const char* model, const char* config, Size size) {
-    cv::String smodel = cv::String(model);
-    cv::String sconfig = cv::String(config);
-    cv::Size   ssize = cv::Size(size.width, size.height);
-
-    return new cv::Ptr<cv::FaceDetectorYN>(cv::FaceDetectorYN::create(smodel, sconfig, ssize));
+    try {
+        cv::String smodel = cv::String(model);
+        cv::String sconfig = cv::String(config);
+        cv::Size   ssize = cv::Size(size.width, size.height);
+    
+        return new cv::Ptr<cv::FaceDetectorYN>(cv::FaceDetectorYN::create(smodel, sconfig, ssize));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 FaceDetectorYN FaceDetectorYN_Create_WithParams(const char* model, const char* config, Size size, float score_threshold, float nms_threshold, int top_k, int backend_id, int target_id) {
-    cv::String smodel = cv::String(model);
-    cv::String sconfig = cv::String(config);
-    cv::Size   ssize = cv::Size(size.width, size.height);
-
-    return new cv::Ptr<cv::FaceDetectorYN>(cv::FaceDetectorYN::create(smodel, sconfig, ssize, score_threshold, nms_threshold, top_k, backend_id, target_id));
+    try {
+        cv::String smodel = cv::String(model);
+        cv::String sconfig = cv::String(config);
+        cv::Size   ssize = cv::Size(size.width, size.height);
+    
+        return new cv::Ptr<cv::FaceDetectorYN>(cv::FaceDetectorYN::create(smodel, sconfig, ssize, score_threshold, nms_threshold, top_k, backend_id, target_id));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 FaceDetectorYN FaceDetectorYN_Create_FromBytes(const char* framework, void* bufferModel, int model_size, void* bufferConfig, int config_size, Size size) {
-    cv::String sframework = cv::String(framework);
-    cv::Size   ssize = cv::Size(size.width, size.height);
+    try {
+        cv::String sframework = cv::String(framework);
+        cv::Size   ssize = cv::Size(size.width, size.height);
+        
+        std::vector<uchar> bufferModelV;
+        std::vector<uchar> bufferConfigV;
     
-    std::vector<uchar> bufferModelV;
-    std::vector<uchar> bufferConfigV;
-
-    uchar* bmv = (uchar*)bufferModel;
-    uchar* bcv = (uchar*)bufferConfig;
-
-
-    for(int i = 0; i < model_size; i ++) {
-        bufferModelV.push_back(bmv[i]);
+        uchar* bmv = (uchar*)bufferModel;
+        uchar* bcv = (uchar*)bufferConfig;
+    
+    
+        for(int i = 0; i < model_size; i ++) {
+            bufferModelV.push_back(bmv[i]);
+        }
+        for(int i = 0; i < config_size; i ++) {
+            bufferConfigV.push_back(bcv[i]);
+        }
+    
+        return new cv::Ptr<cv::FaceDetectorYN>(cv::FaceDetectorYN::create(sframework, bufferModelV, bufferConfigV, ssize));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
     }
-   for(int i = 0; i < config_size; i ++) {
-        bufferConfigV.push_back(bcv[i]);
-    }
-
-    return new cv::Ptr<cv::FaceDetectorYN>(cv::FaceDetectorYN::create(sframework, bufferModelV, bufferConfigV, ssize));
 }
 
 FaceDetectorYN FaceDetectorYN_Create_FromBytes_WithParams(const char* framework, void* bufferModel, int model_size, void* bufferConfig, int config_size, Size size, float score_threshold, float nms_threshold, int top_k, int backend_id, int target_id) {
-    cv::String sframework = cv::String(framework);
-    cv::Size   ssize = cv::Size(size.width, size.height);
+    try {
+        cv::String sframework = cv::String(framework);
+        cv::Size   ssize = cv::Size(size.width, size.height);
+        
+        std::vector<uchar> bufferModelV;
+        std::vector<uchar> bufferConfigV;
     
-    std::vector<uchar> bufferModelV;
-    std::vector<uchar> bufferConfigV;
-
-    uchar* bmv = (uchar*)bufferModel;
-    uchar* bcv = (uchar*)bufferConfig;
-
-
-    for(int i = 0; i < model_size; i ++) {
-        bufferModelV.push_back(bmv[i]);
+        uchar* bmv = (uchar*)bufferModel;
+        uchar* bcv = (uchar*)bufferConfig;
+    
+        for(int i = 0; i < model_size; i ++) {
+            bufferModelV.push_back(bmv[i]);
+        }
+        for(int i = 0; i < config_size; i ++) {
+            bufferConfigV.push_back(bcv[i]);
+        }
+    
+        return new cv::Ptr<cv::FaceDetectorYN>(cv::FaceDetectorYN::create(sframework, bufferModelV, bufferConfigV, ssize, score_threshold, nms_threshold, top_k, backend_id, target_id));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
     }
-    for(int i = 0; i < config_size; i ++) {
-        bufferConfigV.push_back(bcv[i]);
-    }
-
-    return new cv::Ptr<cv::FaceDetectorYN>(cv::FaceDetectorYN::create(sframework, bufferModelV, bufferConfigV, ssize, score_threshold, nms_threshold, top_k, backend_id, target_id));
 }
 
 void FaceDetectorYN_Close(FaceDetectorYN fd) {
@@ -240,56 +347,107 @@ void FaceDetectorYN_Close(FaceDetectorYN fd) {
 }
 
 int FaceDetectorYN_Detect(FaceDetectorYN fd, Mat image, Mat faces) {
-    return (*fd)->detect(*image, *faces);
+    try {
+        return (*fd)->detect(*image, *faces);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 Size FaceDetectorYN_GetInputSize(FaceDetectorYN fd) {
-    Size sz;
+    try {
+        Size sz;
 
-    cv::Size cvsz = (*fd)->getInputSize();
-
-    sz.width = cvsz.width;
-    sz.height = cvsz.height;
-
-    return sz;
+        cv::Size cvsz = (*fd)->getInputSize();
+    
+        sz.width = cvsz.width;
+        sz.height = cvsz.height;
+    
+        return sz;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        Size sz = {0, 0};
+        return sz;
+    }
 }
 
 float FaceDetectorYN_GetNMSThreshold(FaceDetectorYN fd) {
-    return (*fd)->getNMSThreshold();
+    try {
+        return (*fd)->getNMSThreshold();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 float FaceDetectorYN_GetScoreThreshold(FaceDetectorYN fd) {
-    return (*fd)->getScoreThreshold();
+    try {
+        return (*fd)->getScoreThreshold();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 int FaceDetectorYN_GetTopK(FaceDetectorYN fd) {
-    return (*fd)->getTopK();
+    try {
+        return (*fd)->getTopK();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
 }
 
 void FaceDetectorYN_SetInputSize(FaceDetectorYN fd, Size input_size){
-    cv::Size isz(input_size.width, input_size.height);
-    (*fd)->setInputSize(isz);
+    try {
+        cv::Size isz(input_size.width, input_size.height);
+        (*fd)->setInputSize(isz);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void FaceDetectorYN_SetNMSThreshold(FaceDetectorYN fd, float nms_threshold){
-    (*fd)->setNMSThreshold(nms_threshold);
+    try {
+        (*fd)->setNMSThreshold(nms_threshold);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void FaceDetectorYN_SetScoreThreshold(FaceDetectorYN fd, float score_threshold){
-    (*fd)->setScoreThreshold(score_threshold);
+    try {
+        (*fd)->setScoreThreshold(score_threshold);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void FaceDetectorYN_SetTopK(FaceDetectorYN fd, int top_k){
-    (*fd)->setTopK(top_k);
+    try {
+        (*fd)->setTopK(top_k);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 FaceRecognizerSF FaceRecognizerSF_Create(const char* model, const char* config) {
-    return FaceRecognizerSF_Create_WithParams(model, config, 0, 0);
+    try {
+        return FaceRecognizerSF_Create_WithParams(model, config, 0, 0);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 FaceRecognizerSF FaceRecognizerSF_Create_WithParams(const char* model, const char* config, int backend_id, int target_id) {
-    cv::Ptr<cv::FaceRecognizerSF>* p = new cv::Ptr<cv::FaceRecognizerSF>(cv::FaceRecognizerSF::create(model, config, backend_id, target_id));
-    return p;
+    try {
+        return new cv::Ptr<cv::FaceRecognizerSF>(cv::FaceRecognizerSF::create(model, config, backend_id, target_id));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void FaceRecognizerSF_Close(FaceRecognizerSF fr) {
@@ -297,18 +455,36 @@ void FaceRecognizerSF_Close(FaceRecognizerSF fr) {
 }
 
 void FaceRecognizerSF_AlignCrop(FaceRecognizerSF fr, Mat src_img, Mat face_box, Mat aligned_img) {
-    (*fr)->alignCrop(*src_img, *face_box, *aligned_img);
+    try {
+        (*fr)->alignCrop(*src_img, *face_box, *aligned_img);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void FaceRecognizerSF_Feature(FaceRecognizerSF fr, Mat aligned_img, Mat face_feature) {
-    (*fr)->feature(*aligned_img, *face_feature);
+    try {
+        (*fr)->feature(*aligned_img, *face_feature);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 float FaceRecognizerSF_Match(FaceRecognizerSF fr, Mat face_feature1, Mat face_feature2) {
-    return FaceRecognizerSF_Match_WithParams(fr, face_feature1, face_feature2, 0);
+    try {
+        return FaceRecognizerSF_Match_WithParams(fr, face_feature1, face_feature2, 0);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }
 
 float FaceRecognizerSF_Match_WithParams(FaceRecognizerSF fr, Mat face_feature1, Mat face_feature2, int dis_type) {
-    double rv = (*fr)->match(*face_feature1, *face_feature2, dis_type);
-    return (float)rv;
+    try {
+        double rv = (*fr)->match(*face_feature1, *face_feature2, dis_type);
+        return (float)rv;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
 }

--- a/photo.cpp
+++ b/photo.cpp
@@ -1,122 +1,207 @@
 #include "photo.h"
 
 void ColorChange(Mat src, Mat mask, Mat dst, float red_mul, float green_mul, float blue_mul) {
-    cv::colorChange(*src, *mask, *dst, red_mul, green_mul, blue_mul);
+    try {
+        cv::colorChange(*src, *mask, *dst, red_mul, green_mul, blue_mul);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void IlluminationChange(Mat src, Mat mask, Mat dst, float alpha, float beta) {
-    cv::illuminationChange(*src, *mask, *dst, alpha, beta);
+    try {
+        cv::illuminationChange(*src, *mask, *dst, alpha, beta);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void SeamlessClone(Mat src, Mat dst, Mat mask, Point p, Mat blend, int flags) {
-    cv::Point pt(p.x, p.y);
-    cv::seamlessClone(*src, *dst, *mask, pt, *blend, flags);
+    try {
+        cv::Point pt(p.x, p.y);
+        cv::seamlessClone(*src, *dst, *mask, pt, *blend, flags);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void TextureFlattening(Mat src, Mat mask, Mat dst, float low_threshold, float high_threshold, int kernel_size) {
-    cv::textureFlattening(*src, *mask, *dst, low_threshold, high_threshold, kernel_size);
+    try {
+        cv::textureFlattening(*src, *mask, *dst, low_threshold, high_threshold, kernel_size);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 
 void FastNlMeansDenoisingColoredMulti(	struct Mats src, Mat dst, int imgToDenoiseIndex, int 	temporalWindowSize){
-  std::vector<cv::Mat> images;
-  for (int i = 0; i < src.length; ++i) {
-    images.push_back(*src.mats[i]);
-  }
-  cv::fastNlMeansDenoisingColoredMulti( images, *dst, imgToDenoiseIndex, 	temporalWindowSize );
+    try {
+        std::vector<cv::Mat> images;
+        for (int i = 0; i < src.length; ++i) {
+            images.push_back(*src.mats[i]);
+        }
+        cv::fastNlMeansDenoisingColoredMulti( images, *dst, imgToDenoiseIndex, 	temporalWindowSize );
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void FastNlMeansDenoisingColoredMultiWithParams( struct Mats src, Mat dst, int imgToDenoiseIndex, int 	temporalWindowSize, float 	h, float 	hColor, int 	templateWindowSize, int 	searchWindowSize ){
-  std::vector<cv::Mat> images;
-  for (int i = 0; i < src.length; ++i) {
-    images.push_back(*src.mats[i]);
-  }
-  cv::fastNlMeansDenoisingColoredMulti( images, *dst, imgToDenoiseIndex, 	temporalWindowSize, h, hColor, templateWindowSize, searchWindowSize );
+    try {
+        std::vector<cv::Mat> images;
+        for (int i = 0; i < src.length; ++i) {
+            images.push_back(*src.mats[i]);
+        }
+        cv::fastNlMeansDenoisingColoredMulti( images, *dst, imgToDenoiseIndex, 	temporalWindowSize, h, hColor, templateWindowSize, searchWindowSize );
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 MergeMertens MergeMertens_Create() {
-  return new cv::Ptr<cv::MergeMertens>(cv::createMergeMertens());
+    try {
+        return new cv::Ptr<cv::MergeMertens>(cv::createMergeMertens());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 MergeMertens MergeMertens_CreateWithParams(float contrast_weight,
                                            float saturation_weight,
                                            float exposure_weight) {
-  return new cv::Ptr<cv::MergeMertens>(cv::createMergeMertens(
-      contrast_weight, saturation_weight, exposure_weight));
+    try {
+        return new cv::Ptr<cv::MergeMertens>(cv::createMergeMertens(contrast_weight, saturation_weight, exposure_weight));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void MergeMertens_Close(MergeMertens b) {
-  delete b;
+    delete b;
 }
 
 void MergeMertens_Process(MergeMertens b, struct Mats src, Mat dst) {
-  std::vector<cv::Mat> images;
-  for (int i = 0; i < src.length; ++i) {
-    images.push_back(*src.mats[i]);
-  }
-  (*b)->process(images, *dst);
+    try {
+        std::vector<cv::Mat> images;
+        for (int i = 0; i < src.length; ++i) {
+            images.push_back(*src.mats[i]);
+        }
+        (*b)->process(images, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 AlignMTB AlignMTB_Create() {
-  return new cv::Ptr<cv::AlignMTB>(cv::createAlignMTB(6,4,false));
+    try {
+        return new cv::Ptr<cv::AlignMTB>(cv::createAlignMTB(6,4,false));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 AlignMTB AlignMTB_CreateWithParams(int max_bits, int exclude_range, bool cut) {
-  return new cv::Ptr<cv::AlignMTB>(
-      cv::createAlignMTB(max_bits, exclude_range, cut));
+    try {
+        return new cv::Ptr<cv::AlignMTB>(cv::createAlignMTB(max_bits, exclude_range, cut));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return NULL;
+    }
 }
 
 void AlignMTB_Close(AlignMTB b) { delete b; }
 
 void AlignMTB_Process(AlignMTB b, struct Mats src, struct Mats *dst) {
-
-  std::vector<cv::Mat> srcMats;
-  for (int i = 0; i < src.length; ++i) {
-    srcMats.push_back(*src.mats[i]);
-  }
-
-  std::vector<cv::Mat> dstMats;
-  (*b)->process(srcMats, dstMats);
-
-  dst->mats = new Mat[dstMats.size()];
-  for (size_t i = 0; i < dstMats.size() ; ++i) {
-	dst->mats[i] = new cv::Mat( dstMats[i] );
-  }
-  dst->length = (int)dstMats.size();
+    try {
+        std::vector<cv::Mat> srcMats;
+        for (int i = 0; i < src.length; ++i) {
+            srcMats.push_back(*src.mats[i]);
+        }
+      
+        std::vector<cv::Mat> dstMats;
+        (*b)->process(srcMats, dstMats);
+      
+        dst->mats = new Mat[dstMats.size()];
+        for (size_t i = 0; i < dstMats.size() ; ++i) {
+            dst->mats[i] = new cv::Mat( dstMats[i] );
+        }
+        dst->length = (int)dstMats.size();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void FastNlMeansDenoising(Mat src, Mat dst) {
-    cv::fastNlMeansDenoising(*src, *dst);
+    try {
+        cv::fastNlMeansDenoising(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void FastNlMeansDenoisingWithParams(Mat src, Mat dst, float h, int templateWindowSize, int searchWindowSize) {
-    cv::fastNlMeansDenoising(*src, *dst, h, templateWindowSize, searchWindowSize);
+    try {
+        cv::fastNlMeansDenoising(*src, *dst, h, templateWindowSize, searchWindowSize);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void FastNlMeansDenoisingColored(Mat src, Mat dst) {
-    cv::fastNlMeansDenoisingColored(*src, *dst);
+    try {
+        cv::fastNlMeansDenoisingColored(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void FastNlMeansDenoisingColoredWithParams(Mat src, Mat dst, float h, float hColor, int templateWindowSize, int searchWindowSize) {
-    cv::fastNlMeansDenoisingColored(*src, *dst, h, hColor, templateWindowSize, searchWindowSize);
+    try {
+        cv::fastNlMeansDenoisingColored(*src, *dst, h, hColor, templateWindowSize, searchWindowSize);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void EdgePreservingFilter(Mat src, Mat dst, int filter, float sigma_s, float sigma_r) {
-    cv::edgePreservingFilter(*src, *dst, filter, sigma_s, sigma_r);
+    try {
+        cv::edgePreservingFilter(*src, *dst, filter, sigma_s, sigma_r);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void DetailEnhance(Mat src, Mat dst, float sigma_s, float sigma_r) {
-    cv::detailEnhance(*src, *dst, sigma_s, sigma_r);
+    try {
+        cv::detailEnhance(*src, *dst, sigma_s, sigma_r);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void PencilSketch(Mat src, Mat dst1, Mat dst2, float sigma_s, float sigma_r, float shade_factor) {
-    cv::pencilSketch(*src, *dst1, *dst2, sigma_s, sigma_r, shade_factor);
+    try {
+        cv::pencilSketch(*src, *dst1, *dst2, sigma_s, sigma_r, shade_factor);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void Stylization(Mat src, Mat dst, float sigma_s, float sigma_r) {
-    cv::stylization(*src, *dst, sigma_s, sigma_r);
+    try {
+        cv::stylization(*src, *dst, sigma_s, sigma_r);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void PhotoInpaint(Mat src, Mat mask, Mat dst, float inpaint_radius, int algorithm_type) {
-    cv::inpaint(*src, *mask, *dst, inpaint_radius, algorithm_type);
+    try {
+        cv::inpaint(*src, *mask, *dst, inpaint_radius, algorithm_type);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }

--- a/photo.cpp
+++ b/photo.cpp
@@ -1,60 +1,66 @@
 #include "photo.h"
 
-void ColorChange(Mat src, Mat mask, Mat dst, float red_mul, float green_mul, float blue_mul) {
+OpenCVResult ColorChange(Mat src, Mat mask, Mat dst, float red_mul, float green_mul, float blue_mul) {
     try {
         cv::colorChange(*src, *mask, *dst, red_mul, green_mul, blue_mul);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void IlluminationChange(Mat src, Mat mask, Mat dst, float alpha, float beta) {
+OpenCVResult IlluminationChange(Mat src, Mat mask, Mat dst, float alpha, float beta) {
     try {
         cv::illuminationChange(*src, *mask, *dst, alpha, beta);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void SeamlessClone(Mat src, Mat dst, Mat mask, Point p, Mat blend, int flags) {
+OpenCVResult SeamlessClone(Mat src, Mat dst, Mat mask, Point p, Mat blend, int flags) {
     try {
         cv::Point pt(p.x, p.y);
         cv::seamlessClone(*src, *dst, *mask, pt, *blend, flags);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void TextureFlattening(Mat src, Mat mask, Mat dst, float low_threshold, float high_threshold, int kernel_size) {
+OpenCVResult TextureFlattening(Mat src, Mat mask, Mat dst, float low_threshold, float high_threshold, int kernel_size) {
     try {
         cv::textureFlattening(*src, *mask, *dst, low_threshold, high_threshold, kernel_size);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
 
-void FastNlMeansDenoisingColoredMulti(	struct Mats src, Mat dst, int imgToDenoiseIndex, int 	temporalWindowSize){
+OpenCVResult FastNlMeansDenoisingColoredMulti(	struct Mats src, Mat dst, int imgToDenoiseIndex, int 	temporalWindowSize){
     try {
         std::vector<cv::Mat> images;
         for (int i = 0; i < src.length; ++i) {
             images.push_back(*src.mats[i]);
         }
         cv::fastNlMeansDenoisingColoredMulti( images, *dst, imgToDenoiseIndex, 	temporalWindowSize );
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void FastNlMeansDenoisingColoredMultiWithParams( struct Mats src, Mat dst, int imgToDenoiseIndex, int 	temporalWindowSize, float 	h, float 	hColor, int 	templateWindowSize, int 	searchWindowSize ){
+OpenCVResult FastNlMeansDenoisingColoredMultiWithParams( struct Mats src, Mat dst, int imgToDenoiseIndex, int 	temporalWindowSize, float 	h, float 	hColor, int 	templateWindowSize, int 	searchWindowSize ){
     try {
         std::vector<cv::Mat> images;
         for (int i = 0; i < src.length; ++i) {
             images.push_back(*src.mats[i]);
         }
         cv::fastNlMeansDenoisingColoredMulti( images, *dst, imgToDenoiseIndex, 	temporalWindowSize, h, hColor, templateWindowSize, searchWindowSize );
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -82,15 +88,16 @@ void MergeMertens_Close(MergeMertens b) {
     delete b;
 }
 
-void MergeMertens_Process(MergeMertens b, struct Mats src, Mat dst) {
+OpenCVResult MergeMertens_Process(MergeMertens b, struct Mats src, Mat dst) {
     try {
         std::vector<cv::Mat> images;
         for (int i = 0; i < src.length; ++i) {
             images.push_back(*src.mats[i]);
         }
         (*b)->process(images, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
@@ -114,7 +121,7 @@ AlignMTB AlignMTB_CreateWithParams(int max_bits, int exclude_range, bool cut) {
 
 void AlignMTB_Close(AlignMTB b) { delete b; }
 
-void AlignMTB_Process(AlignMTB b, struct Mats src, struct Mats *dst) {
+OpenCVResult AlignMTB_Process(AlignMTB b, struct Mats src, struct Mats *dst) {
     try {
         std::vector<cv::Mat> srcMats;
         for (int i = 0; i < src.length; ++i) {
@@ -129,79 +136,89 @@ void AlignMTB_Process(AlignMTB b, struct Mats src, struct Mats *dst) {
             dst->mats[i] = new cv::Mat( dstMats[i] );
         }
         dst->length = (int)dstMats.size();
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void FastNlMeansDenoising(Mat src, Mat dst) {
+OpenCVResult FastNlMeansDenoising(Mat src, Mat dst) {
     try {
         cv::fastNlMeansDenoising(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void FastNlMeansDenoisingWithParams(Mat src, Mat dst, float h, int templateWindowSize, int searchWindowSize) {
+OpenCVResult FastNlMeansDenoisingWithParams(Mat src, Mat dst, float h, int templateWindowSize, int searchWindowSize) {
     try {
         cv::fastNlMeansDenoising(*src, *dst, h, templateWindowSize, searchWindowSize);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void FastNlMeansDenoisingColored(Mat src, Mat dst) {
+OpenCVResult FastNlMeansDenoisingColored(Mat src, Mat dst) {
     try {
         cv::fastNlMeansDenoisingColored(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void FastNlMeansDenoisingColoredWithParams(Mat src, Mat dst, float h, float hColor, int templateWindowSize, int searchWindowSize) {
+OpenCVResult FastNlMeansDenoisingColoredWithParams(Mat src, Mat dst, float h, float hColor, int templateWindowSize, int searchWindowSize) {
     try {
         cv::fastNlMeansDenoisingColored(*src, *dst, h, hColor, templateWindowSize, searchWindowSize);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void EdgePreservingFilter(Mat src, Mat dst, int filter, float sigma_s, float sigma_r) {
+OpenCVResult EdgePreservingFilter(Mat src, Mat dst, int filter, float sigma_s, float sigma_r) {
     try {
         cv::edgePreservingFilter(*src, *dst, filter, sigma_s, sigma_r);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void DetailEnhance(Mat src, Mat dst, float sigma_s, float sigma_r) {
+OpenCVResult DetailEnhance(Mat src, Mat dst, float sigma_s, float sigma_r) {
     try {
         cv::detailEnhance(*src, *dst, sigma_s, sigma_r);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void PencilSketch(Mat src, Mat dst1, Mat dst2, float sigma_s, float sigma_r, float shade_factor) {
+OpenCVResult PencilSketch(Mat src, Mat dst1, Mat dst2, float sigma_s, float sigma_r, float shade_factor) {
     try {
         cv::pencilSketch(*src, *dst1, *dst2, sigma_s, sigma_r, shade_factor);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void Stylization(Mat src, Mat dst, float sigma_s, float sigma_r) {
+OpenCVResult Stylization(Mat src, Mat dst, float sigma_s, float sigma_r) {
     try {
         cv::stylization(*src, *dst, sigma_s, sigma_r);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }
 
-void PhotoInpaint(Mat src, Mat mask, Mat dst, float inpaint_radius, int algorithm_type) {
+OpenCVResult PhotoInpaint(Mat src, Mat mask, Mat dst, float inpaint_radius, int algorithm_type) {
     try {
         cv::inpaint(*src, *mask, *dst, inpaint_radius, algorithm_type);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }

--- a/photo.go
+++ b/photo.go
@@ -39,44 +39,44 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/master/df/da0/group__photo__clone.html#ga6684f35dc669ff6196a7c340dc73b98e
-func ColorChange(src, mask Mat, dst *Mat, red_mul, green_mul, blue_mul float32) {
-	C.ColorChange(src.p, mask.p, dst.p, C.float(red_mul), C.float(green_mul), C.float(blue_mul))
+func ColorChange(src, mask Mat, dst *Mat, red_mul, green_mul, blue_mul float32) error {
+	return OpenCVResult(C.ColorChange(src.p, mask.p, dst.p, C.float(red_mul), C.float(green_mul), C.float(blue_mul)))
 }
 
 // SeamlessClone blend two image by Poisson Blending.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/df/da0/group__photo__clone.html#ga2bf426e4c93a6b1f21705513dfeca49d
-func SeamlessClone(src, dst, mask Mat, p image.Point, blend *Mat, flags SeamlessCloneFlags) {
+func SeamlessClone(src, dst, mask Mat, p image.Point, blend *Mat, flags SeamlessCloneFlags) error {
 	cp := C.struct_Point{
 		x: C.int(p.X),
 		y: C.int(p.Y),
 	}
 
-	C.SeamlessClone(src.p, dst.p, mask.p, cp, blend.p, C.int(flags))
+	return OpenCVResult(C.SeamlessClone(src.p, dst.p, mask.p, cp, blend.p, C.int(flags)))
 }
 
 // IlluminationChange modifies locally the apparent illumination of an image.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/df/da0/group__photo__clone.html#gac5025767cf2febd8029d474278e886c7
-func IlluminationChange(src, mask Mat, dst *Mat, alpha, beta float32) {
-	C.IlluminationChange(src.p, mask.p, dst.p, C.float(alpha), C.float(beta))
+func IlluminationChange(src, mask Mat, dst *Mat, alpha, beta float32) error {
+	return OpenCVResult(C.IlluminationChange(src.p, mask.p, dst.p, C.float(alpha), C.float(beta)))
 }
 
 // TextureFlattening washes out the texture of the selected region, giving its contents a flat aspect.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/df/da0/group__photo__clone.html#gad55df6aa53797365fa7cc23959a54004
-func TextureFlattening(src, mask Mat, dst *Mat, lowThreshold, highThreshold float32, kernelSize int) {
-	C.TextureFlattening(src.p, mask.p, dst.p, C.float(lowThreshold), C.float(highThreshold), C.int(kernelSize))
+func TextureFlattening(src, mask Mat, dst *Mat, lowThreshold, highThreshold float32, kernelSize int) error {
+	return OpenCVResult(C.TextureFlattening(src.p, mask.p, dst.p, C.float(lowThreshold), C.float(highThreshold), C.int(kernelSize)))
 }
 
 // FastNlMeansDenoisingColoredMulti denoises the selected images.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/d79/group__photo__denoise.html#gaa501e71f52fb2dc17ff8ca5e7d2d3619
-func FastNlMeansDenoisingColoredMulti(src []Mat, dst *Mat, imgToDenoiseIndex int, temporalWindowSize int) {
+func FastNlMeansDenoisingColoredMulti(src []Mat, dst *Mat, imgToDenoiseIndex int, temporalWindowSize int) error {
 	cMatArray := make([]C.Mat, len(src))
 	for i, r := range src {
 		cMatArray[i] = (C.Mat)(r.p)
@@ -85,14 +85,14 @@ func FastNlMeansDenoisingColoredMulti(src []Mat, dst *Mat, imgToDenoiseIndex int
 		mats:   (*C.Mat)(&cMatArray[0]),
 		length: C.int(len(src)),
 	}
-	C.FastNlMeansDenoisingColoredMulti(matsVector, dst.p, C.int(imgToDenoiseIndex), C.int(temporalWindowSize))
+	return OpenCVResult(C.FastNlMeansDenoisingColoredMulti(matsVector, dst.p, C.int(imgToDenoiseIndex), C.int(temporalWindowSize)))
 }
 
 // FastNlMeansDenoisingColoredMulti denoises the selected images.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d1/d79/group__photo__denoise.html#gaa501e71f52fb2dc17ff8ca5e7d2d3619
-func FastNlMeansDenoisingColoredMultiWithParams(src []Mat, dst *Mat, imgToDenoiseIndex int, temporalWindowSize int, h float32, hColor float32, templateWindowSize int, searchWindowSize int) {
+func FastNlMeansDenoisingColoredMultiWithParams(src []Mat, dst *Mat, imgToDenoiseIndex int, temporalWindowSize int, h float32, hColor float32, templateWindowSize int, searchWindowSize int) error {
 	cMatArray := make([]C.Mat, len(src))
 	for i, r := range src {
 		cMatArray[i] = (C.Mat)(r.p)
@@ -101,7 +101,7 @@ func FastNlMeansDenoisingColoredMultiWithParams(src []Mat, dst *Mat, imgToDenois
 		mats:   (*C.Mat)(&cMatArray[0]),
 		length: C.int(len(src)),
 	}
-	C.FastNlMeansDenoisingColoredMultiWithParams(matsVector, dst.p, C.int(imgToDenoiseIndex), C.int(temporalWindowSize), C.float(h), C.float(hColor), C.int(templateWindowSize), C.int(searchWindowSize))
+	return OpenCVResult(C.FastNlMeansDenoisingColoredMultiWithParams(matsVector, dst.p, C.int(imgToDenoiseIndex), C.int(temporalWindowSize), C.float(h), C.float(hColor), C.int(templateWindowSize), C.int(searchWindowSize)))
 }
 
 // NewMergeMertens returns returns a new MergeMertens white LDR merge algorithm.
@@ -139,7 +139,7 @@ func (b *MergeMertens) Close() error {
 // Return a image MAT : 8bits 3 channel image ( RGB 8 bits )
 // For further details, please see:
 // https://docs.opencv.org/master/d7/dd6/classcv_1_1MergeMertens.html#a2d2254b2aab722c16954de13a663644d
-func (b *MergeMertens) Process(src []Mat, dst *Mat) {
+func (b *MergeMertens) Process(src []Mat, dst *Mat) error {
 	cMatArray := make([]C.Mat, len(src))
 	for i, r := range src {
 		cMatArray[i] = (C.Mat)(r.p)
@@ -149,9 +149,10 @@ func (b *MergeMertens) Process(src []Mat, dst *Mat) {
 		mats:   (*C.Mat)(&cMatArray[0]),
 		length: C.int(len(src)),
 	}
-	C.MergeMertens_Process((C.MergeMertens)(b.p), matsVector, dst.p)
+	res := C.MergeMertens_Process((C.MergeMertens)(b.p), matsVector, dst.p)
 	// Convert a series of double [0.0,1.0] to [0,255] with Golang
 	dst.ConvertToWithParams(dst, MatTypeCV8UC3, 255.0, 0.0)
+	return OpenCVResult(res)
 }
 
 // NewAlignMTB returns an AlignMTB for converts images to median threshold bitmaps.
@@ -191,7 +192,7 @@ func (b *AlignMTB) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/db6/classcv_1_1AlignMTB.html#a37b3417d844f362d781f34155cbcb201
-func (b *AlignMTB) Process(src []Mat, dst *[]Mat) {
+func (b *AlignMTB) Process(src []Mat, dst *[]Mat) error {
 
 	cSrcArray := make([]C.Mat, len(src))
 	for i, r := range src {
@@ -204,7 +205,7 @@ func (b *AlignMTB) Process(src []Mat, dst *[]Mat) {
 
 	cDstMats := C.struct_Mats{}
 
-	C.AlignMTB_Process((C.AlignMTB)(b.p), cSrcMats, &cDstMats)
+	res := C.AlignMTB_Process((C.AlignMTB)(b.p), cSrcMats, &cDstMats)
 
 	// Pass the matrices by reference from an OpenCV/C++ to a GoCV::Mat object
 	for i := C.int(0); i < cDstMats.length; i++ {
@@ -212,7 +213,7 @@ func (b *AlignMTB) Process(src []Mat, dst *[]Mat) {
 		tempdst.p = C.Mats_get(cDstMats, i)
 		*dst = append(*dst, tempdst)
 	}
-	return
+	return OpenCVResult(res)
 }
 
 // FastNlMeansDenoising performs image denoising using Non-local Means Denoising algorithm
@@ -220,8 +221,8 @@ func (b *AlignMTB) Process(src []Mat, dst *[]Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d1/d79/group__photo__denoise.html#ga4c6b0031f56ea3f98f768881279ffe93
-func FastNlMeansDenoising(src Mat, dst *Mat) {
-	C.FastNlMeansDenoising(src.p, dst.p)
+func FastNlMeansDenoising(src Mat, dst *Mat) error {
+	return OpenCVResult(C.FastNlMeansDenoising(src.p, dst.p))
 }
 
 // FastNlMeansDenoisingWithParams performs image denoising using Non-local Means Denoising algorithm
@@ -229,32 +230,32 @@ func FastNlMeansDenoising(src Mat, dst *Mat) {
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d1/d79/group__photo__denoise.html#ga4c6b0031f56ea3f98f768881279ffe93
-func FastNlMeansDenoisingWithParams(src Mat, dst *Mat, h float32, templateWindowSize int, searchWindowSize int) {
-	C.FastNlMeansDenoisingWithParams(src.p, dst.p, C.float(h), C.int(templateWindowSize), C.int(searchWindowSize))
+func FastNlMeansDenoisingWithParams(src Mat, dst *Mat, h float32, templateWindowSize int, searchWindowSize int) error {
+	return OpenCVResult(C.FastNlMeansDenoisingWithParams(src.p, dst.p, C.float(h), C.int(templateWindowSize), C.int(searchWindowSize)))
 }
 
 // FastNlMeansDenoisingColored is a modification of fastNlMeansDenoising function for colored images.
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d1/d79/group__photo__denoise.html#ga21abc1c8b0e15f78cd3eff672cb6c476
-func FastNlMeansDenoisingColored(src Mat, dst *Mat) {
-	C.FastNlMeansDenoisingColored(src.p, dst.p)
+func FastNlMeansDenoisingColored(src Mat, dst *Mat) error {
+	return OpenCVResult(C.FastNlMeansDenoisingColored(src.p, dst.p))
 }
 
 // FastNlMeansDenoisingColoredWithParams is a modification of fastNlMeansDenoising function for colored images.
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d1/d79/group__photo__denoise.html#ga21abc1c8b0e15f78cd3eff672cb6c476
-func FastNlMeansDenoisingColoredWithParams(src Mat, dst *Mat, h float32, hColor float32, templateWindowSize int, searchWindowSize int) {
-	C.FastNlMeansDenoisingColoredWithParams(src.p, dst.p, C.float(h), C.float(hColor), C.int(templateWindowSize), C.int(searchWindowSize))
+func FastNlMeansDenoisingColoredWithParams(src Mat, dst *Mat, h float32, hColor float32, templateWindowSize int, searchWindowSize int) error {
+	return OpenCVResult(C.FastNlMeansDenoisingColoredWithParams(src.p, dst.p, C.float(h), C.float(hColor), C.int(templateWindowSize), C.int(searchWindowSize)))
 }
 
 // DetailEnhance filter enhances the details of a particular image
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/dac/group__photo__render.html#gae5930dd822c713b36f8529b21ddebd0c
-func DetailEnhance(src Mat, dst *Mat, sigma_s, sigma_r float32) {
-	C.DetailEnhance(src.p, dst.p, C.float(sigma_s), C.float(sigma_r))
+func DetailEnhance(src Mat, dst *Mat, sigma_s, sigma_r float32) error {
+	return OpenCVResult(C.DetailEnhance(src.p, dst.p, C.float(sigma_s), C.float(sigma_r)))
 }
 
 type EdgeFilter int
@@ -272,16 +273,16 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/dac/group__photo__render.html#gafaee2977597029bc8e35da6e67bd31f7
-func EdgePreservingFilter(src Mat, dst *Mat, filter EdgeFilter, sigma_s, sigma_r float32) {
-	C.EdgePreservingFilter(src.p, dst.p, C.int(filter), C.float(sigma_s), C.float(sigma_r))
+func EdgePreservingFilter(src Mat, dst *Mat, filter EdgeFilter, sigma_s, sigma_r float32) error {
+	return OpenCVResult(C.EdgePreservingFilter(src.p, dst.p, C.int(filter), C.float(sigma_s), C.float(sigma_r)))
 }
 
 // PencilSketch pencil-like non-photorealistic line drawing.
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/dac/group__photo__render.html#gae5930dd822c713b36f8529b21ddebd0c
-func PencilSketch(src Mat, dst1, dst2 *Mat, sigma_s, sigma_r, shade_factor float32) {
-	C.PencilSketch(src.p, dst1.p, dst2.p, C.float(sigma_s), C.float(sigma_r), C.float(shade_factor))
+func PencilSketch(src Mat, dst1, dst2 *Mat, sigma_s, sigma_r, shade_factor float32) error {
+	return OpenCVResult(C.PencilSketch(src.p, dst1.p, dst2.p, C.float(sigma_s), C.float(sigma_r), C.float(shade_factor)))
 }
 
 // Stylization aims to produce digital imagery with a wide variety of effects
@@ -291,8 +292,8 @@ func PencilSketch(src Mat, dst1, dst2 *Mat, sigma_s, sigma_r, shade_factor float
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/df/dac/group__photo__render.html#gacb0f7324017df153d7b5d095aed53206
-func Stylization(src Mat, dst *Mat, sigma_s, sigma_r float32) {
-	C.Stylization(src.p, dst.p, C.float(sigma_s), C.float(sigma_r))
+func Stylization(src Mat, dst *Mat, sigma_s, sigma_r float32) error {
+	return OpenCVResult(C.Stylization(src.p, dst.p, C.float(sigma_s), C.float(sigma_r)))
 }
 
 // InpaintMethods is the methods for inpainting process.
@@ -313,6 +314,6 @@ const (
 //
 // For further details, please see:
 // https://docs.opencv.org/4.x/d7/d8b/group__photo__inpaint.html#gaedd30dfa0214fec4c88138b51d678085
-func Inpaint(src Mat, mask Mat, dst *Mat, inpaintRadius float32, algorithmType InpaintMethods) {
-	C.PhotoInpaint(C.Mat(src.Ptr()), C.Mat(mask.Ptr()), C.Mat(dst.Ptr()), C.float(inpaintRadius), C.int(algorithmType))
+func Inpaint(src Mat, mask Mat, dst *Mat, inpaintRadius float32, algorithmType InpaintMethods) error {
+	return OpenCVResult(C.PhotoInpaint(C.Mat(src.Ptr()), C.Mat(mask.Ptr()), C.Mat(dst.Ptr()), C.float(inpaintRadius), C.int(algorithmType)))
 }

--- a/photo.h
+++ b/photo.h
@@ -19,37 +19,37 @@ typedef void *MergeMertens;
 typedef void *AlignMTB;
 #endif
 
-void ColorChange(Mat src, Mat mask, Mat dst, float red_mul, float green_mul, float blue_mul);
+OpenCVResult ColorChange(Mat src, Mat mask, Mat dst, float red_mul, float green_mul, float blue_mul);
 
-void SeamlessClone(Mat src, Mat dst, Mat mask, Point p, Mat blend, int flags);
+OpenCVResult SeamlessClone(Mat src, Mat dst, Mat mask, Point p, Mat blend, int flags);
 
-void IlluminationChange(Mat src, Mat mask, Mat dst, float alpha, float beta);
+OpenCVResult IlluminationChange(Mat src, Mat mask, Mat dst, float alpha, float beta);
 
-void TextureFlattening(Mat src, Mat mask, Mat dst, float low_threshold, float high_threshold, int kernel_size);
+OpenCVResult TextureFlattening(Mat src, Mat mask, Mat dst, float low_threshold, float high_threshold, int kernel_size);
 
-void FastNlMeansDenoisingColoredMulti(struct Mats src, Mat dst, int imgToDenoiseIndex, int 	temporalWindowSize);
-void FastNlMeansDenoisingColoredMultiWithParams(struct Mats src, Mat dst, int imgToDenoiseIndex, int 	temporalWindowSize, float 	h, float 	hColor, int 	templateWindowSize, int 	searchWindowSize );
-void FastNlMeansDenoising(Mat src, Mat dst);
-void FastNlMeansDenoisingWithParams(Mat src, Mat dst, float h, int templateWindowSize, int searchWindowSize);
-void FastNlMeansDenoisingColored(Mat src, Mat dst);
-void FastNlMeansDenoisingColoredWithParams(Mat src, Mat dst, float h, float hColor, int templateWindowSize, int searchWindowSize);
+OpenCVResult FastNlMeansDenoisingColoredMulti(struct Mats src, Mat dst, int imgToDenoiseIndex, int 	temporalWindowSize);
+OpenCVResult FastNlMeansDenoisingColoredMultiWithParams(struct Mats src, Mat dst, int imgToDenoiseIndex, int 	temporalWindowSize, float 	h, float 	hColor, int 	templateWindowSize, int 	searchWindowSize );
+OpenCVResult FastNlMeansDenoising(Mat src, Mat dst);
+OpenCVResult FastNlMeansDenoisingWithParams(Mat src, Mat dst, float h, int templateWindowSize, int searchWindowSize);
+OpenCVResult FastNlMeansDenoisingColored(Mat src, Mat dst);
+OpenCVResult FastNlMeansDenoisingColoredWithParams(Mat src, Mat dst, float h, float hColor, int templateWindowSize, int searchWindowSize);
 
 MergeMertens MergeMertens_Create();
 MergeMertens MergeMertens_CreateWithParams(float contrast_weight, float saturation_weight, float exposure_weight);
-void MergeMertens_Process(MergeMertens b, struct Mats src, Mat dst);
+OpenCVResult MergeMertens_Process(MergeMertens b, struct Mats src, Mat dst);
 void MergeMertens_Close(MergeMertens b);
 
 AlignMTB AlignMTB_Create();
 AlignMTB AlignMTB_CreateWithParams(int max_bits, int exclude_range, bool cut);
-void AlignMTB_Process(AlignMTB b, struct Mats src, struct Mats *dst);
+OpenCVResult AlignMTB_Process(AlignMTB b, struct Mats src, struct Mats *dst);
 void AlignMTB_Close(AlignMTB b);
 
-void DetailEnhance(Mat src, Mat dst, float sigma_s, float sigma_r);
-void EdgePreservingFilter(Mat src, Mat dst, int filter, float sigma_s, float sigma_r);
-void PencilSketch(Mat src, Mat dst1, Mat dst2, float sigma_s, float sigma_r, float shade_factor);
-void Stylization(Mat src, Mat dst, float sigma_s, float sigma_r);
+OpenCVResult DetailEnhance(Mat src, Mat dst, float sigma_s, float sigma_r);
+OpenCVResult EdgePreservingFilter(Mat src, Mat dst, int filter, float sigma_s, float sigma_r);
+OpenCVResult PencilSketch(Mat src, Mat dst1, Mat dst2, float sigma_s, float sigma_r, float shade_factor);
+OpenCVResult Stylization(Mat src, Mat dst, float sigma_s, float sigma_r);
 
-void PhotoInpaint(Mat src, Mat mask, Mat dst, float inpaint_radius, int algorithm_type);
+OpenCVResult PhotoInpaint(Mat src, Mat mask, Mat dst, float inpaint_radius, int algorithm_type);
 
 #ifdef __cplusplus
 }

--- a/svd.cpp
+++ b/svd.cpp
@@ -1,5 +1,9 @@
 #include "svd.h"
 
 void SVD_Compute(Mat src, Mat w, Mat u, Mat vt) {
-    cv::SVD::compute(*src, *w, *u, *vt, 0);
+    try {
+        cv::SVD::compute(*src, *w, *u, *vt, 0);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }

--- a/svd.cpp
+++ b/svd.cpp
@@ -1,9 +1,10 @@
 #include "svd.h"
 
-void SVD_Compute(Mat src, Mat w, Mat u, Mat vt) {
+OpenCVResult SVD_Compute(Mat src, Mat w, Mat u, Mat vt) {
     try {
         cv::SVD::compute(*src, *w, *u, *vt, 0);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
     }
 }

--- a/svd.go
+++ b/svd.go
@@ -9,6 +9,6 @@ import "C"
 // SVDCompute decomposes matrix and stores the results to user-provided matrices
 //
 // https://docs.opencv.org/4.1.2/df/df7/classcv_1_1SVD.html#a76f0b2044df458160292045a3d3714c6
-func SVDCompute(src Mat, w, u, vt *Mat) {
-	C.SVD_Compute(src.Ptr(), w.Ptr(), u.Ptr(), vt.Ptr())
+func SVDCompute(src Mat, w, u, vt *Mat) error {
+	return OpenCVResult(C.SVD_Compute(src.Ptr(), w.Ptr(), u.Ptr(), vt.Ptr()))
 }

--- a/svd.h
+++ b/svd.h
@@ -9,7 +9,7 @@ extern "C" {
 
 #include "core.h"
 
-void SVD_Compute(Mat src, Mat w, Mat u, Mat vt);
+OpenCVResult SVD_Compute(Mat src, Mat w, Mat u, Mat vt);
 
 #ifdef __cplusplus
 }

--- a/video.cpp
+++ b/video.cpp
@@ -40,58 +40,76 @@ void BackgroundSubtractorMOG2_Close(BackgroundSubtractorMOG2 b) {
     delete b;
 }
 
-void BackgroundSubtractorMOG2_Apply(BackgroundSubtractorMOG2 b, Mat src, Mat dst) {
-    try {
+OpenCVResult BackgroundSubtractorMOG2_Apply(BackgroundSubtractorMOG2 b, Mat src, Mat dst) {
+  	try {
 		(*b)->apply(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+      	OpenCVResult result = {0, NULL};
+      	return result;
+  	} catch(const cv::Exception& e) {
+      	OpenCVResult result = {e.code, e.what()};
+      	return result;
     }
 }
 
-void BackgroundSubtractorMOG2_ApplyWithParams(BackgroundSubtractorMOG2 b, Mat src, Mat dst, double learningRate) {
+OpenCVResult BackgroundSubtractorMOG2_ApplyWithParams(BackgroundSubtractorMOG2 b, Mat src, Mat dst, double learningRate) {
     try {
 		(*b)->apply(*src, *dst, learningRate);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
-    }
+		OpenCVResult result = {0, NULL};
+		return result;
+	} catch(const cv::Exception& e) {
+		OpenCVResult result = {e.code, e.what()};
+		return result;
+  	}
 }
 
 void BackgroundSubtractorKNN_Close(BackgroundSubtractorKNN k) {
     delete k;
 }
 
-void BackgroundSubtractorKNN_Apply(BackgroundSubtractorKNN k, Mat src, Mat dst) {
+OpenCVResult BackgroundSubtractorKNN_Apply(BackgroundSubtractorKNN k, Mat src, Mat dst) {
     try {
 		(*k)->apply(*src, *dst);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
-    }
+		OpenCVResult result = {0, NULL};
+		return result;
+	} catch(const cv::Exception& e) {
+		OpenCVResult result = {e.code, e.what()};
+		return result;
+  	}
 }
 
-void CalcOpticalFlowFarneback(Mat prevImg, Mat nextImg, Mat flow, double scale, int levels,
+OpenCVResult CalcOpticalFlowFarneback(Mat prevImg, Mat nextImg, Mat flow, double scale, int levels,
                               int winsize, int iterations, int polyN, double polySigma, int flags) {
 	try {
 		cv::calcOpticalFlowFarneback(*prevImg, *nextImg, *flow, scale, levels, winsize, iterations, polyN, polySigma, flags);
-	} catch(const cv::Exception& e){
-		setExceptionInfo(e.code, e.what());
+		OpenCVResult result = {0, NULL};
+		return result;
+	} catch(const cv::Exception& e) {
+		OpenCVResult result = {e.code, e.what()};
+		return result;
+  	}
+}
+
+OpenCVResult CalcOpticalFlowPyrLK(Mat prevImg, Mat nextImg, Mat prevPts, Mat nextPts, Mat status, Mat err) {
+    try {
+		cv::calcOpticalFlowPyrLK(*prevImg, *nextImg, *prevPts, *nextPts, *status, *err);
+		OpenCVResult result = {0, NULL};
+		return result;
+	} catch(const cv::Exception& e) {
+		OpenCVResult result = {e.code, e.what()};
+		return result;
 	}
 }
 
-void CalcOpticalFlowPyrLK(Mat prevImg, Mat nextImg, Mat prevPts, Mat nextPts, Mat status, Mat err) {
-    try {
-		cv::calcOpticalFlowPyrLK(*prevImg, *nextImg, *prevPts, *nextPts, *status, *err);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
-    }
-}
-
-void CalcOpticalFlowPyrLKWithParams(Mat prevImg, Mat nextImg, Mat prevPts, Mat nextPts, Mat status, Mat err, Size winSize, int maxLevel, TermCriteria criteria, int flags, double minEigThreshold){
+OpenCVResult CalcOpticalFlowPyrLKWithParams(Mat prevImg, Mat nextImg, Mat prevPts, Mat nextPts, Mat status, Mat err, Size winSize, int maxLevel, TermCriteria criteria, int flags, double minEigThreshold){
     try {
 		cv::Size sz(winSize.width, winSize.height);
 		cv::calcOpticalFlowPyrLK(*prevImg, *nextImg, *prevPts, *nextPts, *status, *err, sz, maxLevel, *criteria, flags, minEigThreshold);
-	} catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
-    }
+		OpenCVResult result = {0, NULL};
+		return result;
+	} catch(const cv::Exception& e) {
+		OpenCVResult result = {e.code, e.what()};
+		return result;
+  	}
 }
 
 double FindTransformECC(Mat templateImage, Mat inputImage, Mat warpMatrix, int motionType, TermCriteria criteria, Mat inputMask, int gaussFiltSize){
@@ -188,20 +206,26 @@ KalmanFilter KalmanFilter_NewWithParams(int dynamParams, int measureParams, int 
     }
 }
 
-void KalmanFilter_Init(KalmanFilter kf, int dynamParams, int measureParams) {
+OpenCVResult KalmanFilter_Init(KalmanFilter kf, int dynamParams, int measureParams) {
     try {
 		kf->init(dynamParams, measureParams, 0, CV_32F);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
-    }
+		OpenCVResult result = {0, NULL};
+		return result;
+	} catch(const cv::Exception& e) {
+		OpenCVResult result = {e.code, e.what()};
+		return result;
+  	}
 }
 
-void KalmanFilter_InitWithParams(KalmanFilter kf, int dynamParams, int measureParams, int controlParams, int type) {
+OpenCVResult KalmanFilter_InitWithParams(KalmanFilter kf, int dynamParams, int measureParams, int controlParams, int type) {
     try {
 		kf->init(dynamParams, measureParams, controlParams, type);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
-    }
+		OpenCVResult result = {0, NULL};
+		return result;
+	} catch(const cv::Exception& e) {
+		OpenCVResult result = {e.code, e.what()};
+		return result;
+  	}
 }
 
 void KalmanFilter_Close(KalmanFilter kf) {

--- a/video.cpp
+++ b/video.cpp
@@ -1,19 +1,39 @@
 #include "video.h"
 
 BackgroundSubtractorMOG2 BackgroundSubtractorMOG2_Create() {
-    return new cv::Ptr<cv::BackgroundSubtractorMOG2>(cv::createBackgroundSubtractorMOG2());
+    try {
+		return new cv::Ptr<cv::BackgroundSubtractorMOG2>(cv::createBackgroundSubtractorMOG2());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return NULL;
+    }
 }
 
 BackgroundSubtractorMOG2 BackgroundSubtractorMOG2_CreateWithParams(int history, double varThreshold, bool detectShadows) {
-    return new cv::Ptr<cv::BackgroundSubtractorMOG2>(cv::createBackgroundSubtractorMOG2(history,varThreshold,detectShadows));
+    try {
+		return new cv::Ptr<cv::BackgroundSubtractorMOG2>(cv::createBackgroundSubtractorMOG2(history,varThreshold,detectShadows));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return NULL;
+    }
 }
 
 BackgroundSubtractorKNN BackgroundSubtractorKNN_Create() {
-    return new cv::Ptr<cv::BackgroundSubtractorKNN>(cv::createBackgroundSubtractorKNN());
+    try {
+		return new cv::Ptr<cv::BackgroundSubtractorKNN>(cv::createBackgroundSubtractorKNN());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return NULL;
+    }
 }
 
 BackgroundSubtractorKNN BackgroundSubtractorKNN_CreateWithParams(int history, double dist2Threshold, bool detectShadows) {
-    return new cv::Ptr<cv::BackgroundSubtractorKNN>(cv::createBackgroundSubtractorKNN(history,dist2Threshold,detectShadows));
+    try {
+		return new cv::Ptr<cv::BackgroundSubtractorKNN>(cv::createBackgroundSubtractorKNN(history,dist2Threshold,detectShadows));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return NULL;
+    }
 }
 
 void BackgroundSubtractorMOG2_Close(BackgroundSubtractorMOG2 b) {
@@ -21,11 +41,19 @@ void BackgroundSubtractorMOG2_Close(BackgroundSubtractorMOG2 b) {
 }
 
 void BackgroundSubtractorMOG2_Apply(BackgroundSubtractorMOG2 b, Mat src, Mat dst) {
-    (*b)->apply(*src, *dst);
+    try {
+		(*b)->apply(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void BackgroundSubtractorMOG2_ApplyWithParams(BackgroundSubtractorMOG2 b, Mat src, Mat dst, double learningRate) {
-    (*b)->apply(*src, *dst, learningRate);
+    try {
+		(*b)->apply(*src, *dst, learningRate);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void BackgroundSubtractorKNN_Close(BackgroundSubtractorKNN k) {
@@ -33,47 +61,82 @@ void BackgroundSubtractorKNN_Close(BackgroundSubtractorKNN k) {
 }
 
 void BackgroundSubtractorKNN_Apply(BackgroundSubtractorKNN k, Mat src, Mat dst) {
-    (*k)->apply(*src, *dst);
+    try {
+		(*k)->apply(*src, *dst);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void CalcOpticalFlowFarneback(Mat prevImg, Mat nextImg, Mat flow, double scale, int levels,
                               int winsize, int iterations, int polyN, double polySigma, int flags) {
-    cv::calcOpticalFlowFarneback(*prevImg, *nextImg, *flow, scale, levels, winsize, iterations, polyN,
-                                 polySigma, flags);
+	try {
+		cv::calcOpticalFlowFarneback(*prevImg, *nextImg, *flow, scale, levels, winsize, iterations, polyN, polySigma, flags);
+	} catch(const cv::Exception& e){
+		setExceptionInfo(e.code, e.what());
+	}
 }
 
 void CalcOpticalFlowPyrLK(Mat prevImg, Mat nextImg, Mat prevPts, Mat nextPts, Mat status, Mat err) {
-    cv::calcOpticalFlowPyrLK(*prevImg, *nextImg, *prevPts, *nextPts, *status, *err);
+    try {
+		cv::calcOpticalFlowPyrLK(*prevImg, *nextImg, *prevPts, *nextPts, *status, *err);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void CalcOpticalFlowPyrLKWithParams(Mat prevImg, Mat nextImg, Mat prevPts, Mat nextPts, Mat status, Mat err, Size winSize, int maxLevel, TermCriteria criteria, int flags, double minEigThreshold){
-    cv::Size sz(winSize.width, winSize.height);
-    cv::calcOpticalFlowPyrLK(*prevImg, *nextImg, *prevPts, *nextPts, *status, *err, sz, maxLevel, *criteria, flags, minEigThreshold);
+    try {
+		cv::Size sz(winSize.width, winSize.height);
+		cv::calcOpticalFlowPyrLK(*prevImg, *nextImg, *prevPts, *nextPts, *status, *err, sz, maxLevel, *criteria, flags, minEigThreshold);
+	} catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 double FindTransformECC(Mat templateImage, Mat inputImage, Mat warpMatrix, int motionType, TermCriteria criteria, Mat inputMask, int gaussFiltSize){
-    return cv::findTransformECC(*templateImage, *inputImage, *warpMatrix, motionType, *criteria, *inputMask, gaussFiltSize);
+    try {
+		return cv::findTransformECC(*templateImage, *inputImage, *warpMatrix, motionType, *criteria, *inputMask, gaussFiltSize);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return 0.0;
+	}
 }
 
 bool Tracker_Init(Tracker self, Mat image, Rect boundingBox) {
-    cv::Rect bb(boundingBox.x, boundingBox.y, boundingBox.width, boundingBox.height);
+    try {
+		cv::Rect bb(boundingBox.x, boundingBox.y, boundingBox.width, boundingBox.height);
 
-    (*self)->init(*image, bb);
-    return true;
+		(*self)->init(*image, bb);
+		return true;
+	} catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return false;
+	}
 }
 
 bool Tracker_Update(Tracker self, Mat image, Rect* boundingBox) {
-    cv::Rect bb;
-    bool ret = (*self)->update(*image, bb);
-    boundingBox->x = int(bb.x);
-    boundingBox->y = int(bb.y);
-    boundingBox->width = int(bb.width);
-    boundingBox->height = int(bb.height);
-    return ret;
+    try {
+		cv::Rect bb;
+		bool ret = (*self)->update(*image, bb);
+		boundingBox->x = int(bb.x);
+		boundingBox->y = int(bb.y);
+		boundingBox->width = int(bb.width);
+		boundingBox->height = int(bb.height);
+		return ret;
+	} catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return false;
+	}
 }
 
 TrackerMIL TrackerMIL_Create() {
-    return new cv::Ptr<cv::TrackerMIL>(cv::TrackerMIL::create());
+    try {
+		return new cv::Ptr<cv::TrackerMIL>(cv::TrackerMIL::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return NULL;
+    }
 }
 
 void TrackerMIL_Close(TrackerMIL self) {
@@ -81,16 +144,25 @@ void TrackerMIL_Close(TrackerMIL self) {
 }
 
 TrackerGOTURN TrackerGOTURN_Create(void){
-  return new cv::Ptr<cv::TrackerGOTURN>(cv::TrackerGOTURN::create());
+    try {
+		return new cv::Ptr<cv::TrackerGOTURN>(cv::TrackerGOTURN::create());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return NULL;
+    }
 }
 
 TrackerGOTURN TrackerGOTURN_CreateWithParams(const char* modelBin, const char* modelTxt){
-
-  cv::TrackerGOTURN::Params params;
-  params.modelBin = modelBin;
-  params.modelTxt = modelTxt;
-
-  return new cv::Ptr<cv::TrackerGOTURN>(cv::TrackerGOTURN::create(params));
+    try {
+		cv::TrackerGOTURN::Params params;
+		params.modelBin = modelBin;
+		params.modelTxt = modelTxt;
+	  
+		return new cv::Ptr<cv::TrackerGOTURN>(cv::TrackerGOTURN::create(params));
+	} catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return NULL;
+    }
 }
 
 
@@ -99,19 +171,37 @@ void TrackerGOTURN_Close(TrackerGOTURN tr) {
 }
 
 KalmanFilter KalmanFilter_New(int dynamParams, int measureParams) {
-    return new cv::KalmanFilter(dynamParams, measureParams, 0, CV_32F);
+    try {
+		return new cv::KalmanFilter(dynamParams, measureParams, 0, CV_32F);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return NULL;
+    }
 }
 
 KalmanFilter KalmanFilter_NewWithParams(int dynamParams, int measureParams, int controlParams, int type) {
-    return new cv::KalmanFilter(dynamParams, measureParams, controlParams, type);
+    try {
+		return new cv::KalmanFilter(dynamParams, measureParams, controlParams, type);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return NULL;
+    }
 }
 
 void KalmanFilter_Init(KalmanFilter kf, int dynamParams, int measureParams) {
-  kf->init(dynamParams, measureParams, 0, CV_32F);
+    try {
+		kf->init(dynamParams, measureParams, 0, CV_32F);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void KalmanFilter_InitWithParams(KalmanFilter kf, int dynamParams, int measureParams, int controlParams, int type) {
-  kf->init(dynamParams, measureParams, controlParams, type);
+    try {
+		kf->init(dynamParams, measureParams, controlParams, type);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 void KalmanFilter_Close(KalmanFilter kf) {
@@ -119,113 +209,203 @@ void KalmanFilter_Close(KalmanFilter kf) {
 }
 
 Mat KalmanFilter_Predict(KalmanFilter kf) {
- return new cv::Mat(kf->predict());
+    try {
+		return new cv::Mat(kf->predict());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return new cv::Mat();
+    }
 }
 
 Mat KalmanFilter_PredictWithParams(KalmanFilter kf, Mat control) {
- return new cv::Mat(kf->predict(*control));
+    try {
+		return new cv::Mat(kf->predict(*control));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return new cv::Mat();
+    }
 }
 
 Mat KalmanFilter_Correct(KalmanFilter kf, Mat measurement) {
-  return new cv::Mat(kf->correct(*measurement));
+    try {
+		return new cv::Mat(kf->correct(*measurement));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return new cv::Mat();
+    }
 }
 
 Mat KalmanFilter_GetStatePre(KalmanFilter kf) {
-  return new cv::Mat(kf->statePre);
+    try {
+		return new cv::Mat(kf->statePre);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return new cv::Mat();
+    }
 }
 
 Mat KalmanFilter_GetStatePost(KalmanFilter kf) {
-  return new cv::Mat(kf->statePost);
+    try {
+		return new cv::Mat(kf->statePost);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return new cv::Mat();
+    }
 }
 
 Mat KalmanFilter_GetTransitionMatrix(KalmanFilter kf) {
-  return new cv::Mat(kf->transitionMatrix);
+    try {
+		return new cv::Mat(kf->transitionMatrix);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return new cv::Mat();
+    }
 }
 
 Mat KalmanFilter_GetControlMatrix(KalmanFilter kf) {
-  return new cv::Mat(kf->controlMatrix);
+    try {
+		return new cv::Mat(kf->controlMatrix);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return new cv::Mat();
+    }
 }
 
 Mat KalmanFilter_GetMeasurementMatrix(KalmanFilter kf) {
-  return new cv::Mat(kf->measurementMatrix);
+    try {
+		return new cv::Mat(kf->measurementMatrix);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return new cv::Mat();
+    }
 }
 
 Mat KalmanFilter_GetProcessNoiseCov(KalmanFilter kf) {
-  return new cv::Mat(kf->processNoiseCov);
+    try {
+		return new cv::Mat(kf->processNoiseCov);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return new cv::Mat();
+    }
 }
 
 Mat KalmanFilter_GetMeasurementNoiseCov(KalmanFilter kf) {
-  return new cv::Mat(kf->measurementNoiseCov);
+    try {
+		return new cv::Mat(kf->measurementNoiseCov);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return new cv::Mat();
+    }
 }
 
 Mat KalmanFilter_GetErrorCovPre(KalmanFilter kf) {
-  return new cv::Mat(kf->errorCovPre);
+    try {
+		return new cv::Mat(kf->errorCovPre);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return new cv::Mat();
+    }
 }
 
 Mat KalmanFilter_GetGain(KalmanFilter kf) {
-  return new cv::Mat(kf->gain);
+    try {
+		return new cv::Mat(kf->gain);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return new cv::Mat();
+    }
 }
 
 Mat KalmanFilter_GetErrorCovPost(KalmanFilter kf) {
-  return new cv::Mat(kf->errorCovPost);
+    try {
+		return new cv::Mat(kf->errorCovPost);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return new cv::Mat();
+    }
 }
 
 Mat KalmanFilter_GetTemp1(KalmanFilter kf) {
-  return new cv::Mat(kf->temp1);
+    try {
+		return new cv::Mat(kf->temp1);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return new cv::Mat();
+    }
 }
 
 Mat KalmanFilter_GetTemp2(KalmanFilter kf) {
-  return new cv::Mat(kf->temp2);
+    try {
+		return new cv::Mat(kf->temp2);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return new cv::Mat();
+    }
 }
 
 Mat KalmanFilter_GetTemp3(KalmanFilter kf) {
-  return new cv::Mat(kf->temp3);
+    try {
+		return new cv::Mat(kf->temp3);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return new cv::Mat();
+    }
 }
 
 Mat KalmanFilter_GetTemp4(KalmanFilter kf) {
-  return new cv::Mat(kf->temp4);
+    try {
+		return new cv::Mat(kf->temp4);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return new cv::Mat();
+    }
 }
 
 Mat KalmanFilter_GetTemp5(KalmanFilter kf) {
-  return new cv::Mat(kf->temp5);
+    try {
+		return new cv::Mat(kf->temp5);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return new cv::Mat();
+    }
 }
 
 void KalmanFilter_SetStatePre(KalmanFilter kf, Mat statePre) {
-  kf->statePre = *statePre;
+  	kf->statePre = *statePre;
 }
 
 void KalmanFilter_SetStatePost(KalmanFilter kf, Mat statePost) {
-  kf->statePost = *statePost;
+  	kf->statePost = *statePost;
 }
 
 void KalmanFilter_SetTransitionMatrix(KalmanFilter kf, Mat transitionMatrix) {
-  kf->transitionMatrix = *transitionMatrix;
+  	kf->transitionMatrix = *transitionMatrix;
 }
 
 void KalmanFilter_SetControlMatrix(KalmanFilter kf, Mat controlMatrix) {
-  kf->controlMatrix = *controlMatrix;
+  	kf->controlMatrix = *controlMatrix;
 }
 
 void KalmanFilter_SetMeasurementMatrix(KalmanFilter kf, Mat measurementMatrix) {
-  kf->measurementMatrix = *measurementMatrix;
+  	kf->measurementMatrix = *measurementMatrix;
 }
 
 void KalmanFilter_SetProcessNoiseCov(KalmanFilter kf, Mat processNoiseCov) {
-  kf->processNoiseCov = *processNoiseCov;
+  	kf->processNoiseCov = *processNoiseCov;
 }
 
 void KalmanFilter_SetMeasurementNoiseCov(KalmanFilter kf, Mat measurementNoiseCov) {
-  kf->measurementNoiseCov = *measurementNoiseCov;
+  	kf->measurementNoiseCov = *measurementNoiseCov;
 }
 
 void KalmanFilter_SetErrorCovPre(KalmanFilter kf, Mat errorCovPre) {
-  kf->errorCovPre = *errorCovPre;
+  	kf->errorCovPre = *errorCovPre;
 }
 
 void KalmanFilter_SetGain(KalmanFilter kf, Mat gain) {
-  kf->gain = *gain;
+  	kf->gain = *gain;
 }
 
 void KalmanFilter_SetErrorCovPost(KalmanFilter kf, Mat errorCovPost) {
-  kf->errorCovPost = *errorCovPost;
+  	kf->errorCovPost = *errorCovPost;
 }

--- a/video.go
+++ b/video.go
@@ -79,14 +79,12 @@ func (b *BackgroundSubtractorMOG2) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/df6/classcv_1_1BackgroundSubtractor.html#aa735e76f7069b3fa9c3f32395f9ccd21
-func (b *BackgroundSubtractorMOG2) Apply(src Mat, dst *Mat) {
-	C.BackgroundSubtractorMOG2_Apply((C.BackgroundSubtractorMOG2)(b.p), src.p, dst.p)
-	return
+func (b *BackgroundSubtractorMOG2) Apply(src Mat, dst *Mat) error {
+	return OpenCVResult(C.BackgroundSubtractorMOG2_Apply((C.BackgroundSubtractorMOG2)(b.p), src.p, dst.p))
 }
 
-func (b *BackgroundSubtractorMOG2) ApplyWithLearningRate(src Mat, dst *Mat, learningRate float64) {
-	C.BackgroundSubtractorMOG2_ApplyWithParams((C.BackgroundSubtractorMOG2)(b.p), src.p, dst.p, C.double(learningRate))
-	return
+func (b *BackgroundSubtractorMOG2) ApplyWithLearningRate(src Mat, dst *Mat, learningRate float64) error {
+	return OpenCVResult(C.BackgroundSubtractorMOG2_ApplyWithParams((C.BackgroundSubtractorMOG2)(b.p), src.p, dst.p, C.double(learningRate)))
 }
 
 // BackgroundSubtractorKNN is a wrapper around the cv::BackgroundSubtractorKNN.
@@ -128,9 +126,8 @@ func (k *BackgroundSubtractorKNN) Close() error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d7/df6/classcv_1_1BackgroundSubtractor.html#aa735e76f7069b3fa9c3f32395f9ccd21
-func (k *BackgroundSubtractorKNN) Apply(src Mat, dst *Mat) {
-	C.BackgroundSubtractorKNN_Apply((C.BackgroundSubtractorKNN)(k.p), src.p, dst.p)
-	return
+func (k *BackgroundSubtractorKNN) Apply(src Mat, dst *Mat) error {
+	return OpenCVResult(C.BackgroundSubtractorKNN_Apply((C.BackgroundSubtractorKNN)(k.p), src.p, dst.p))
 }
 
 // CalcOpticalFlowFarneback computes a dense optical flow using
@@ -139,10 +136,9 @@ func (k *BackgroundSubtractorKNN) Apply(src Mat, dst *Mat) {
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d6b/group__video__track.html#ga5d10ebbd59fe09c5f650289ec0ece5af
 func CalcOpticalFlowFarneback(prevImg Mat, nextImg Mat, flow *Mat, pyrScale float64, levels int, winsize int,
-	iterations int, polyN int, polySigma float64, flags int) {
-	C.CalcOpticalFlowFarneback(prevImg.p, nextImg.p, flow.p, C.double(pyrScale), C.int(levels), C.int(winsize),
-		C.int(iterations), C.int(polyN), C.double(polySigma), C.int(flags))
-	return
+	iterations int, polyN int, polySigma float64, flags int) error {
+	return OpenCVResult(C.CalcOpticalFlowFarneback(prevImg.p, nextImg.p, flow.p, C.double(pyrScale), C.int(levels), C.int(winsize),
+		C.int(iterations), C.int(polyN), C.double(polySigma), C.int(flags)))
 }
 
 // CalcOpticalFlowPyrLK calculates an optical flow for a sparse feature set using
@@ -150,9 +146,8 @@ func CalcOpticalFlowFarneback(prevImg Mat, nextImg Mat, flow *Mat, pyrScale floa
 //
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d6b/group__video__track.html#ga473e4b886d0bcc6b65831eb88ed93323
-func CalcOpticalFlowPyrLK(prevImg Mat, nextImg Mat, prevPts Mat, nextPts Mat, status *Mat, err *Mat) {
-	C.CalcOpticalFlowPyrLK(prevImg.p, nextImg.p, prevPts.p, nextPts.p, status.p, err.p)
-	return
+func CalcOpticalFlowPyrLK(prevImg Mat, nextImg Mat, prevPts Mat, nextPts Mat, status *Mat, err *Mat) error {
+	return OpenCVResult(C.CalcOpticalFlowPyrLK(prevImg.p, nextImg.p, prevPts.p, nextPts.p, status.p, err.p))
 }
 
 // CalcOpticalFlowPyrLKWithParams calculates an optical flow for a sparse feature set using
@@ -161,13 +156,12 @@ func CalcOpticalFlowPyrLK(prevImg Mat, nextImg Mat, prevPts Mat, nextPts Mat, st
 // For further details, please see:
 // https://docs.opencv.org/master/dc/d6b/group__video__track.html#ga473e4b886d0bcc6b65831eb88ed93323
 func CalcOpticalFlowPyrLKWithParams(prevImg Mat, nextImg Mat, prevPts Mat, nextPts Mat, status *Mat, err *Mat,
-	winSize image.Point, maxLevel int, criteria TermCriteria, flags int, minEigThreshold float64) {
+	winSize image.Point, maxLevel int, criteria TermCriteria, flags int, minEigThreshold float64) error {
 	winSz := C.struct_Size{
 		width:  C.int(winSize.X),
 		height: C.int(winSize.Y),
 	}
-	C.CalcOpticalFlowPyrLKWithParams(prevImg.p, nextImg.p, prevPts.p, nextPts.p, status.p, err.p, winSz, C.int(maxLevel), criteria.p, C.int(flags), C.double(minEigThreshold))
-	return
+	return OpenCVResult(C.CalcOpticalFlowPyrLKWithParams(prevImg.p, nextImg.p, prevPts.p, nextPts.p, status.p, err.p, winSz, C.int(maxLevel), criteria.p, C.int(flags), C.double(minEigThreshold)))
 }
 
 // FindTransformECC finds the geometric transform (warp) between two images in terms of the ECC criterion.
@@ -335,8 +329,8 @@ func NewKalmanFilterWithParams(dynamParams int, measureParams int, controlParams
 //
 // For further details, please see:
 // https://docs.opencv.org/4.6.0/dd/d6a/classcv_1_1KalmanFilter.html#a4f136c39c016d3530c7c5801dd1ddb3b
-func (kf *KalmanFilter) Init(dynamParams int, measureParams int) {
-	C.KalmanFilter_Init(kf.p, C.int(dynamParams), C.int(measureParams))
+func (kf *KalmanFilter) Init(dynamParams int, measureParams int) error {
+	return OpenCVResult(C.KalmanFilter_Init(kf.p, C.int(dynamParams), C.int(measureParams)))
 }
 
 // Predict computes a predicted state.

--- a/video.h
+++ b/video.h
@@ -28,18 +28,18 @@ typedef void* KalmanFilter;
 BackgroundSubtractorMOG2 BackgroundSubtractorMOG2_Create();
 BackgroundSubtractorMOG2 BackgroundSubtractorMOG2_CreateWithParams(int history, double varThreshold, bool detectShadows);
 void BackgroundSubtractorMOG2_Close(BackgroundSubtractorMOG2 b);
-void BackgroundSubtractorMOG2_Apply(BackgroundSubtractorMOG2 b, Mat src, Mat dst);
-void BackgroundSubtractorMOG2_ApplyWithParams(BackgroundSubtractorMOG2 b, Mat src, Mat dst, double learningRate);
+OpenCVResult BackgroundSubtractorMOG2_Apply(BackgroundSubtractorMOG2 b, Mat src, Mat dst);
+OpenCVResult BackgroundSubtractorMOG2_ApplyWithParams(BackgroundSubtractorMOG2 b, Mat src, Mat dst, double learningRate);
 
 BackgroundSubtractorKNN BackgroundSubtractorKNN_Create();
 BackgroundSubtractorKNN BackgroundSubtractorKNN_CreateWithParams(int history, double dist2Threshold, bool detectShadows);
 
 void BackgroundSubtractorKNN_Close(BackgroundSubtractorKNN b);
-void BackgroundSubtractorKNN_Apply(BackgroundSubtractorKNN b, Mat src, Mat dst);
+OpenCVResult BackgroundSubtractorKNN_Apply(BackgroundSubtractorKNN b, Mat src, Mat dst);
 
-void CalcOpticalFlowPyrLK(Mat prevImg, Mat nextImg, Mat prevPts, Mat nextPts, Mat status, Mat err);
-void CalcOpticalFlowPyrLKWithParams(Mat prevImg, Mat nextImg, Mat prevPts, Mat nextPts, Mat status, Mat err, Size winSize, int maxLevel, TermCriteria criteria, int flags, double minEigThreshold);
-void CalcOpticalFlowFarneback(Mat prevImg, Mat nextImg, Mat flow, double pyrScale, int levels,
+OpenCVResult CalcOpticalFlowPyrLK(Mat prevImg, Mat nextImg, Mat prevPts, Mat nextPts, Mat status, Mat err);
+OpenCVResult CalcOpticalFlowPyrLKWithParams(Mat prevImg, Mat nextImg, Mat prevPts, Mat nextPts, Mat status, Mat err, Size winSize, int maxLevel, TermCriteria criteria, int flags, double minEigThreshold);
+OpenCVResult CalcOpticalFlowFarneback(Mat prevImg, Mat nextImg, Mat flow, double pyrScale, int levels,
                               int winsize, int iterations, int polyN, double polySigma, int flags);
 
 double FindTransformECC(Mat templateImage, Mat inputImage, Mat warpMatrix, int motionType, TermCriteria criteria, Mat inputMask, int gaussFiltSize);
@@ -58,8 +58,8 @@ KalmanFilter KalmanFilter_New(int dynamParams, int measureParams);
 KalmanFilter KalmanFilter_NewWithParams(int dynamParams, int measureParams, int controlParams, int type);
 void KalmanFilter_Close(KalmanFilter kf);
 
-void KalmanFilter_Init(KalmanFilter kf, int dynamParams, int measureParams);
-void KalmanFilter_InitWithParams(KalmanFilter kf, int dynamParams, int measureParams, int controlParams, int type);
+OpenCVResult KalmanFilter_Init(KalmanFilter kf, int dynamParams, int measureParams);
+OpenCVResult KalmanFilter_InitWithParams(KalmanFilter kf, int dynamParams, int measureParams, int controlParams, int type);
 Mat KalmanFilter_Predict(KalmanFilter kf);
 Mat KalmanFilter_PredictWithParams(KalmanFilter kf, Mat control);
 Mat KalmanFilter_Correct(KalmanFilter kf, Mat measurement);

--- a/videoio.cpp
+++ b/videoio.cpp
@@ -82,11 +82,14 @@ bool VideoCapture_OpenDeviceWithAPIParams(VideoCapture v, int device, int apiPre
 }
 
 
-void VideoCapture_Set(VideoCapture v, int prop, double param) {
+OpenCVResult VideoCapture_Set(VideoCapture v, int prop, double param) {
     try {
         v->set(prop, param);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+		OpenCVResult result = {0, NULL};
+		return result;
+	} catch(const cv::Exception& e) {
+		OpenCVResult result = {e.code, e.what()};
+		return result;
     }
 }
 
@@ -117,13 +120,16 @@ int VideoCapture_Read(VideoCapture v, Mat buf) {
     }
 }
 
-void VideoCapture_Grab(VideoCapture v, int skip) {
+OpenCVResult VideoCapture_Grab(VideoCapture v, int skip) {
     try {
         for (int i = 0; i < skip; i++) {
             v->grab();
         }
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+		OpenCVResult result = {0, NULL};
+		return result;
+	} catch(const cv::Exception& e) {
+		OpenCVResult result = {e.code, e.what()};
+		return result;
     }
 }
 
@@ -150,25 +156,31 @@ void VideoWriter_Close(VideoWriter vw) {
     delete vw;
 }
 
-void VideoWriter_Open(VideoWriter vw, const char* name, const char* codec, double fps, int width, int height, bool isColor) {
+OpenCVResult VideoWriter_Open(VideoWriter vw, const char* name, const char* codec, double fps, int width, int height, bool isColor) {
     try {
         int codecCode = cv::VideoWriter::fourcc(codec[0], codec[1], codec[2], codec[3]);
         vw->open(name, codecCode, fps, cv::Size(width, height), isColor);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+		OpenCVResult result = {0, NULL};
+		return result;
+	} catch(const cv::Exception& e) {
+		OpenCVResult result = {e.code, e.what()};
+		return result;
     }
 }
 
-void VideoWriter_OpenWithAPI(VideoWriter vw, const char* name, int apiPreference, const char* codec, double fps, int width, int height, bool isColor) {
+OpenCVResult VideoWriter_OpenWithAPI(VideoWriter vw, const char* name, int apiPreference, const char* codec, double fps, int width, int height, bool isColor) {
     try {
         int codecCode = cv::VideoWriter::fourcc(codec[0], codec[1], codec[2], codec[3]);
         vw->open(name, apiPreference, codecCode, fps, cv::Size(width, height), isColor);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+		OpenCVResult result = {0, NULL};
+		return result;
+	} catch(const cv::Exception& e) {
+		OpenCVResult result = {e.code, e.what()};
+		return result;
     }
 }
 
-void VideoWriter_OpenWithAPIParams(VideoWriter vw, const char* name, int apiPreference, const char* codec, double fps, int width, int height, IntVector params) {
+OpenCVResult VideoWriter_OpenWithAPIParams(VideoWriter vw, const char* name, int apiPreference, const char* codec, double fps, int width, int height, IntVector params) {
     try {
         std::vector<int> cpp_params;
 
@@ -178,8 +190,11 @@ void VideoWriter_OpenWithAPIParams(VideoWriter vw, const char* name, int apiPref
     
         int codecCode = cv::VideoWriter::fourcc(codec[0], codec[1], codec[2], codec[3]);
         vw->open(name, apiPreference, codecCode, fps, cv::Size(width, height), cpp_params);
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
+		OpenCVResult result = {0, NULL};
+		return result;
+	} catch(const cv::Exception& e) {
+		OpenCVResult result = {e.code, e.what()};
+		return result;
     }
 }
 
@@ -192,8 +207,15 @@ int VideoWriter_IsOpened(VideoWriter vw) {
     }
 }
 
-void VideoWriter_Write(VideoWriter vw, Mat img) {
-    *vw << *img;
+OpenCVResult VideoWriter_Write(VideoWriter vw, Mat img) {
+    try {
+        *vw << *img;
+		OpenCVResult result = {0, NULL};
+		return result;
+	} catch(const cv::Exception& e) {
+		OpenCVResult result = {e.code, e.what()};
+		return result;
+    }
 }
 
 const char* Videoio_Registry_GetBackendName(int api) {

--- a/videoio.cpp
+++ b/videoio.cpp
@@ -3,7 +3,12 @@
 
 // VideoWriter
 VideoCapture VideoCapture_New() {
-    return new cv::VideoCapture();
+    try {
+        return new cv::VideoCapture();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return NULL;
+    }
 }
 
 void VideoCapture_Close(VideoCapture v) {
@@ -11,203 +16,326 @@ void VideoCapture_Close(VideoCapture v) {
 }
 
 bool VideoCapture_Open(VideoCapture v, const char* uri) {
-    return v->open(uri);
+    try {
+        return v->open(uri);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return false;
+    }
 }
 
 bool VideoCapture_OpenWithAPI(VideoCapture v, const char* uri, int apiPreference) {
-    return v->open(uri, apiPreference);
+    try {
+        return v->open(uri, apiPreference);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return false;
+    }
 }
 
 bool VideoCapture_OpenWithAPIParams(VideoCapture v, const char* uri, int apiPreference, int *paramsv, int paramsc) {
-    std::vector< int > params;
+    try {
+        std::vector< int > params;
 
-    for( int i = 0; i< paramsc; i++) {
-        params.push_back(paramsv[i]);
+        for( int i = 0; i< paramsc; i++) {
+            params.push_back(paramsv[i]);
+        }
+    
+        return v->open(cv::String(uri), apiPreference, params);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return false;
     }
-
-    return v->open(cv::String(uri), apiPreference, params);
 }
 
 bool VideoCapture_OpenDevice(VideoCapture v, int device) {
-    return v->open(device);
+    try {
+        return v->open(device);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return false;
+    }
 }
 
 bool VideoCapture_OpenDeviceWithAPI(VideoCapture v, int device, int apiPreference) {
-    return v->open(device, apiPreference);
+    try {
+        return v->open(device, apiPreference);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return false;
+    }
 }
 
 bool VideoCapture_OpenDeviceWithAPIParams(VideoCapture v, int device, int apiPreference, int *paramsv, int paramsc) {
-    std::vector< int > params;
+    try {
+        std::vector< int > params;
 
-    for( int i = 0; i< paramsc; i++) {
-        params.push_back(paramsv[i]);
+        for( int i = 0; i< paramsc; i++) {
+            params.push_back(paramsv[i]);
+        }
+    
+        return v->open(device, apiPreference, params);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return false;
     }
-
-    return v->open(device, apiPreference, params);
 }
 
 
 void VideoCapture_Set(VideoCapture v, int prop, double param) {
-    v->set(prop, param);
+    try {
+        v->set(prop, param);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 double VideoCapture_Get(VideoCapture v, int prop) {
-    return v->get(prop);
+    try {
+        return v->get(prop);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return 0.0;
+    }
 }
 
 int VideoCapture_IsOpened(VideoCapture v) {
-    return v->isOpened();
+    try {
+        return v->isOpened();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return 0;
+    }
 }
 
 int VideoCapture_Read(VideoCapture v, Mat buf) {
-    return v->read(*buf);
+    try {
+        return v->read(*buf);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return 0;
+    }
 }
 
 void VideoCapture_Grab(VideoCapture v, int skip) {
-    for (int i = 0; i < skip; i++) {
-        v->grab();
+    try {
+        for (int i = 0; i < skip; i++) {
+            v->grab();
+        }
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
 }
 
 int VideoCapture_Retrieve(VideoCapture v, Mat buf) {
-    return v->retrieve(*buf);
+    try {
+        return v->retrieve(*buf);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return 0;
+    }
 }
 
 // VideoWriter
 VideoWriter VideoWriter_New() {
-    return new cv::VideoWriter();
+    try {
+        return new cv::VideoWriter();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return NULL;
+    }
 }
 
 void VideoWriter_Close(VideoWriter vw) {
     delete vw;
 }
 
-void VideoWriter_Open(VideoWriter vw, const char* name, const char* codec, double fps, int width,
-                      int height, bool isColor) {
-    int codecCode = cv::VideoWriter::fourcc(codec[0], codec[1], codec[2], codec[3]);
-    vw->open(name, codecCode, fps, cv::Size(width, height), isColor);
-}
-
-void VideoWriter_OpenWithAPI(VideoWriter vw, const char* name, int apiPreference, const char* codec, double fps, int width,
-                      int height, bool isColor) {
-    int codecCode = cv::VideoWriter::fourcc(codec[0], codec[1], codec[2], codec[3]);
-    vw->open(name, apiPreference, codecCode, fps, cv::Size(width, height), isColor);
-}
-
-void VideoWriter_OpenWithAPIParams(VideoWriter vw, const char* name, int apiPreference, const char* codec, double fps, int width,
-                      int height, IntVector params) {
-    
-    std::vector<int>  cpp_params;
-
-    for(int i = 0; i < params.length; i++) {
-        cpp_params.push_back(params.val[i]);
+void VideoWriter_Open(VideoWriter vw, const char* name, const char* codec, double fps, int width, int height, bool isColor) {
+    try {
+        int codecCode = cv::VideoWriter::fourcc(codec[0], codec[1], codec[2], codec[3]);
+        vw->open(name, codecCode, fps, cv::Size(width, height), isColor);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
     }
+}
 
-    int codecCode = cv::VideoWriter::fourcc(codec[0], codec[1], codec[2], codec[3]);
-    vw->open(name, apiPreference, codecCode, fps, cv::Size(width, height), cpp_params);
+void VideoWriter_OpenWithAPI(VideoWriter vw, const char* name, int apiPreference, const char* codec, double fps, int width, int height, bool isColor) {
+    try {
+        int codecCode = cv::VideoWriter::fourcc(codec[0], codec[1], codec[2], codec[3]);
+        vw->open(name, apiPreference, codecCode, fps, cv::Size(width, height), isColor);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
+}
+
+void VideoWriter_OpenWithAPIParams(VideoWriter vw, const char* name, int apiPreference, const char* codec, double fps, int width, int height, IntVector params) {
+    try {
+        std::vector<int> cpp_params;
+
+        for(int i = 0; i < params.length; i++) {
+            cpp_params.push_back(params.val[i]);
+        }
+    
+        int codecCode = cv::VideoWriter::fourcc(codec[0], codec[1], codec[2], codec[3]);
+        vw->open(name, apiPreference, codecCode, fps, cv::Size(width, height), cpp_params);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+    }
 }
 
 int VideoWriter_IsOpened(VideoWriter vw) {
-    return vw->isOpened();
+    try {
+        return vw->isOpened();
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return 0;
+    }
 }
 
 void VideoWriter_Write(VideoWriter vw, Mat img) {
     *vw << *img;
 }
 
-char* Videoio_Registry_GetBackendName(int api) {
-    cv::String name;
-
-    name = cv::videoio_registry::getBackendName((cv::VideoCaptureAPIs)(api));
-
-    return strdup(name.c_str());
+const char* Videoio_Registry_GetBackendName(int api) {
+    try {
+        cv::String name;
+        name = cv::videoio_registry::getBackendName((cv::VideoCaptureAPIs)(api));
+        return strdup(name.c_str());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return "";
+    }
 }
 
 IntVector Videio_Registry_GetBackends() {
-    IntVector c_backs;
-
-    std::vector<cv::VideoCaptureAPIs> backs = cv::videoio_registry::getBackends();
-
-    c_backs.val = new int[backs.size()];
-    c_backs.length = backs.size();
-
-    for(int i = 0; i < c_backs.length; i++) {
-        c_backs.val[i] = backs[i];
+    try {
+        IntVector c_backs;
+        std::vector<cv::VideoCaptureAPIs> backs = cv::videoio_registry::getBackends();
+    
+        c_backs.val = new int[backs.size()];
+        c_backs.length = backs.size();
+    
+        for(int i = 0; i < c_backs.length; i++) {
+            c_backs.val[i] = backs[i];
+        }
+    
+        return c_backs;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        IntVector empty;
+		return empty;
     }
-
-    return c_backs;
 }
 
-char* Videoio_Registry_GetCameraBackendPluginVersion(int api, int* version_ABI, int* version_API) {
+const char* Videoio_Registry_GetCameraBackendPluginVersion(int api, int* version_ABI, int* version_API) {
+    try {
+        std::string desc = cv::videoio_registry::getCameraBackendPluginVersion((cv::VideoCaptureAPIs)(api), *version_ABI, *version_API);
 
-    std::string desc = cv::videoio_registry::getCameraBackendPluginVersion((cv::VideoCaptureAPIs)(api), *version_ABI, *version_API);
-
-    return strdup(desc.c_str());
+        return strdup(desc.c_str());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return "";
+    }
 }
 
 IntVector Videoio_Registry_GetCameraBackends() {
-    IntVector c_backs;
-
-    std::vector<cv::VideoCaptureAPIs> backs = cv::videoio_registry::getCameraBackends();
-
-    c_backs.val = new int[backs.size()];
-    c_backs.length = backs.size();
-
-    for(int i = 0; i < c_backs.length; i++) {
-        c_backs.val[i] = backs[i];
+    try {
+        IntVector c_backs;
+        std::vector<cv::VideoCaptureAPIs> backs = cv::videoio_registry::getCameraBackends();
+    
+        c_backs.val = new int[backs.size()];
+        c_backs.length = backs.size();
+    
+        for(int i = 0; i < c_backs.length; i++) {
+            c_backs.val[i] = backs[i];
+        }
+    
+        return c_backs;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        IntVector empty;
+		return empty;
     }
-
-    return c_backs;
 }
 
-char* Videoio_Registry_GetStreamBackendPluginVersion(int api, int* version_ABI, int* version_API){
- 
-    std::string desc = cv::videoio_registry::getStreamBackendPluginVersion((cv::VideoCaptureAPIs)(api), *version_ABI, *version_API);
+const char* Videoio_Registry_GetStreamBackendPluginVersion(int api, int* version_ABI, int* version_API){
+    try {
+        std::string desc = cv::videoio_registry::getStreamBackendPluginVersion((cv::VideoCaptureAPIs)(api), *version_ABI, *version_API);
 
-    return strdup(desc.c_str());
+        return strdup(desc.c_str());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return "";
+    } 
 }
 
 IntVector Videoio_Registry_GetStreamBackends() {
-    IntVector c_backs;
+    try {
+        IntVector c_backs;
 
-    std::vector<cv::VideoCaptureAPIs> backs = cv::videoio_registry::getStreamBackends();
-
-    c_backs.val = new int[backs.size()];
-    c_backs.length = backs.size();
-
-    for(int i = 0; i < c_backs.length; i++) {
-        c_backs.val[i] = backs[i];
+        std::vector<cv::VideoCaptureAPIs> backs = cv::videoio_registry::getStreamBackends();
+    
+        c_backs.val = new int[backs.size()];
+        c_backs.length = backs.size();
+    
+        for(int i = 0; i < c_backs.length; i++) {
+            c_backs.val[i] = backs[i];
+        }
+    
+        return c_backs;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        IntVector empty;
+		return empty;
     }
-
-    return c_backs;
 }
 
-char* Videoio_Registry_GetWriterBackendPluginVersion(int api, int* version_ABI, int* version_API){
- 
-    std::string desc = cv::videoio_registry::getWriterBackendPluginVersion((cv::VideoCaptureAPIs)(api), *version_ABI, *version_API);
+const char* Videoio_Registry_GetWriterBackendPluginVersion(int api, int* version_ABI, int* version_API){
+    try {
+        std::string desc = cv::videoio_registry::getWriterBackendPluginVersion((cv::VideoCaptureAPIs)(api), *version_ABI, *version_API);
 
-    return strdup(desc.c_str());
+        return strdup(desc.c_str());
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return "";
+    }
 }
 
 IntVector Videoio_Registry_GetWriterBackends() {
-    IntVector c_backs;
+    try {
+        IntVector c_backs;
 
-    std::vector<cv::VideoCaptureAPIs> backs = cv::videoio_registry::getWriterBackends();
-
-    c_backs.val = new int[backs.size()];
-    c_backs.length = backs.size();
-
-    for(int i = 0; i < c_backs.length; i++) {
-        c_backs.val[i] = backs[i];
+        std::vector<cv::VideoCaptureAPIs> backs = cv::videoio_registry::getWriterBackends();
+    
+        c_backs.val = new int[backs.size()];
+        c_backs.length = backs.size();
+    
+        for(int i = 0; i < c_backs.length; i++) {
+            c_backs.val[i] = backs[i];
+        }
+    
+        return c_backs;
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        IntVector empty;
+		return empty;
     }
-
-    return c_backs;
 }
 
 bool Videoio_Registry_HasBackend(int api) {
-    return cv::videoio_registry::hasBackend((cv::VideoCaptureAPIs)(api));
+    try {
+        return cv::videoio_registry::hasBackend((cv::VideoCaptureAPIs)(api));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return false;
+    }
 }
 
 bool Videoio_Registry_IsBackendBuiltIn(int api) {
-    return cv::videoio_registry::isBackendBuiltIn((cv::VideoCaptureAPIs)(api));
+    try {
+        return cv::videoio_registry::isBackendBuiltIn((cv::VideoCaptureAPIs)(api));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+		return false;
+    }
 }

--- a/videoio.go
+++ b/videoio.go
@@ -465,8 +465,8 @@ func (v *VideoCapture) Read(m *Mat) bool {
 }
 
 // Grab skips a specific number of frames.
-func (v *VideoCapture) Grab(skip int) {
-	C.VideoCapture_Grab(v.p, C.int(skip))
+func (v *VideoCapture) Grab(skip int) error {
+	return OpenCVResult(C.VideoCapture_Grab(v.p, C.int(skip)))
 }
 
 // Retrieve decodes and returns the grabbed video frame. Should be used after Grab
@@ -532,7 +532,7 @@ func VideoWriterFile(name string, codec string, fps float64, width int, height i
 	cCodec := C.CString(codec)
 	defer C.free(unsafe.Pointer(cCodec))
 
-	C.VideoWriter_Open(vw.p, cName, cCodec, C.double(fps), C.int(width), C.int(height), C.bool(isColor))
+	err = OpenCVResult(C.VideoWriter_Open(vw.p, cName, cCodec, C.double(fps), C.int(width), C.int(height), C.bool(isColor)))
 	return
 }
 
@@ -560,7 +560,7 @@ func VideoWriterFileWithAPI(name string, apiPreference VideoCaptureAPI, codec st
 	cCodec := C.CString(codec)
 	defer C.free(unsafe.Pointer(cCodec))
 
-	C.VideoWriter_OpenWithAPI(vw.p, cName, C.int(apiPreference), cCodec, C.double(fps), C.int(width), C.int(height), C.bool(isColor))
+	err = OpenCVResult(C.VideoWriter_OpenWithAPI(vw.p, cName, C.int(apiPreference), cCodec, C.double(fps), C.int(width), C.int(height), C.bool(isColor)))
 	return
 }
 
@@ -597,7 +597,7 @@ func VideoWriterFileWithAPIParams(name string, apiPreference VideoCaptureAPI, co
 		val:    unsafe.SliceData(c_ints),
 		length: C.int(len(params)),
 	}
-	C.VideoWriter_OpenWithAPIParams(vw.p, c_name, C.int(apiPreference), c_codec, C.double(fps), C.int(width), C.int(height), c_params)
+	err = OpenCVResult(C.VideoWriter_OpenWithAPIParams(vw.p, c_name, C.int(apiPreference), c_codec, C.double(fps), C.int(width), C.int(height), c_params))
 	return
 }
 
@@ -624,8 +624,7 @@ func (vw *VideoWriter) IsOpened() bool {
 func (vw *VideoWriter) Write(img Mat) error {
 	vw.mu.Lock()
 	defer vw.mu.Unlock()
-	C.VideoWriter_Write(vw.p, img.p)
-	return nil
+	return OpenCVResult(C.VideoWriter_Write(vw.p, img.p))
 }
 
 // OpenVideoCapture return VideoCapture specified by device ID if v is a

--- a/videoio.h
+++ b/videoio.h
@@ -26,25 +26,25 @@ bool VideoCapture_OpenWithAPIParams(VideoCapture v, const char* uri, int apiPref
 bool VideoCapture_OpenDevice(VideoCapture v, int device);
 bool VideoCapture_OpenDeviceWithAPI(VideoCapture v, int device, int apiPreference);
 bool VideoCapture_OpenDeviceWithAPIParams(VideoCapture v, int device, int apiPreference, int *paramsv, int paramsc);
-void VideoCapture_Set(VideoCapture v, int prop, double param);
+OpenCVResult VideoCapture_Set(VideoCapture v, int prop, double param);
 double VideoCapture_Get(VideoCapture v, int prop);
 int VideoCapture_IsOpened(VideoCapture v);
 int VideoCapture_Read(VideoCapture v, Mat buf);
-void VideoCapture_Grab(VideoCapture v, int skip);
+OpenCVResult VideoCapture_Grab(VideoCapture v, int skip);
 int VideoCapture_Retrieve(VideoCapture v, Mat buf);
 
 // VideoWriter
 VideoWriter VideoWriter_New();
 void VideoWriter_Close(VideoWriter vw);
-void VideoWriter_Open(VideoWriter vw, const char* name, const char* codec, double fps, int width,
+OpenCVResult VideoWriter_Open(VideoWriter vw, const char* name, const char* codec, double fps, int width,
                       int height, bool isColor);
-void VideoWriter_OpenWithAPI(VideoWriter vw, const char* name, int apiPreference, const char* codec, double fps,
+OpenCVResult VideoWriter_OpenWithAPI(VideoWriter vw, const char* name, int apiPreference, const char* codec, double fps,
                       int width, int height, bool isColor);
-void VideoWriter_OpenWithAPIParams(VideoWriter vw, const char* name, int apiPreference, const char* codec, double fps,
+OpenCVResult VideoWriter_OpenWithAPIParams(VideoWriter vw, const char* name, int apiPreference, const char* codec, double fps,
                       int width, int height, IntVector params);
 
 int VideoWriter_IsOpened(VideoWriter vw);
-void VideoWriter_Write(VideoWriter vw, Mat img);
+OpenCVResult VideoWriter_Write(VideoWriter vw, Mat img);
 
 //Videoio Query I/O API backends registry
 const char* Videoio_Registry_GetBackendName(int api);

--- a/videoio.h
+++ b/videoio.h
@@ -47,13 +47,13 @@ int VideoWriter_IsOpened(VideoWriter vw);
 void VideoWriter_Write(VideoWriter vw, Mat img);
 
 //Videoio Query I/O API backends registry
-char* Videoio_Registry_GetBackendName(int api);
+const char* Videoio_Registry_GetBackendName(int api);
 IntVector Videio_Registry_GetBackends();
-char* Videoio_Registry_GetCameraBackendPluginVersion(int api, int* version_ABI, int* version_API);
+const char* Videoio_Registry_GetCameraBackendPluginVersion(int api, int* version_ABI, int* version_API);
 IntVector Videoio_Registry_GetCameraBackends();
-char* Videoio_Registry_GetStreamBackendPluginVersion(int api, int* version_ABI, int* version_API);
+const char* Videoio_Registry_GetStreamBackendPluginVersion(int api, int* version_ABI, int* version_API);
 IntVector Videoio_Registry_GetStreamBackends();
-char* Videoio_Registry_GetWriterBackendPluginVersion(int api, int* version_ABI, int* version_API);
+const char* Videoio_Registry_GetWriterBackendPluginVersion(int api, int* version_ABI, int* version_API);
 IntVector Videoio_Registry_GetWriterBackends();
 bool Videoio_Registry_HasBackend(int api);
 bool Videoio_Registry_IsBackendBuiltIn(int api);


### PR DESCRIPTION
This PR is to add exception handling functions and try/catch blocks around calls to OpenCV functions to prevent unexpected exceptions from crashing the process.

The way that it works is most functions that were previously not returning anything, now return an error. The error will be populated with any exception caught by the calls to OpenCV that would have previously resulted in a crash due to that exception. These errors are very reliable and thread-safe.

```go
	img := gocv.NewMat()
	defer img.Close()

	dest := gocv.NewMat()
	defer dest.Close()

        // previously this would crash due to exception
	err := gocv.CvtColor(img, &dest, ColorBGRAToGray)
        // info in error comes directly from failed function call
	if err == nil {
		t.Error("Expected exception in test")
	}
	if len(err.Error()) == 0 {
		t.Error("Expected exception message in test")
	}
```

In addition, this PR introduces some new functions to try to figure out if an exception has occured after calling functions that already returned something else besides an error:

```go
func LastExceptionError() error
```

Here is how you would use it:

```go
net := ReadNet("googlenet-9.onnx")
if err := gocv.LastExceptionError(); err != nil {
       t.Errorf("There was an exception: %v", err)
}
...
```

However these new functions are not thread safe. They only exist for the case that the user needs to check for exceptions after calling one of the function that does not currently return an error.

Perhaps in the future the functions will make a breaking change to also return errors, but that is not part of this PR.

In short: the errors returned from a function call with exception info should be very reliable. The other new functions, less so.