### PR TITLE
Add cv::stereoRectify binding.

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -138,7 +138,7 @@ Your pull requests will be greatly appreciated!
         - [ ] [solvePnPRefineLM](https://docs.opencv.org/master/d9/d0c/group__calib3d.html)
         - [ ] [solvePnPRefineVVS](https://docs.opencv.org/master/d9/d0c/group__calib3d.html)
         - [ ] [stereoCalibrate](https://docs.opencv.org/master/d9/d0c/group__calib3d.html)
-        - [ ] [stereoRectify](https://docs.opencv.org/master/d9/d0c/group__calib3d.html)
+        - [X] [stereoRectify](https://docs.opencv.org/master/d9/d0c/group__calib3d.html)
         - [ ] [stereoRectifyUncalibrated](https://docs.opencv.org/master/d9/d0c/group__calib3d.html)
         - [ ] [validateDisparity](https://docs.opencv.org/master/d9/d0c/group__calib3d.html)
 

--- a/calib3d.cpp
+++ b/calib3d.cpp
@@ -233,3 +233,12 @@ bool SolvePnP(Point3fVector objectPoints, Point2fVector imagePoints, Mat cameraM
         return false;
     }
 }
+
+OpenCVResult StereoRectify(Mat cameraMatrix1, Mat distCoeffs1, Mat cameraMatrix2, Mat distCoeffs2, Size imageSize, Mat r, Mat t, Mat R1, Mat R2, Mat P1, Mat P2, Mat Q, int flags) {
+    try {
+        cv::stereoRectify(*cameraMatrix1, *distCoeffs1, *cameraMatrix2, *distCoeffs2, cv::Size(imageSize.width, imageSize.height), *r, *t, *R1, *R2, *P1, *P2, *Q, flags);
+        return successResult();
+    } catch(const cv::Exception& e){
+        return errorResult(e.code, e.what());
+    }
+}

--- a/calib3d.go
+++ b/calib3d.go
@@ -55,6 +55,39 @@ const (
 	CalibFixPrincipalPoint
 )
 
+// CalibFlagPinhole defines the enumeration values for calibration flags when using the so-called pinhole camera model.
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/d9/d0c/group__calib3d.html#enum-members
+type CalibFlagPinhole int
+
+const (
+	CalibFlagPinholeNIntrinsic        CalibFlagPinhole = 18
+	CalibFlagPinholeUseIntrinsicGuess CalibFlagPinhole = 0x00001
+	CalibFlagPinholeFixAspectRatio    CalibFlagPinhole = 0x00002
+	CalibFlagPinholeFixPrincipalPoint CalibFlagPinhole = 0x00004
+	CalibFlagPinholeZeroTangentDist   CalibFlagPinhole = 0x00008
+	CalibFlagPinholeFixFocalLength    CalibFlagPinhole = 0x00010
+	CalibFlagPinholeFixK1             CalibFlagPinhole = 0x00020
+	CalibFlagPinholeFixK2             CalibFlagPinhole = 0x00040
+	CalibFlagPinholeFixK3             CalibFlagPinhole = 0x00080
+	CalibFlagPinholeFixK4             CalibFlagPinhole = 0x00800
+	CalibFlagPinholeFixK5             CalibFlagPinhole = 0x01000
+	CalibFlagPinholeFixK6             CalibFlagPinhole = 0x02000
+	CalibFlagPinholeRationalModel     CalibFlagPinhole = 0x04000
+	CalibFlagPinholeThinPrismModel    CalibFlagPinhole = 0x08000
+	CalibFlagPinholeFixS1S2S3S4       CalibFlagPinhole = 0x10000
+	CalibFlagPinholeTiltedModel       CalibFlagPinhole = 0x40000
+	CalibFlagPinholeFixTauxTauy       CalibFlagPinhole = 0x80000
+	CalibFlagPinholeUseQR             CalibFlagPinhole = 0x100000
+	CalibFlagPinholeFixTangentDist    CalibFlagPinhole = 0x200000
+	CalibFlagPinholeFixIntrinsic      CalibFlagPinhole = 0x00100
+	CalibFlagPinholeSameFocalLength   CalibFlagPinhole = 0x00200
+	CalibFlagPinholeZeroDisparity     CalibFlagPinhole = 0x00400
+	CalibFlagPinholeUseLU             CalibFlagPinhole = (1 << 17)
+	CalibFlagPinholeUseExtrinsicGuess CalibFlagPinhole = (1 << 22)
+)
+
 // FisheyeCalibrate performs camera calibration.
 //
 // For further details, please see:
@@ -326,4 +359,16 @@ func Rodrigues(src Mat, dst *Mat) error {
 // https://docs.opencv.org/4.0.0/d9/d0c/group__calib3d.html#ga549c2075fac14829ff4a58bc931c033d
 func SolvePnP(objectPoints Point3fVector, imagePoints Point2fVector, cameraMatrix, distCoeffs Mat, rvec, tvec *Mat, useExtrinsicGuess bool, flags int) bool {
 	return bool(C.SolvePnP(objectPoints.p, imagePoints.p, cameraMatrix.p, distCoeffs.p, rvec.p, tvec.p, C.bool(useExtrinsicGuess), C.int(flags)))
+}
+
+// StereoRectify computes rectification transforms for each head of a calibrated stereo camera.
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/d9/d0c/group__calib3d.html#ga617b1685d4059c6040827800e72ad2b6
+func StereoRectify(cameraMatrix1, distCoeffs1, cameraMatrix2, distCoeffs2 Mat, imageSize image.Point, r Mat, t Mat, R1, R2, P1, P2, Q *Mat, flags CalibFlagPinhole) error {
+	sz := C.struct_Size{
+		width:  C.int(imageSize.X),
+		height: C.int(imageSize.Y),
+	}
+	return OpenCVResult(C.StereoRectify(cameraMatrix1.Ptr(), distCoeffs1.Ptr(), cameraMatrix2.Ptr(), distCoeffs2.Ptr(), sz, r.Ptr(), t.Ptr(), R1.Ptr(), R2.Ptr(), P1.Ptr(), P2.Ptr(), Q.Ptr(), C.int(flags)))
 }

--- a/calib3d.h
+++ b/calib3d.h
@@ -37,6 +37,7 @@ OpenCVResult TriangulatePoints(Mat projMatr1, Mat projMatr2, Point2fVector projP
 OpenCVResult ConvertPointsFromHomogeneous(Mat src, Mat dst);
 OpenCVResult Rodrigues(Mat src, Mat dst);
 bool SolvePnP(Point3fVector objectPoints, Point2fVector imagePoints, Mat cameraMatrix, Mat distCoeffs, Mat rvec, Mat tvec, bool useExtrinsicGuess, int flags);
+OpenCVResult StereoRectify(Mat cameraMatrix1, Mat distCoeffs1, Mat cameraMatrix2, Mat distCoeffs2, Size imageSize, Mat r, Mat t, Mat R1, Mat R2, Mat P1, Mat P2, Mat Q, int flags);
 #ifdef __cplusplus
 }
 #endif

--- a/calib3d_test.go
+++ b/calib3d_test.go
@@ -922,3 +922,96 @@ func TestSolvePnP(t *testing.T) {
 		return
 	}
 }
+
+func TestStereoRectify(t *testing.T) {
+	cameraMatrix1 := NewMatWithSize(3, 3, MatTypeCV64F)
+	defer cameraMatrix1.Close()
+	cameraMatrix1.SetDoubleAt(0, 0, 1679.861998224759)
+	cameraMatrix1.SetDoubleAt(0, 1, 0)
+	cameraMatrix1.SetDoubleAt(0, 2, 1231.158426771668)
+	cameraMatrix1.SetDoubleAt(1, 0, 0)
+	cameraMatrix1.SetDoubleAt(1, 1, 1679.6751024982132)
+	cameraMatrix1.SetDoubleAt(1, 2, 998.4768157307255)
+	cameraMatrix1.SetDoubleAt(2, 0, 0)
+	cameraMatrix1.SetDoubleAt(2, 1, 0)
+	cameraMatrix1.SetDoubleAt(2, 2, 1)
+
+	distCoeffs1 := NewMatWithSize(1, 5, MatTypeCV64F)
+	defer distCoeffs1.Close()
+	distCoeffs1.SetDoubleAt(0, 0, -0.13657891044008158)
+	distCoeffs1.SetDoubleAt(0, 1, 0.08861314898314139)
+	distCoeffs1.SetDoubleAt(0, 2, -0.0006100429198910993)
+	distCoeffs1.SetDoubleAt(0, 3, -0.000146035714553745)
+	distCoeffs1.SetDoubleAt(0, 4, -0.0223854079208295)
+
+	cameraMatrix2 := NewMatWithSize(3, 3, MatTypeCV64F)
+	defer cameraMatrix2.Close()
+	cameraMatrix2.SetDoubleAt(0, 0, 1678.7797594660801)
+	cameraMatrix2.SetDoubleAt(0, 1, 0)
+	cameraMatrix2.SetDoubleAt(0, 2, 1233.9647439048256)
+	cameraMatrix2.SetDoubleAt(1, 0, 0)
+	cameraMatrix2.SetDoubleAt(1, 1, 1679.0176277206788)
+	cameraMatrix2.SetDoubleAt(1, 2, 964.4565768594671)
+	cameraMatrix2.SetDoubleAt(2, 0, 0)
+	cameraMatrix2.SetDoubleAt(2, 1, 0)
+	cameraMatrix2.SetDoubleAt(2, 2, 1)
+
+	distCoeffs2 := NewMatWithSize(1, 5, MatTypeCV64F)
+	defer distCoeffs2.Close()
+	distCoeffs2.SetDoubleAt(0, 0, -0.13690489442431938)
+	distCoeffs2.SetDoubleAt(0, 1, 0.08705821688253863)
+	distCoeffs2.SetDoubleAt(0, 2, 0.001288895752441417)
+	distCoeffs2.SetDoubleAt(0, 3, -5.508164903909865e-05)
+	distCoeffs2.SetDoubleAt(0, 4, -0.02092107478701842)
+
+	R := NewMatWithSize(3, 3, MatTypeCV64F)
+	defer R.Close()
+	R.SetDoubleAt(0, 0, 0.9978384271270464)
+	R.SetDoubleAt(0, 1, 0.06567174227009016)
+	R.SetDoubleAt(0, 2, -0.0023865489378896566)
+	R.SetDoubleAt(1, 0, -0.06567842187628788)
+	R.SetDoubleAt(1, 1, 0.9978368073955511)
+	R.SetDoubleAt(1, 2, -0.002837376692327134)
+	R.SetDoubleAt(2, 0, 0.0021950509020153912)
+	R.SetDoubleAt(2, 1, 0.0029879882638097722)
+	R.SetDoubleAt(2, 2, 0.9999931268152161)
+
+	T := NewMatWithSize(3, 1, MatTypeCV64F)
+	defer T.Close()
+	T.SetDoubleAt(0, 0, -0.1600062730246643)
+	T.SetDoubleAt(1, 0, 0.007804854680409705)
+	T.SetDoubleAt(2, 0, 9.242933249524358e-05)
+
+	R1 := NewMat()
+	defer R1.Close()
+	R2 := NewMat()
+	defer R2.Close()
+	P1 := NewMat()
+	defer P1.Close()
+	P2 := NewMat()
+	defer P2.Close()
+	Q := NewMat()
+	defer Q.Close()
+
+	imageSize := image.Point{X: 2448, Y: 2048}
+	err := StereoRectify(cameraMatrix1, distCoeffs1, cameraMatrix2, distCoeffs2, imageSize, R, T, &R1, &R2, &P1, &P2, &Q, CalibFlagPinholeZeroDisparity)
+	if err != nil {
+		t.Errorf("StereoRectify failed: %v", err)
+	}
+
+	if R1.Empty() {
+		t.Error("R1 result is empty")
+	}
+	if R2.Empty() {
+		t.Error("R2 result is empty")
+	}
+	if P1.Empty() {
+		t.Error("P1 result is empty")
+	}
+	if P2.Empty() {
+		t.Error("P2 result is empty")
+	}
+	if Q.Empty() {
+		t.Error("Q result is empty")
+	}
+}


### PR DESCRIPTION
Note: The original enumerations for calibration flags are for the FishEye model but do not reference FishEye or "FE" in the name like they are in opencv source code. Because of this, I included "Pinhole" in the new enumeration naming for clarity that the flags are used with calibration functions for the pinhole model. 

Closes #1303 