### PR TITLE
imgproc: update DilateWithParams function to use int for borderType parameter

### DIFF
--- a/imgproc.go
+++ b/imgproc.go
@@ -279,7 +279,7 @@ func Dilate(src Mat, dst *Mat, kernel Mat) error {
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#ga4ff0f3318642c4f469d0e11f242f3b6c
-func DilateWithParams(src Mat, dst *Mat, kernel Mat, anchor image.Point, iterations, borderType BorderType, borderValue color.RGBA) error {
+func DilateWithParams(src Mat, dst *Mat, kernel Mat, anchor image.Point, iterations, borderType int, borderValue color.RGBA) error {
 	cAnchor := C.struct_Point{
 		x: C.int(anchor.X),
 		y: C.int(anchor.Y),


### PR DESCRIPTION
imgproc: update DilateWithParams function to use int for borderType parameter