### PR TITLE
feature: use build tags to be able to have a reduced size OpenCV build

### DIFF
--- a/aruco.cpp
+++ b/aruco.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_aruco)
+
 #include "aruco.h"
 
 ArucoDetector ArucoDetector_New() {

--- a/aruco.go
+++ b/aruco.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_aruco)
+
 package gocv
 
 /*

--- a/aruco_dictionaries.go
+++ b/aruco_dictionaries.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_aruco)
+
 package gocv
 
 /*

--- a/aruco_test.go
+++ b/aruco_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_aruco)
+
 package gocv
 
 import (

--- a/calib3d.cpp
+++ b/calib3d.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_calib3d)
+
 #include "calib3d.h"
 
 double Fisheye_Calibrate(Points3fVector objectPoints, Points2fVector imagePoints, Size size, Mat k, Mat d, Mat rvecs, Mat tvecs, int flags) {
@@ -240,5 +242,14 @@ OpenCVResult StereoRectify(Mat cameraMatrix1, Mat distCoeffs1, Mat cameraMatrix2
         return successResult();
     } catch(const cv::Exception& e){
         return errorResult(e.code, e.what());
+    }
+}
+
+Mat FindHomography(Mat src, Mat dst, int method, double ransacReprojThreshold, Mat mask, const int maxIters, const double confidence) {
+    try {
+        return new cv::Mat(cv::findHomography(*src, *dst, method, ransacReprojThreshold, *mask, maxIters, confidence));
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return new cv::Mat();
     }
 }

--- a/calib3d.go
+++ b/calib3d.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_calib3d)
+
 package gocv
 
 /*
@@ -371,4 +373,21 @@ func StereoRectify(cameraMatrix1, distCoeffs1, cameraMatrix2, distCoeffs2 Mat, i
 		height: C.int(imageSize.Y),
 	}
 	return OpenCVResult(C.StereoRectify(cameraMatrix1.Ptr(), distCoeffs1.Ptr(), cameraMatrix2.Ptr(), distCoeffs2.Ptr(), sz, r.Ptr(), t.Ptr(), R1.Ptr(), R2.Ptr(), P1.Ptr(), P2.Ptr(), Q.Ptr(), C.int(flags)))
+}
+
+type HomographyMethod int
+
+const (
+	HomographyMethodAllPoints HomographyMethod = 0
+	HomographyMethodLMEDS     HomographyMethod = 4
+	HomographyMethodRANSAC    HomographyMethod = 8
+	HomographyMethodRHO       HomographyMethod = 16
+)
+
+// FindHomography finds an optimal homography matrix using 4 or more point pairs (as opposed to GetPerspectiveTransform, which uses exactly 4)
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d9/d0c/group__calib3d.html#ga4abc2ece9fab9398f2e560d53c8c9780
+func FindHomography(srcPoints Mat, targetPoints Mat, method HomographyMethod, ransacReprojThreshold float64, mask *Mat, maxIters int, confidence float64) Mat {
+	return newMat(C.FindHomography(srcPoints.Ptr(), targetPoints.Ptr(), C.int(method), C.double(ransacReprojThreshold), mask.Ptr(), C.int(maxIters), C.double(confidence)))
 }

--- a/calib3d.h
+++ b/calib3d.h
@@ -38,6 +38,7 @@ OpenCVResult ConvertPointsFromHomogeneous(Mat src, Mat dst);
 OpenCVResult Rodrigues(Mat src, Mat dst);
 bool SolvePnP(Point3fVector objectPoints, Point2fVector imagePoints, Mat cameraMatrix, Mat distCoeffs, Mat rvec, Mat tvec, bool useExtrinsicGuess, int flags);
 OpenCVResult StereoRectify(Mat cameraMatrix1, Mat distCoeffs1, Mat cameraMatrix2, Mat distCoeffs2, Size imageSize, Mat r, Mat t, Mat R1, Mat R2, Mat P1, Mat P2, Mat Q, int flags);
+Mat FindHomography(Mat src, Mat dst, int method, double ransacReprojThreshold, Mat mask, const int maxIters, const double confidence);
 #ifdef __cplusplus
 }
 #endif

--- a/calib3d_string.go
+++ b/calib3d_string.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_calib3d)
+
 package gocv
 
 func (c CalibFlag) String() string {

--- a/contrib/bgsegm.cpp
+++ b/contrib/bgsegm.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_bgsegm)
+
 #include "bgsegm.h"
 
 BackgroundSubtractorCNT BackgroundSubtractorCNT_Create() {

--- a/contrib/bgsegm.go
+++ b/contrib/bgsegm.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_bgsegm)
+
 package contrib
 
 /*

--- a/contrib/bgsegm_test.go
+++ b/contrib/bgsegm_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_bgsegm)
+
 package contrib
 
 import (

--- a/contrib/face.cpp
+++ b/contrib/face.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_face)
+
 #include "face.h"
 
 bool FaceRecognizer_Empty(FaceRecognizer fr) {

--- a/contrib/face.go
+++ b/contrib/face.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_face)
+
 package contrib
 
 /*

--- a/contrib/face_recognizer.go
+++ b/contrib/face_recognizer.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_face)
+
 package contrib
 
 /*

--- a/contrib/face_test.go
+++ b/contrib/face_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_face)
+
 package contrib
 
 import (

--- a/contrib/freetype.cpp
+++ b/contrib/freetype.cpp
@@ -1,3 +1,4 @@
+//go:build linux && (!gocv_specific_modules || (gocv_specific_modules && gocv_contrib_freetype))
 
 #ifndef _WIN32  // Exclude compiling on Windows platforms
 

--- a/contrib/freetype.go
+++ b/contrib/freetype.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && (!gocv_specific_modules || (gocv_specific_modules && gocv_contrib_freetype))
 
 package contrib
 

--- a/contrib/freetype_test.go
+++ b/contrib/freetype_test.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && (!gocv_specific_modules || (gocv_specific_modules && gocv_contrib_freetype))
 
 package contrib
 

--- a/contrib/img_hash.cpp
+++ b/contrib/img_hash.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_img_hash)
+
 #include "img_hash.h"
 
 void pHashCompute(Mat inputArr, Mat outputArr) {

--- a/contrib/img_hash.go
+++ b/contrib/img_hash.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_img_hash)
+
 package contrib
 
 //#include <stdlib.h>

--- a/contrib/img_hash_string.go
+++ b/contrib/img_hash_string.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_img_hash)
+
 package contrib
 
 func (c BlockMeanHashMode) String() string {

--- a/contrib/img_hash_test.go
+++ b/contrib/img_hash_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_img_hash)
+
 package contrib
 
 import (

--- a/contrib/tracking.cpp
+++ b/contrib/tracking.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_tracking)
+
 #include "tracking.h"
 #include <opencv2/opencv.hpp>
 

--- a/contrib/tracking.go
+++ b/contrib/tracking.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_tracking)
+
 package contrib
 
 /*

--- a/contrib/tracking_test.go
+++ b/contrib/tracking_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_tracking)
+
 package contrib
 
 import (

--- a/contrib/wechat_qrcode.cpp
+++ b/contrib/wechat_qrcode.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_wechat_qrcode)
+
 #include "wechat_qrcode.h"
 
 WeChatQRCode NewWeChatQRCode(const char *detector_prototxt_path,

--- a/contrib/wechat_qrcode.go
+++ b/contrib/wechat_qrcode.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_wechat_qrcode)
+
 package contrib
 
 /*

--- a/contrib/wechat_qrcode_test.go
+++ b/contrib/wechat_qrcode_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_wechat_qrcode)
+
 package contrib
 
 import (

--- a/contrib/xfeatures2d.cpp
+++ b/contrib/xfeatures2d.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_xfeatures2d)
+
 #include "xfeatures2d.h"
 
 

--- a/contrib/xfeatures2d.go
+++ b/contrib/xfeatures2d.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_xfeatures2d)
+
 package contrib
 
 /*

--- a/contrib/xfeatures2d_test.go
+++ b/contrib/xfeatures2d_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_xfeatures2d)
+
 package contrib
 
 import (

--- a/contrib/ximgproc.cpp
+++ b/contrib/ximgproc.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_ximgproc)
+
 #include "ximgproc.h"
 
 OpenCVResult anisotropicDiffusion(Mat src, Mat dst, float alpha, float K, int niters) {

--- a/contrib/ximgproc.go
+++ b/contrib/ximgproc.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_ximgproc)
+
 package contrib
 
 /*

--- a/contrib/ximgproc_test.go
+++ b/contrib/ximgproc_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_ximgproc)
+
 package contrib
 
 import (

--- a/contrib/xobjdetect.cpp
+++ b/contrib/xobjdetect.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_xobjdetect)
+
 #include "xobjdetect.h"
 
 WBDetector WBDetector_Create(){

--- a/contrib/xobjdetect.go
+++ b/contrib/xobjdetect.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_xobjdetect)
+
 package contrib
 
 /*

--- a/contrib/xobjdetect_test.go
+++ b/contrib/xobjdetect_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_xobjdetect)
+
 package contrib
 
 import (

--- a/contrib/xphoto.cpp
+++ b/contrib/xphoto.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_xphoto)
+
 #include "xphoto.h"
 
 OpenCVResult Xphoto_ApplyChannelGains(Mat src, Mat dst, float gainB, float gainG, float gainR) {

--- a/contrib/xphoto.go
+++ b/contrib/xphoto.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_xphoto)
+
 package contrib
 
 /*

--- a/contrib/xphoto_test.go
+++ b/contrib/xphoto_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_contrib_xphoto)
+
 package contrib
 
 //:testing

--- a/cuda/arithm.cpp
+++ b/cuda/arithm.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_cuda_arithm)
+
 #include "../core.h"
 #include "arithm.h"
 #include <string.h>

--- a/cuda/arithm.go
+++ b/cuda/arithm.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_cuda_arithm)
+
 package cuda
 
 /*

--- a/cuda/arithm_test.go
+++ b/cuda/arithm_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_cuda_arithm)
+
 package cuda
 
 import (

--- a/cuda/bgsegm.cpp
+++ b/cuda/bgsegm.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_cuda_bgsegm)
+
 #include "bgsegm.h"
 
 CudaBackgroundSubtractorMOG2 CudaBackgroundSubtractorMOG2_Create() {

--- a/cuda/bgsegm.go
+++ b/cuda/bgsegm.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_cuda_bgsegm)
+
 package cuda
 
 /*

--- a/cuda/bgsegm_test.go
+++ b/cuda/bgsegm_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_cuda_bgsegm)
+
 package cuda
 
 import (

--- a/cuda/filters.cpp
+++ b/cuda/filters.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_cuda_filters)
+
 #include "../core.h"
 #include "filters.h"
 #include <string.h>

--- a/cuda/filters.go
+++ b/cuda/filters.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_cuda_filters)
+
 package cuda
 
 /*

--- a/cuda/filters_test.go
+++ b/cuda/filters_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_cuda_filters)
+
 package cuda
 
 import (

--- a/cuda/objdetect.cpp
+++ b/cuda/objdetect.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_cuda_objdetect)
+
 #include "../core.h"
 #include "cuda.h"
 #include "objdetect.h"

--- a/cuda/objdetect.go
+++ b/cuda/objdetect.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_cuda_objdetect)
+
 // Package cuda is the GoCV wrapper around OpenCV cuda.
 //
 // For further details, please see:

--- a/cuda/optflow.cpp
+++ b/cuda/optflow.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_cuda_optflow)
+
 #include "optflow.h"
 
 CudaSparsePyrLKOpticalFlow CudaSparsePyrLKOpticalFlow_Create() {

--- a/cuda/optflow.go
+++ b/cuda/optflow.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_cuda_optflow)
+
 package cuda
 
 /*

--- a/cuda/optflow_test.go
+++ b/cuda/optflow_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_cuda_optflow)
+
 package cuda
 
 import "testing"

--- a/cuda/warping.cpp
+++ b/cuda/warping.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_cuda_warping)
+
 #include "warping.h"
 
 OpenCVResult CudaResize(GpuMat src, GpuMat dst, Size dsize, double fx, double fy, int interp, Stream s) {

--- a/cuda/warping.go
+++ b/cuda/warping.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_cuda_warping)
+
 package cuda
 
 /*

--- a/cuda/warping_string.go
+++ b/cuda/warping_string.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_cuda_warping)
+
 package cuda
 
 func (c InterpolationFlags) String() string {

--- a/cuda/warping_test.go
+++ b/cuda/warping_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_cuda_warping)
+
 package cuda
 
 import (

--- a/dnn.cpp
+++ b/dnn.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_dnn)
+
 #include "dnn.h"
 
 Net Net_ReadNet(const char* model, const char* config) {

--- a/dnn.go
+++ b/dnn.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_dnn)
+
 package gocv
 
 /*

--- a/dnn_ext.go
+++ b/dnn_ext.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_dnn)
+
 package gocv
 
 import (

--- a/dnn_string.go
+++ b/dnn_string.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_dnn)
+
 package gocv
 
 func (c NetBackendType) String() string {

--- a/dnn_test.go
+++ b/dnn_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_dnn)
+
 package gocv
 
 import (

--- a/features2d.cpp
+++ b/features2d.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_features2d)
+
 #include "features2d.h"
 
 AKAZE AKAZE_Create() {

--- a/features2d.go
+++ b/features2d.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_features2d)
+
 package gocv
 
 /*

--- a/features2d_string.go
+++ b/features2d_string.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_features2d)
+
 package gocv
 
 /*

--- a/features2d_test.go
+++ b/features2d_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_features2d)
+
 package gocv
 
 import (

--- a/highgui.cpp
+++ b/highgui.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_highgui)
+
 #include "highgui_gocv.h"
 
 void Window_SetMouseCallback(char* winname, mouse_callback on_mouse) {

--- a/highgui.go
+++ b/highgui.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_highgui)
+
 package gocv
 
 /*

--- a/highgui_onmouse_test.go
+++ b/highgui_onmouse_test.go
@@ -1,7 +1,6 @@
 // Do not run these tests on mac OS X. They fail with errors suggesting the GUI
 // should only be touched from the main thread.
-//go:build !darwin
-// +build !darwin
+//go:build !darwin && (!gocv_specific_modules || (gocv_specific_modules && gocv_highgui))
 
 package gocv
 

--- a/highgui_string.go
+++ b/highgui_string.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_highgui)
+
 package gocv
 
 /*

--- a/highgui_test.go
+++ b/highgui_test.go
@@ -1,7 +1,6 @@
 // Do not run these tests on mac OS X. They fail with errors suggesting the GUI
 // should only be touched from the main thread.
-//go:build !darwin
-// +build !darwin
+//go:build !darwin && (!gocv_specific_modules || (gocv_specific_modules && gocv_highgui))
 
 package gocv
 

--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -1040,15 +1040,6 @@ Mat GetAffineTransform2f(Point2fVector src, Point2fVector dst) {
     }
 }
 
-Mat FindHomography(Mat src, Mat dst, int method, double ransacReprojThreshold, Mat mask, const int maxIters, const double confidence) {
-    try {
-        return new cv::Mat(cv::findHomography(*src, *dst, method, ransacReprojThreshold, *mask, maxIters, confidence));
-    } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
-        return new cv::Mat();
-    }
-}
-
 OpenCVResult DrawContours(Mat src, PointsVector contours, int contourIdx, Scalar color, int thickness) {
     try {
         cv::Scalar c = cv::Scalar(color.val1, color.val2, color.val3, color.val4);

--- a/imgproc.go
+++ b/imgproc.go
@@ -1823,23 +1823,6 @@ func GetAffineTransform2f(src, dst Point2fVector) Mat {
 	return newMat(C.GetAffineTransform2f(src.p, dst.p))
 }
 
-type HomographyMethod int
-
-const (
-	HomographyMethodAllPoints HomographyMethod = 0
-	HomographyMethodLMEDS     HomographyMethod = 4
-	HomographyMethodRANSAC    HomographyMethod = 8
-	HomographyMethodRHO       HomographyMethod = 16
-)
-
-// FindHomography finds an optimal homography matrix using 4 or more point pairs (as opposed to GetPerspectiveTransform, which uses exactly 4)
-//
-// For further details, please see:
-// https://docs.opencv.org/master/d9/d0c/group__calib3d.html#ga4abc2ece9fab9398f2e560d53c8c9780
-func FindHomography(srcPoints Mat, targetPoints Mat, method HomographyMethod, ransacReprojThreshold float64, mask *Mat, maxIters int, confidence float64) Mat {
-	return newMat(C.FindHomography(srcPoints.Ptr(), targetPoints.Ptr(), C.int(method), C.double(ransacReprojThreshold), mask.Ptr(), C.int(maxIters), C.double(confidence)))
-}
-
 // DrawContours draws contours outlines or filled contours.
 //
 // For further details, please see:

--- a/imgproc.h
+++ b/imgproc.h
@@ -117,7 +117,6 @@ Mat GetPerspectiveTransform(PointVector src, PointVector dst);
 Mat GetPerspectiveTransform2f(Point2fVector src, Point2fVector dst);
 Mat GetAffineTransform(PointVector src, PointVector dst);
 Mat GetAffineTransform2f(Point2fVector src, Point2fVector dst);
-Mat FindHomography(Mat src, Mat dst, int method, double ransacReprojThreshold, Mat mask, const int maxIters, const double confidence) ;
 OpenCVResult DrawContours(Mat src, PointsVector contours, int contourIdx, Scalar color, int thickness);
 OpenCVResult DrawContoursWithParams(Mat src, PointsVector contours, int contourIdx, Scalar color, int thickness, int lineType, Mat hierarchy, int maxLevel, Point offset);
 OpenCVResult Sobel(Mat src, Mat dst, int ddepth, int dx, int dy, int ksize, double scale, double delta, int borderType);

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -2092,59 +2092,6 @@ func TestGetAffineTransform2f(t *testing.T) {
 	}
 }
 
-func TestFindHomography(t *testing.T) {
-	src := NewMatWithSize(4, 1, MatTypeCV64FC2)
-	defer src.Close()
-	target := NewMatWithSize(4, 1, MatTypeCV64FC2)
-	defer target.Close()
-
-	srcPoints := []Point2f{
-		{193, 932},
-		{191, 378},
-		{1497, 183},
-		{1889, 681},
-	}
-	targetPoints := []Point2f{
-		{51.51206544281359, -0.10425475260813055},
-		{51.51211051314331, -0.10437947532732306},
-		{51.512222354139325, -0.10437679311830816},
-		{51.51214828037607, -0.1042212249954444},
-	}
-
-	for i, point := range srcPoints {
-		src.SetDoubleAt(i, 0, float64(point.X))
-		src.SetDoubleAt(i, 1, float64(point.Y))
-	}
-
-	for i, point := range targetPoints {
-		target.SetDoubleAt(i, 0, float64(point.X))
-		target.SetDoubleAt(i, 1, float64(point.Y))
-	}
-
-	mask := NewMat()
-	defer mask.Close()
-
-	m := FindHomography(src, target, HomographyMethodAllPoints, 3, &mask, 2000, 0.995)
-	defer m.Close()
-
-	pvsrc := NewPoint2fVectorFromPoints(srcPoints)
-	defer pvsrc.Close()
-
-	pvdst := NewPoint2fVectorFromPoints(targetPoints)
-	defer pvdst.Close()
-
-	m2 := GetPerspectiveTransform2f(pvsrc, pvdst)
-	defer m2.Close()
-
-	for row := 0; row < 3; row++ {
-		for col := 0; col < 3; col++ {
-			if math.Abs(m.GetDoubleAt(row, col)-m2.GetDoubleAt(row, col)) > 0.002 {
-				t.Errorf("expected little difference between GetPerspectiveTransform2f and FindHomography results, got %f for row %d col %d", math.Abs(m.GetDoubleAt(row, col)-m2.GetDoubleAt(row, col)), row, col)
-			}
-		}
-	}
-}
-
 func TestWarpPerspective(t *testing.T) {
 	img := IMRead("images/gocvlogo.jpg", IMReadUnchanged)
 	defer img.Close()

--- a/objdetect.cpp
+++ b/objdetect.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_objdetect)
+
 #include "objdetect.h"
 
 // CascadeClassifier

--- a/objdetect.go
+++ b/objdetect.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_objdetect)
+
 package gocv
 
 /*

--- a/objdetect_test.go
+++ b/objdetect_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_objdetect)
+
 package gocv
 
 import (

--- a/photo.cpp
+++ b/photo.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_photo)
+
 #include "photo.h"
 
 OpenCVResult ColorChange(Mat src, Mat mask, Mat dst, float red_mul, float green_mul, float blue_mul) {

--- a/photo.go
+++ b/photo.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_photo)
+
 package gocv
 
 /*

--- a/photo_string.go
+++ b/photo_string.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_photo)
+
 package gocv
 
 func (c SeamlessCloneFlags) String() string {

--- a/photo_test.go
+++ b/photo_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_photo)
+
 package gocv
 
 import (

--- a/svd.cpp
+++ b/svd.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_svd)
+
 #include "svd.h"
 
 OpenCVResult SVD_Compute(Mat src, Mat w, Mat u, Mat vt) {

--- a/svd.go
+++ b/svd.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_svd)
+
 package gocv
 
 /*

--- a/svd_test.go
+++ b/svd_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_svd)
+
 package gocv
 
 import (

--- a/video.cpp
+++ b/video.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_video)
+
 #include "video.h"
 
 BackgroundSubtractorMOG2 BackgroundSubtractorMOG2_Create() {

--- a/video.go
+++ b/video.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_video)
+
 package gocv
 
 /*

--- a/video_test.go
+++ b/video_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_video)
+
 package gocv
 
 import (

--- a/videoio.cpp
+++ b/videoio.cpp
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_videoio)
+
 #include <stdexcept>
 #include "videoio.h"
 

--- a/videoio.go
+++ b/videoio.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_videoio)
+
 package gocv
 
 /*

--- a/videoio_string.go
+++ b/videoio_string.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_videoio)
+
 package gocv
 
 func (c VideoCaptureAPI) String() string {

--- a/videoio_test.go
+++ b/videoio_test.go
@@ -1,3 +1,5 @@
+//go:build !gocv_specific_modules || (gocv_specific_modules && gocv_videoio)
+
 package gocv
 
 import (


### PR DESCRIPTION
This PR allows using build tags to be able to have a reduced size OpenCV build that only contains specific modules.

Example:

```shell
go test -tags=gocv_specific_modules,gocv_videoio .
```

The above only builds/runs tests that include `videoio`.

*UPDATE* Is now working, since imgproc and imgcodecs are currently considered required.

At the moment, it does also include some other modules such as `imgproc` because of lacking a clean separation between modules in the GoCV implementation. Some additional work needs to be done on this.