### PR TITLE
cuda: add implementation for norm, calcNorm, and calcNormDiff functions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -97,7 +97,7 @@ Your pull requests will be greatly appreciated!
         - [ ] [SparsePyrLKOpticalFlow](https://docs.opencv.org/4.x/d7/d08/classcv_1_1SparsePyrLKOpticalFlow.html)
         - [ ] [TrackerDaSiamRPN](https://docs.opencv.org/4.x/de/d93/classcv_1_1TrackerDaSiamRPN.html)
         - [ ] [TrackerNano](https://docs.opencv.org/4.x/d8/d69/classcv_1_1TrackerNano.html)
-        - [ ] [TrackerVit](https://docs.opencv.org/4.x/d9/d26/classcv_1_1TrackerVit.html)
+        - [X] [TrackerVit](https://docs.opencv.org/4.x/d9/d26/classcv_1_1TrackerVit.html)
 
 - [ ] **calib3d. Camera Calibration and 3D Reconstruction - WORK STARTED**. The following functions still need implementation:
     - [ ] **Camera Calibration - WORK STARTED** The following functions still need implementation:
@@ -226,8 +226,8 @@ Your pull requests will be greatly appreciated!
     - [ ] **matrix reductions - WORK STARTED** The following functions still need implementation:
         - [ ] [cv::cuda::absSum](https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga690fa79ba4426c53f7d2bebf3d37a32a)
         - [ ] [cv::cuda::calcAbsSum](https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga15c403b76ab2c4d7ed0f5edc09891b7e)
-        - [ ] [cv::cuda::calcNorm](https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga39d2826990d29b7e4b69dbe02bdae2e1)
-        - [ ] [cv::cuda::calcNormDiff](https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga9be3d9a7b6c5760955f37d1039d01265)
+        - [X] [cv::cuda::calcNorm](https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga39d2826990d29b7e4b69dbe02bdae2e1)
+        - [X] [cv::cuda::calcNormDiff](https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga9be3d9a7b6c5760955f37d1039d01265)
         - [ ] [cv::cuda::calcSqrSum](https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#gac998c83597f6c206c78cee16aa87946f)
         - [ ] [cv::cuda::calcSum](https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga98a09144047f09f5cb1d6b6ea8e0856f)
         - [ ] [cv::cuda::countNonZero](https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga98a09144047f09f5cb1d6b6ea8e0856f)
@@ -237,7 +237,7 @@ Your pull requests will be greatly appreciated!
         - [ ] [cv::cuda::meanStdDev](https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga990a4db4c6d7e8f0f3a6685ba48fbddc)
         - [ ] [cv::cuda::minMax](https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga8d7de68c10717cf25e787e3c20d2dfee)
         - [ ] [cv::cuda::minMaxLoc](https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga5cacbc2a2323c4eaa81e7390c5d9f530)
-        - [ ] [cv::cuda::norm](https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga6c01988a58d92126a7c60a4ab76d8324)
+        - [X] [cv::cuda::norm](https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga6c01988a58d92126a7c60a4ab76d8324)
         - [ ] [cv::cuda::normalize](https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga4da4738b9956a5baaa2f5f8c2fba438a)
         - [ ] [cv::cuda::rectStdDev](https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#gac311484a4e57cab2ce2cfdc195fda7ee)
         - [ ] [cv::cuda::reduce](https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga21d57f661db7be093caf2c4378be2007)

--- a/cuda/arithm.cpp
+++ b/cuda/arithm.cpp
@@ -353,3 +353,38 @@ OpenCVResult Cuda_Split(GpuMat src, GpuMats dst, Stream s) {
         return errorResult(e.code, e.what());
     }
 }
+
+OpenCVResult GpuCalcNorm(GpuMat src, GpuMat dst, int typ, Stream s) {
+    try {
+        if (s == NULL) {
+            cv::cuda::calcNorm(*src, *dst, typ);
+        } else {
+            cv::cuda::calcNorm(*src, *dst, typ, cv::noArray(), *s);
+        }
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
+    }
+}
+
+OpenCVResult GpuCalcNormDiff(GpuMat src1, GpuMat src2, GpuMat dst, int typ, Stream s) {
+    try {
+        if (s == NULL) {
+            cv::cuda::calcNormDiff(*src1, *src2, *dst, typ);
+        } else {
+            cv::cuda::calcNormDiff(*src1, *src2, *dst, typ, *s);
+        }
+        return successResult();
+    } catch(const cv::Exception& e) {
+        return errorResult(e.code, e.what());
+    }
+}
+
+double GpuNorm(GpuMat src1, GpuMat src2, int typ) {
+    try {
+        return cv::cuda::norm(*src1, *src2, typ);
+    } catch(const cv::Exception& e) {
+        setExceptionInfo(e.code, e.what());
+        return 0.0;
+    }
+}

--- a/cuda/arithm.go
+++ b/cuda/arithm.go
@@ -529,3 +529,43 @@ func SplitWithStream(src GpuMat, dst []GpuMat, s Stream) error {
 
 	return OpenCVResult(C.Cuda_Split(src.p, c_dstv, s.p))
 }
+
+// CalcNorm calculates the norm of a matrix.
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga39d2826990d29b7e4b69dbe02bdae2e1
+func CalcNorm(src, dst GpuMat, normType gocv.NormType) error {
+	return OpenCVResult(C.GpuCalcNorm(src.p, dst.p, C.int(normType), nil))
+}
+
+// CalcNormWithStream calculates the norm of a matrix.
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga39d2826990d29b7e4b69dbe02bdae2e1
+func CalcNormWithStream(src, dst GpuMat, normType gocv.NormType, s Stream) error {
+	return OpenCVResult(C.GpuCalcNorm(src.p, dst.p, C.int(normType), s.p))
+}
+
+// CalcNormDiff calculates the norm of a matrix.
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga9be3d9a7b6c5760955f37d1039d01265
+func CalcNormDiff(src1, src2, dst GpuMat, normType gocv.NormType) error {
+	return OpenCVResult(C.GpuCalcNormDiff(src1.p, src2.p, dst.p, C.int(normType), nil))
+}
+
+// CalcNormDiffWithStream calculates the norm of a matrix.
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga9be3d9a7b6c5760955f37d1039d01265
+func CalcNormDiffWithStream(src1, src2, dst GpuMat, normType gocv.NormType, s Stream) error {
+	return OpenCVResult(C.GpuCalcNormDiff(src1.p, src2.p, dst.p, C.int(normType), s.p))
+}
+
+// Norm returns the difference of two matrices.
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/d5/de6/group__cudaarithm__reduce.html#ga48b6298589b80a6915d076e2dcdbd11b
+func Norm(src1, src2 GpuMat, normType gocv.NormType) float64 {
+	return float64(C.GpuNorm(src1.p, src2.p, C.int(normType)))
+}

--- a/cuda/arithm.h
+++ b/cuda/arithm.h
@@ -39,6 +39,9 @@ OpenCVResult GpuMerge(struct GpuMats mats, GpuMat dst, Stream s);
 OpenCVResult GpuTranspose(GpuMat src, GpuMat dst, Stream s);
 OpenCVResult GpuAddWeighted(GpuMat src1, double alpha, GpuMat src2, double beta, double gamma, GpuMat dst, int dType, Stream s);
 OpenCVResult GpuCopyMakeBorder(GpuMat src, GpuMat dst, int top, int bottom, int left, int right, int borderType, Scalar value, Stream s);
+OpenCVResult GpuCalcNorm(GpuMat src, GpuMat dst, int typ, Stream s);
+OpenCVResult GpuCalcNormDiff(GpuMat src1, GpuMat src2, GpuMat dst, int typ, Stream s);
+double GpuNorm(GpuMat src1, GpuMat src2, int typ);
 
 //LookUpTable
 LookUpTable Cuda_Create_LookUpTable(GpuMat lut);

--- a/cuda/arithm_test.go
+++ b/cuda/arithm_test.go
@@ -833,3 +833,144 @@ func TestSplitWithStream(t *testing.T) {
 	SplitWithStream(m, mats, s)
 	s.WaitForCompletion()
 }
+
+func TestCalcNorm(t *testing.T) {
+	src := gocv.IMRead("../images/chessboard_4x6_distort_correct.png", gocv.IMReadGrayScale)
+	if src.Empty() {
+		t.Error("Invalid read of Mat in CalcNorm test")
+	}
+	defer src.Close()
+
+	var cimg, dimg = NewGpuMat(), NewGpuMat()
+	defer cimg.Close()
+	defer dimg.Close()
+
+	dest := gocv.NewMat()
+	defer dest.Close()
+
+	cimg.Upload(src)
+	CalcNorm(cimg, dimg, gocv.NormL2)
+	dimg.Download(&dest)
+
+	if dest.Empty() {
+		t.Error("Invalid CalcNorm test")
+	}
+}
+
+func TestCalcNormWithStream(t *testing.T) {
+	src := gocv.IMRead("../images/chessboard_4x6_distort_correct.png", gocv.IMReadGrayScale)
+	if src.Empty() {
+		t.Error("Invalid read of Mat in CalcNorm test")
+	}
+	defer src.Close()
+
+	var cimg, dimg, s = NewGpuMat(), NewGpuMat(), NewStream()
+	defer cimg.Close()
+	defer dimg.Close()
+	defer s.Close()
+
+	dest := gocv.NewMat()
+	defer dest.Close()
+
+	cimg.UploadWithStream(src, s)
+	CalcNormWithStream(cimg, dimg, gocv.NormL2, s)
+	dimg.DownloadWithStream(&dest, s)
+
+	s.WaitForCompletion()
+
+	if dest.Empty() {
+		t.Error("Invalid CalcNormWithStream test")
+	}
+}
+
+func TestCalcNormDiff(t *testing.T) {
+	src1 := gocv.IMRead("../images/chessboard_4x6_distort_correct.png", gocv.IMReadGrayScale)
+	if src1.Empty() {
+		t.Error("Invalid read of Mat in CalcNormDiff test")
+	}
+	defer src1.Close()
+
+	src2 := gocv.IMRead("../images/chessboard_4x6_distort.png", gocv.IMReadGrayScale)
+	if src2.Empty() {
+		t.Error("Invalid read of Mat in CalcNormDiff test")
+	}
+	defer src2.Close()
+
+	var cimg1, cimg2, dimg = NewGpuMat(), NewGpuMat(), NewGpuMat()
+	defer cimg1.Close()
+	defer cimg2.Close()
+	defer dimg.Close()
+
+	dest := gocv.NewMat()
+	defer dest.Close()
+
+	cimg1.Upload(src1)
+	cimg2.Upload(src2)
+	CalcNormDiff(cimg1, cimg2, dimg, gocv.NormL2)
+	dimg.Download(&dest)
+
+	if dest.Empty() {
+		t.Error("Invalid CalcNormDiff test")
+	}
+}
+
+func TestCalcNormDiffWithStream(t *testing.T) {
+	src1 := gocv.IMRead("../images/chessboard_4x6_distort_correct.png", gocv.IMReadGrayScale)
+	if src1.Empty() {
+		t.Error("Invalid read of Mat in CalcNormDiff test")
+	}
+	defer src1.Close()
+
+	src2 := gocv.IMRead("../images/chessboard_4x6_distort.png", gocv.IMReadGrayScale)
+	if src2.Empty() {
+		t.Error("Invalid read of Mat in CalcNormDiff test")
+	}
+	defer src2.Close()
+
+	var cimg1, cimg2, dimg, s = NewGpuMat(), NewGpuMat(), NewGpuMat(), NewStream()
+	defer cimg1.Close()
+	defer cimg2.Close()
+	defer dimg.Close()
+	defer s.Close()
+
+	dest := gocv.NewMat()
+	defer dest.Close()
+
+	cimg1.UploadWithStream(src1, s)
+	cimg2.UploadWithStream(src2, s)
+	CalcNormDiffWithStream(cimg1, cimg2, dimg, gocv.NormL2, s)
+	dimg.DownloadWithStream(&dest, s)
+
+	s.WaitForCompletion()
+
+	if dest.Empty() {
+		t.Error("Invalid CalcNormWithStream test")
+	}
+}
+
+func TestNorm(t *testing.T) {
+	src1 := gocv.IMRead("../images/chessboard_4x6_distort_correct.png", gocv.IMReadGrayScale)
+	if src1.Empty() {
+		t.Error("Invalid read of Mat in Norm test")
+	}
+	defer src1.Close()
+
+	src2 := gocv.IMRead("../images/chessboard_4x6_distort.png", gocv.IMReadGrayScale)
+	if src2.Empty() {
+		t.Error("Invalid read of Mat in Norm test")
+	}
+	defer src2.Close()
+
+	var cimg1, cimg2 = NewGpuMat(), NewGpuMat()
+	defer cimg1.Close()
+	defer cimg2.Close()
+
+	cimg1.Upload(src1)
+	cimg2.Upload(src2)
+
+	result := Norm(cimg1, cimg2, gocv.NormL2)
+
+	if result == 0 {
+		t.Error("Invalid Norm test")
+	}
+}


### PR DESCRIPTION
This PR adds the implementations for  the`cv::cuda::norm()`, `cv::cuda::calcNorm()`, and `cv::cuda::calcNormDiff()` functions.