### PR TITLE
ci: update to run GH actions tests for macOS 14 and 15

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,21 +10,17 @@ jobs:
   build:
     strategy:
         matrix:
-          os: [macos-13, macos-14]
+          os: [macos-14, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install OpenCV
         run: |
-          rm /usr/local/bin/2to3*
-          rm /usr/local/bin/idle3*
-          rm /usr/local/bin/pydoc*
-          rm /usr/local/bin/python3*
           brew update
           brew install opencv
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25.1'
           cache: true
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR updates the GH actions tests to use macOS 14 and 15 since Homebrew has now dropped support for macOS 13.

See https://github.com/Homebrew/brew/pull/20672 for details.