### PR TITLE
videoio: add RetrieveChannel function to make it possible to capture audio

### DIFF
--- a/videoio.cpp
+++ b/videoio.cpp
@@ -144,6 +144,15 @@ int VideoCapture_Retrieve(VideoCapture v, Mat buf) {
     }
 }
 
+int VideoCapture_RetrieveChannel(VideoCapture v, Mat buf, int channel) {
+    try {
+        return v->retrieve(*buf, channel);
+    } catch(const cv::Exception& e){
+        setExceptionInfo(e.code, e.what());
+        return 0;
+    }
+}
+
 // VideoWriter
 VideoWriter VideoWriter_New() {
     try {

--- a/videoio.go
+++ b/videoio.go
@@ -474,9 +474,17 @@ func (v *VideoCapture) Grab(skip int) error {
 // Retrieve decodes and returns the grabbed video frame. Should be used after Grab
 //
 // For further details, please see:
-// http://docs.opencv.org/master/d8/dfe/classcv_1_1VideoCapture.html#a9ac7f4b1cdfe624663478568486e6712
+// https://docs.opencv.org/4.x/d8/dfe/classcv_1_1VideoCapture.html#a9ac7f4b1cdfe624663478568486e6712
 func (v *VideoCapture) Retrieve(m *Mat) bool {
 	return C.VideoCapture_Retrieve(v.p, m.p) != 0
+}
+
+// Retrieve decodes and returns the grabbed frame for a specific channel. Should be used after Grab
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/d8/dfe/classcv_1_1VideoCapture.html#a9ac7f4b1cdfe624663478568486e6712
+func (v *VideoCapture) RetrieveChannel(m *Mat, channel int) bool {
+	return C.VideoCapture_RetrieveChannel(v.p, m.p, C.int(channel)) != 0
 }
 
 // CodecString returns a string representation of FourCC bytes, i.e. the name of a codec

--- a/videoio.h
+++ b/videoio.h
@@ -32,6 +32,7 @@ int VideoCapture_IsOpened(VideoCapture v);
 int VideoCapture_Read(VideoCapture v, Mat buf);
 OpenCVResult VideoCapture_Grab(VideoCapture v, int skip);
 int VideoCapture_Retrieve(VideoCapture v, Mat buf);
+int VideoCapture_RetrieveChannel(VideoCapture v, Mat buf, int channel);
 
 // VideoWriter
 VideoWriter VideoWriter_New();

--- a/videoio_test.go
+++ b/videoio_test.go
@@ -296,6 +296,40 @@ func TestVideoCaptureFile_GrabRetrieve(t *testing.T) {
 	}
 }
 
+func TestVideoCaptureFile_GrabRetrieveChannel(t *testing.T) {
+	vc, err := VideoCaptureFile("images/small.mp4")
+	defer vc.Close()
+
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	if !vc.IsOpened() {
+		t.Error("Unable to open VideoCaptureFile")
+	}
+
+	if fw := vc.Get(VideoCaptureFrameWidth); int(fw) != 560 {
+		t.Errorf("Expected frame width property of 560.0 got %f", fw)
+	}
+	if fh := vc.Get(VideoCaptureFrameHeight); int(fh) != 320 {
+		t.Errorf("Expected frame height property of 320.0 got %f", fh)
+	}
+
+	vc.Set(VideoCaptureBrightness, 100.0)
+
+	vc.Grab(10)
+
+	img := NewMat()
+	defer img.Close()
+
+	if ok := vc.RetrieveChannel(&img, 0); !ok {
+		t.Error("Unable to read VideoCaptureFile")
+	}
+	if img.Empty() {
+		t.Error("Unable to read VideoCaptureFile")
+	}
+}
+
 func TestVideoRegistry(t *testing.T) {
 
 	name := VideoRegistry.GetBackendName(VideoCaptureFFmpeg)


### PR DESCRIPTION
This PR adds a `RetrieveChannel` function to make it possible to capture both video and audio at the same time.