### PR TITLE
feat: add Copy method to Mat

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -168,6 +168,10 @@ Mat Mat_Row(Mat m, int r) {
     return new cv::Mat(m->row(r));
 }
 
+Mat Mat_Copy(Mat m) {
+    return new Cv::Mat(*m);
+}
+
 // Mat_Clone returns a clone of this Mat
 Mat Mat_Clone(Mat m) {
     return new cv::Mat(m->clone());

--- a/core.cpp
+++ b/core.cpp
@@ -169,7 +169,7 @@ Mat Mat_Row(Mat m, int r) {
 }
 
 Mat Mat_Copy(Mat m) {
-    return new Cv::Mat(*m);
+    return new cv::Mat(*m);
 }
 
 // Mat_Clone returns a clone of this Mat

--- a/core.go
+++ b/core.go
@@ -437,6 +437,17 @@ func (m *Mat) Row(row int) Mat {
 	return newMat(C.Mat_Row(m.p, C.int(row)))
 }
 
+// Copy returns a shallow copy of the Mat. No data is copied.
+//
+// For further details, please see:
+// https://docs.opencv.org/4.x/d3/d63/classcv_1_1Mat.html#a294eaf8a95d2f9c7be19ff594d06278e
+func (m *Mat) Copy() Mat {
+	return Mat{
+		p: C.Mat_Copy(m.p),
+		d: m.d,
+	}
+}
+
 // Clone returns a cloned full copy of the Mat.
 func (m *Mat) Clone() Mat {
 	return newMat(C.Mat_Clone(m.p))

--- a/core.h
+++ b/core.h
@@ -343,6 +343,7 @@ bool Mat_IsContinuous(Mat m);
 void Mat_Inv(Mat m);
 Mat Mat_Col(Mat m, int c);
 Mat Mat_Row(Mat m, int r);
+Mat Mat_Copy(Mat m);
 Mat Mat_Clone(Mat m);
 OpenCVResult Mat_CopyTo(Mat m, Mat dst);
 int Mat_Total(Mat m);


### PR DESCRIPTION
This PR adds `Copy` method to `Mat`, which allows to create a shallow copy of a Mat.