### PR TITLE
Added in missing ColorMaps

### DIFF
--- a/imgproc.go
+++ b/imgproc.go
@@ -1756,19 +1756,28 @@ type ColormapTypes int
 // For further details, please see:
 // https://docs.opencv.org/master/d3/d50/group__imgproc__colormap.html#ga9a805d8262bcbe273f16be9ea2055a65
 const (
-	ColormapAutumn  ColormapTypes = 0
-	ColormapBone    ColormapTypes = 1
-	ColormapJet     ColormapTypes = 2
-	ColormapWinter  ColormapTypes = 3
-	ColormapRainbow ColormapTypes = 4
-	ColormapOcean   ColormapTypes = 5
-	ColormapSummer  ColormapTypes = 6
-	ColormapSpring  ColormapTypes = 7
-	ColormapCool    ColormapTypes = 8
-	ColormapHsv     ColormapTypes = 9
-	ColormapPink    ColormapTypes = 10
-	ColormapHot     ColormapTypes = 11
-	ColormapParula  ColormapTypes = 12
+	ColormapAutumn          ColormapTypes = 0
+	ColormapBone            ColormapTypes = 1
+	ColormapJet             ColormapTypes = 2
+	ColormapWinter          ColormapTypes = 3
+	ColormapRainbow         ColormapTypes = 4
+	ColormapOcean           ColormapTypes = 5
+	ColormapSummer          ColormapTypes = 6
+	ColormapSpring          ColormapTypes = 7
+	ColormapCool            ColormapTypes = 8
+	ColormapHsv             ColormapTypes = 9
+	ColormapPink            ColormapTypes = 10
+	ColormapHot             ColormapTypes = 11
+	ColormapParula          ColormapTypes = 12
+	ColormapMagma           ColormapTypes = 13
+	ColormapInferno         ColormapTypes = 14
+	ColormapPlasma          ColormapTypes = 15
+	ColormapViridis         ColormapTypes = 16
+	ColormapCividis         ColormapTypes = 17
+	ColormapTwilight        ColormapTypes = 18
+	ColormapTwilightShifted ColormapTypes = 19
+	ColormapTurbo           ColormapTypes = 20
+	ColormapDeepGreen       ColormapTypes = 21
 )
 
 // ApplyColorMap applies a GNU Octave/MATLAB equivalent colormap on a given image.

--- a/imgproc_string.go
+++ b/imgproc_string.go
@@ -308,6 +308,24 @@ func (c ColormapTypes) String() string {
 		return "colormap-pink"
 	case ColormapParula:
 		return "colormap-parula"
+	case ColormapMagma:
+		return "colormap-magma"
+	case ColormapInferno:
+		return "colormap-inferno"
+	case ColormapPlasma:
+		return "colormap-plasma"
+	case ColormapViridis:
+		return "colormap-viridis"
+	case ColormapCividis:
+		return "colormap-cividis"
+	case ColormapTwilight:
+		return "colormap-twilight"
+	case ColormapTwilightShifted:
+		return "colormap-twilight-shifted"
+	case ColormapTurbo:
+		return "colormap-turbo"
+	case ColormapDeepGreen:
+		return "colormap-deep-green"
 	}
 	return ""
 }

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -1942,6 +1942,15 @@ func TestApplyColorMap(t *testing.T) {
 		{name: "COLORMAP_PINK", args: args{colormapType: ColormapPink, want: 136043.97287274434}},
 		{name: "COLORMAP_HOT", args: args{colormapType: ColormapHot, want: 124941.02475968412}},
 		{name: "COLORMAP_PARULA", args: args{colormapType: ColormapParula, want: 111483.33555738274}},
+		{name: "COLORMAP_MAGMA", args: args{colormapType: ColormapMagma, want: 113197.48853662788}},
+		{name: "COLORMAP_INFERNO", args: args{colormapType: ColormapInferno, want: 108186.83126425323}},
+		{name: "COLORMAP_PLASMA", args: args{colormapType: ColormapPlasma, want: 108665.39830599251}},
+		{name: "COLORMAP_VIRIDIS", args: args{colormapType: ColormapViridis, want: 95101.87774697196}},
+		{name: "COLORMAP_CIVIDIS", args: args{colormapType: ColormapCividis, want: 102175.91244515509}},
+		{name: "COLORMAP_TWILIGHT", args: args{colormapType: ColormapTwilight, want: 98676.48484821498}},
+		{name: "COLORMAP_TWILIGHT_SHIFTED", args: args{colormapType: ColormapTwilightShifted, want: 74717.33848311247}},
+		{name: "COLORMAP_TURBO", args: args{colormapType: ColormapTurbo, want: 96848.08501978756}},
+		{name: "COLORMAP_DEEPGREEN", args: args{colormapType: ColormapDeepGreen, want: 106444.16919681415}},
 	}
 	src := IMRead("images/gocvlogo.jpg", IMReadGrayScale)
 	defer src.Close()


### PR DESCRIPTION
This PR adds in the [missing Colormaps](https://github.com/opencv/opencv/blob/0ca4117c272611e0576b272b0f93fa01e0d8361a/modules/imgproc/include/opencv2/imgproc.hpp#L4597-L4621).

Just for fun, here is how they all look!

<img width="1869" height="1403" alt="gocv-all-colormaps" src="https://github.com/user-attachments/assets/5e68c10c-45b5-46c0-aa6e-05f78b9f96d3" />
 