### PR TITLE
feat: add FindContoursWithVecParams and IMEncodeWithBufParams functions

### DIFF
--- a/cmd/facedetect-from-url/main.go
+++ b/cmd/facedetect-from-url/main.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 	"image"
 	"image/color"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -54,7 +54,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	resByte, err := ioutil.ReadAll(res.Body)
+	resByte, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/core.go
+++ b/core.go
@@ -2691,7 +2691,8 @@ type NativeByteBuffer struct {
 	stdVectorOpaq [3]uintptr
 }
 
-func newNativeByteBuffer() *NativeByteBuffer {
+// NewNativeByteBuffer returns a new empty NativeByteBuffer.
+func NewNativeByteBuffer() *NativeByteBuffer {
 	buffer := &NativeByteBuffer{}
 	C.StdByteVectorInitialize(buffer.nativePointer())
 	return buffer

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gocv.io/x/gocv
 
-go 1.21
+go 1.24.0
 
 require (
 	github.com/hybridgroup/mjpeg v0.0.0-20140228234708-4680f319790e

--- a/imgcodecs.go
+++ b/imgcodecs.go
@@ -168,7 +168,7 @@ func IMReadMulti(name string, flags IMReadFlag) []Mat {
 	return mats
 }
 
-// IMReadMulti reads multi-page image from a file into a []Mat.
+// IMReadMulti_WithParams reads multi-page image from a file into a []Mat.
 // The flags param is one of the IMReadFlag flags.
 // If the image cannot be read (because of missing file, improper permissions,
 // unsupported or invalid format), the function returns an empty []Mat.
@@ -239,6 +239,20 @@ const (
 	GIFFileExt FileExt = ".gif"
 )
 
+// cFileExt returns C-string for FileExt and true if it was allocated on the heap and needs to be freed.
+func cFileExt(fileExt FileExt) (*C.char, bool) {
+	switch fileExt {
+	case PNGFileExt:
+		return (*C.char)(unsafe.Pointer(unsafe.StringData(".png\x00"))), false
+	case JPEGFileExt:
+		return (*C.char)(unsafe.Pointer(unsafe.StringData(".jpg\x00"))), false
+	case GIFFileExt:
+		return (*C.char)(unsafe.Pointer(unsafe.StringData(".gif\x00"))), false
+	default:
+		return C.CString(string(fileExt)), true
+	}
+}
+
 // IMEncode encodes an image Mat into a memory buffer.
 // This function compresses the image and stores it in the returned memory buffer,
 // using the image format passed in in the form of a file extension string.
@@ -246,12 +260,16 @@ const (
 // For further details, please see:
 // http://docs.opencv.org/master/d4/da8/group__imgcodecs.html#ga461f9ac09887e47797a54567df3b8b63
 func IMEncode(fileExt FileExt, img Mat) (buf *NativeByteBuffer, err error) {
-	cfileExt := C.CString(string(fileExt))
-	defer C.free(unsafe.Pointer(cfileExt))
-
-	buffer := newNativeByteBuffer()
-	res := C.Image_IMEncode(cfileExt, img.Ptr(), buffer.nativePointer())
-	return buffer, OpenCVResult(res)
+	cfileExt, allocated := cFileExt(fileExt)
+	if allocated {
+		defer C.free(unsafe.Pointer(cfileExt))
+	}
+	b := NewNativeByteBuffer()
+	if err := OpenCVResult(C.Image_IMEncode(cfileExt, img.Ptr(), b.nativePointer())); err != nil {
+		b.Close()
+		return nil, err
+	}
+	return b, nil
 }
 
 // IMEncodeWithParams encodes an image Mat into a memory buffer.
@@ -265,22 +283,42 @@ func IMEncode(fileExt FileExt, img Mat) (buf *NativeByteBuffer, err error) {
 // For further details, please see:
 // http://docs.opencv.org/master/d4/da8/group__imgcodecs.html#ga461f9ac09887e47797a54567df3b8b63
 func IMEncodeWithParams(fileExt FileExt, img Mat, params []int) (buf *NativeByteBuffer, err error) {
-	cfileExt := C.CString(string(fileExt))
-	defer C.free(unsafe.Pointer(cfileExt))
+	b := NewNativeByteBuffer()
+	if err := IMEncodeWithBufParams(fileExt, img, b, params); err != nil {
+		b.Close()
+		return nil, err
+	}
+	return b, nil
+}
 
-	cparams := []C.int{}
+// IMEncodeWithBufParams encodes an image Mat into the provided memory buffer.
+// This function compresses the image and stores it in the provided memory buffer,
+// using the image format passed in in the form of a file extension string.
+//
+// Usage example:
+//
+//	buffer := gocv.NewNativeByteBuffer()
+//	err := gocv.IMEncodeWithBufParams(gocv.JPEGFileExt, img, buffer, []int{gocv.IMWriteJpegQuality, quality})
+//
+// For further details, please see:
+// http://docs.opencv.org/master/d4/da8/group__imgcodecs.html#ga461f9ac09887e47797a54567df3b8b63
+func IMEncodeWithBufParams(fileExt FileExt, img Mat, b *NativeByteBuffer, params []int) error {
+	cfileExt, allocated := cFileExt(fileExt)
+	if allocated {
+		defer C.free(unsafe.Pointer(cfileExt))
+	}
 
-	for _, v := range params {
-		cparams = append(cparams, C.int(v))
+	cparams := make([]C.int, len(params))
+	for i, v := range params {
+		cparams[i] = C.int(v)
 	}
 
 	paramsVector := C.struct_IntVector{}
 	paramsVector.val = (*C.int)(&cparams[0])
 	paramsVector.length = (C.int)(len(cparams))
 
-	b := newNativeByteBuffer()
 	res := C.Image_IMEncode_WithParams(cfileExt, img.Ptr(), paramsVector, b.nativePointer())
-	return b, OpenCVResult(res)
+	return OpenCVResult(res)
 }
 
 // IMDecode reads an image from a buffer in memory.

--- a/imgcodecs_test.go
+++ b/imgcodecs_test.go
@@ -3,7 +3,6 @@ package gocv
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -22,7 +21,7 @@ func TestIMRead(t *testing.T) {
 }
 
 func TestIMWrite(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "gocvtests")
+	dir := t.TempDir()
 	tmpfn := filepath.Join(dir, "test.jpg")
 
 	img := IMRead("images/face-detect.jpg", IMReadColor)
@@ -38,7 +37,7 @@ func TestIMWrite(t *testing.T) {
 }
 
 func TestIMWriteWithParams(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "gocvtests")
+	dir := t.TempDir()
 	tmpfn := filepath.Join(dir, "test.jpg")
 
 	img := IMRead("images/face-detect.jpg", IMReadColor)
@@ -114,6 +113,7 @@ func TestIMEncodeWithParams(t *testing.T) {
 	if buf.Len() < 18000 {
 		t.Errorf("Wrong buffer size in IMEncode test. Should have been %v\n", buf.Len())
 	}
+	t.Logf("Buffer size for 75 quality: %v", buf.Len())
 
 	buf2, err := IMEncodeWithParams(JPEGFileExt, img, []int{IMWriteJpegQuality, 100})
 	if err != nil {
@@ -123,14 +123,48 @@ func TestIMEncodeWithParams(t *testing.T) {
 	if buf2.Len() < 18000 {
 		t.Errorf("Wrong buffer size in IMEncode test. Should have been %v\n", buf2.Len())
 	}
+	t.Logf("Buffer size for 100 quality: %v", buf2.Len())
 
 	if buf.Len() >= buf2.Len() {
 		t.Errorf("Jpeg quality parameter does not work correctly\n")
 	}
 }
 
+func TestIMEncodeWithBufParams(t *testing.T) {
+	img := IMRead("images/face-detect.jpg", IMReadColor)
+	defer img.Close()
+	if img.Empty() {
+		t.Error("Invalid Mat in IMEncode test")
+	}
+
+	buf := NewNativeByteBuffer()
+	defer buf.Close()
+
+	if err := IMEncodeWithBufParams(JPEGFileExt, img, buf, []int{IMWriteJpegQuality, 75}); err != nil {
+		t.Error(err)
+	}
+	bufLen1 := buf.Len()
+	if bufLen1 < 18000 {
+		t.Errorf("Wrong buffer size in IMEncode test. Should have been %v\n", bufLen1)
+	}
+	t.Logf("Buffer size for 75 quality: %v", bufLen1)
+
+	if err := IMEncodeWithBufParams(JPEGFileExt, img, buf, []int{IMWriteJpegQuality, 100}); err != nil {
+		t.Error(err)
+	}
+	bufLen2 := buf.Len()
+	if bufLen2 < 18000 {
+		t.Errorf("Wrong buffer size in IMEncode test. Should have been %v\n", bufLen2)
+	}
+	t.Logf("Buffer size for 100 quality: %v", bufLen2)
+
+	if bufLen1 >= bufLen2 {
+		t.Errorf("Jpeg quality parameter does not work correctly\n")
+	}
+}
+
 func TestIMDecode(t *testing.T) {
-	content, err := ioutil.ReadFile("images/face-detect.jpg")
+	content, err := os.ReadFile("images/face-detect.jpg")
 	if err != nil {
 		t.Error("Invalid ReadFile in IMDecode")
 	}
@@ -153,7 +187,7 @@ func TestIMDecode(t *testing.T) {
 func TestIMDecodeIntoMat(t *testing.T) {
 	mat := NewMat()
 	defer mat.Close()
-	content, err := ioutil.ReadFile("images/face-detect.jpg")
+	content, err := os.ReadFile("images/face-detect.jpg")
 	if err != nil {
 		t.Error("Invalid ReadFile in IMDecode")
 	}
@@ -165,11 +199,10 @@ func TestIMDecodeIntoMat(t *testing.T) {
 	if mat.Empty() {
 		t.Error("Invalid Mat in IMDecode")
 	}
-
 }
 
 func TestIMDecodeWebp(t *testing.T) {
-	content, err := ioutil.ReadFile("images/sample.webp")
+	content, err := os.ReadFile("images/sample.webp")
 	if err != nil {
 		t.Error("Invalid ReadFile in IMDecodeWebp")
 	}
@@ -182,13 +215,10 @@ func TestIMDecodeWebp(t *testing.T) {
 		t.Error("Invalid Mat in IMDecodeWebp")
 	}
 	dec.Close()
-
 }
 
 func TestIMReadMulti(t *testing.T) {
-
 	mats := IMReadMulti("images/multipage.tif", IMReadAnyColor)
-
 	for i, page := range mats {
 		if page.Empty() {
 			t.Errorf("page %d empty", i)
@@ -198,13 +228,10 @@ func TestIMReadMulti(t *testing.T) {
 }
 
 func TestIMReadMulti_WithParams(t *testing.T) {
-
 	mats := IMReadMulti_WithParams("images/multipage.tif", 2, 3, IMReadAnyColor)
-
 	for i, page := range mats {
 		if page.Empty() {
 			t.Errorf("page %d empty", i)
 		}
 	}
-
 }

--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -438,15 +438,12 @@ OpenCVResult MinEnclosingCircle(PointVector pts, Point2f* center, float* radius)
     }
 }
 
-PointsVector FindContours(Mat src, Mat hierarchy, int mode, int method) {
+OpenCVResult FindContours(Mat src, PointsVector contours, Mat hierarchy, int mode, int method) {
     try {
-        PointsVector contours = new std::vector<std::vector<cv::Point> >;
         cv::findContours(*src, *contours, *hierarchy, mode, method);
-
-        return contours;
+        return successResult();
     } catch(const cv::Exception& e){
-        setExceptionInfo(e.code, e.what());
-        return NULL;
+        return errorResult(e.code, e.what());
     }
 }
 

--- a/imgproc.go
+++ b/imgproc.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"image"
 	"image/color"
-	"reflect"
 	"unsafe"
 )
 
@@ -535,12 +534,7 @@ func toPoints(points C.Contour) []image.Point {
 	pArray := points.points
 	pLength := int(points.length)
 
-	pHdr := reflect.SliceHeader{
-		Data: uintptr(unsafe.Pointer(pArray)),
-		Len:  pLength,
-		Cap:  pLength,
-	}
-	sPoints := *(*[]C.Point)(unsafe.Pointer(&pHdr))
+	sPoints := unsafe.Slice(pArray, pLength)
 
 	points4 := make([]image.Point, pLength)
 	for j, pt := range sPoints {
@@ -554,12 +548,7 @@ func toPoints2f(points C.Contour2f) []Point2f {
 	pArray := points.points
 	pLength := int(points.length)
 
-	pHdr := reflect.SliceHeader{
-		Data: uintptr(unsafe.Pointer(pArray)),
-		Len:  pLength,
-		Cap:  pLength,
-	}
-	sPoints := *(*[]C.Point)(unsafe.Pointer(&pHdr))
+	sPoints := unsafe.Slice(pArray, pLength)
 
 	points4 := make([]Point2f, pLength)
 	for j, pt := range sPoints {
@@ -586,7 +575,7 @@ func MinAreaRect(points PointVector) RotatedRect {
 	}
 }
 
-// MinAreaRect finds a rotated rectangle of the minimum area enclosing the input 2D point set.
+// MinAreaRect2f finds a rotated rectangle of the minimum area enclosing the input 2D point set.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/dc0/group__imgproc__shape.html#ga3d476a3417130ae5154aea421ca7ead9
@@ -651,7 +640,18 @@ func FindContours(src Mat, mode RetrievalMode, method ContourApproximationMode) 
 // For further details, please see:
 // https://docs.opencv.org/master/d3/dc0/group__imgproc__shape.html#ga17ed9f5d79ae97bd4c7cf18403e1689a
 func FindContoursWithParams(src Mat, hierarchy *Mat, mode RetrievalMode, method ContourApproximationMode) PointsVector {
-	return PointsVector{p: C.FindContours(src.p, hierarchy.p, C.int(mode), C.int(method))}
+	contours := NewPointsVector()
+	FindContoursWithVecParams(src, &contours, hierarchy, mode, method)
+	return contours
+}
+
+// FindContoursWithVecParams finds contours in a binary image
+// and stores them in the provided PointsVector.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/d3/dc0/group__imgproc__shape.html#ga17ed9f5d79ae97bd4c7cf18403e1689a
+func FindContoursWithVecParams(src Mat, contours *PointsVector, hierarchy *Mat, mode RetrievalMode, method ContourApproximationMode) {
+	C.FindContours(src.p, contours.p, hierarchy.p, C.int(mode), C.int(method))
 }
 
 // PointPolygonTest performs a point-in-contour test.
@@ -688,7 +688,7 @@ func ConnectedComponents(src Mat, labels *Mat) int {
 	return int(C.ConnectedComponents(src.p, labels.p, C.int(8), C.int(MatTypeCV32S), C.int(CCL_DEFAULT)))
 }
 
-// ConnectedComponents computes the connected components labeled image of boolean image.
+// ConnectedComponentsWithParams computes the connected components labeled image of boolean image.
 //
 // For further details, please see:
 // https://docs.opencv.org/master/d3/dc0/group__imgproc__shape.html#gaedef8c7340499ca391d459122e51bef5

--- a/imgproc.h
+++ b/imgproc.h
@@ -49,7 +49,7 @@ struct RotatedRect MinAreaRect(PointVector pts);
 struct RotatedRect2f MinAreaRect2f(PointVector pts);
 struct RotatedRect FitEllipse(PointVector pts);
 OpenCVResult MinEnclosingCircle(PointVector pts, Point2f* center, float* radius);
-PointsVector FindContours(Mat src, Mat hierarchy, int mode, int method);
+OpenCVResult FindContours(Mat src, PointsVector contours, Mat hierarchy, int mode, int method);
 double PointPolygonTest(PointVector pts, Point pt, bool measureDist);
 int ConnectedComponents(Mat src, Mat dst, int connectivity, int ltype, int ccltype);
 int ConnectedComponentsWithStats(Mat src, Mat labels, Mat stats, Mat centroids, int connectivity, int ltype, int ccltype);

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"slices"
 	"testing"
 )
 
@@ -686,8 +687,45 @@ func TestFindContoursWithParams(t *testing.T) {
 		{-1, -1, -1, 2},
 	} {
 		got := hierarchy.GetVeciAt(0, i)
-		if !reflect.DeepEqual(want, got) {
+		if !slices.Equal(want, got) {
 			t.Errorf("wrong hierarchy at position %d, want %v got %v", i, want, got)
+		}
+	}
+}
+
+func TestFindContoursWithVecParams(t *testing.T) {
+	img := IMRead("images/contours.png", IMReadGrayScale)
+	if img.Empty() {
+		t.Fatal("Invalid read of Mat in FindContours test")
+	}
+	defer img.Close()
+
+	pts := NewPointsVector()
+	defer pts.Close()
+
+	hierarchy := NewMat()
+	defer hierarchy.Close()
+
+	for range 3 {
+		FindContoursWithVecParams(img, &pts, &hierarchy, RetrievalTree, ChainApproxNone)
+		if want := 4; want != pts.Size() {
+			t.Fatalf("Expected %d contours but got %d", want, pts.Size())
+		}
+		if pts.Size() != hierarchy.Cols() {
+			t.Fatalf("Expected %d hierarchy of contours, got %d", pts.Size(), hierarchy.Cols())
+		}
+		// Assert hierarchy values, the pattern is [Next, Previous, First_Child, Parent]
+		// More info at https://docs.opencv.org/master/d9/d8b/tutorial_py_contours_hierarchy.html
+		for i, want := range []Veci{
+			{1, -1, -1, -1},
+			{-1, 0, 2, -1},
+			{-1, -1, 3, 1},
+			{-1, -1, -1, 2},
+		} {
+			got := hierarchy.GetVeciAt(0, i)
+			if !slices.Equal(want, got) {
+				t.Errorf("wrong hierarchy at position %d, want %v got %v", i, want, got)
+			}
 		}
 	}
 }
@@ -2930,7 +2968,7 @@ func TestImageGrayToMatGray(t *testing.T) {
 		log.Fatal(err)
 	}
 	img0 := image.NewGray(imgSrc.Bounds())
-	draw.Draw(img0, imgSrc.Bounds(), imgSrc, image.ZP, draw.Src)
+	draw.Draw(img0, imgSrc.Bounds(), imgSrc, image.Point{}, draw.Src)
 
 	mat, err := ImageGrayToMatGray(img0)
 	if err != nil {

--- a/videoio_test.go
+++ b/videoio_test.go
@@ -3,7 +3,6 @@
 package gocv
 
 import (
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -193,7 +192,7 @@ func TestVideoCaptureFile(t *testing.T) {
 }
 
 func TestVideoWriterFile(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "gocvtests")
+	dir := t.TempDir()
 	tmpfn := filepath.Join(dir, "test.avi")
 
 	img := IMRead("images/face-detect.jpg", IMReadColor)


### PR DESCRIPTION
This adds two functions:

- `IMEncodeWithBufParams(fileExt FileExt, img Mat, b *NativeByteBuffer, params []int) error`
- `FindContoursWithVecParams(src Mat, contours *PointsVector, hierarchy *Mat, mode RetrievalMode, method ContourApproximationMode)`

Compared to `IMEncodeWithParams` and `FindContoursWithParams` these functions accept additional output arguments which helps reduce the number of allocations and minimize memory fragmentation.

Also bumps `go.mod` version to 1.24 and modernizes the code a little bit.