### PR TITLE
Fix binding for cv::getRectSubPix

### DIFF
--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -902,10 +902,10 @@ OpenCVResult Resize(Mat src, Mat dst, Size dsize, double fx, double fy, int inte
     }
 }
 
-OpenCVResult GetRectSubPix(Mat src, Size patchSize, Point center, Mat dst) {
+OpenCVResult GetRectSubPix(Mat src, Size patchSize, Point2f center, Mat dst) {
     try {
         cv::Size sz(patchSize.width, patchSize.height);
-        cv::Point pt(center.x, center.y);
+        cv::Point2f pt(center.x, center.y);
         cv::getRectSubPix(*src, sz, pt, *dst);
         return successResult();
     } catch(const cv::Exception& e) {

--- a/imgproc.go
+++ b/imgproc.go
@@ -1650,14 +1650,14 @@ func Resize(src Mat, dst *Mat, sz image.Point, fx, fy float64, interp Interpolat
 //
 // For further details, please see:
 // https://docs.opencv.org/master/da/d54/group__imgproc__transform.html#ga77576d06075c1a4b6ba1a608850cd614
-func GetRectSubPix(src Mat, patchSize image.Point, center image.Point, dst *Mat) error {
+func GetRectSubPix(src Mat, patchSize image.Point, center Point2f, dst *Mat) error {
 	sz := C.struct_Size{
 		width:  C.int(patchSize.X),
 		height: C.int(patchSize.Y),
 	}
-	pt := C.struct_Point{
-		x: C.int(center.X),
-		y: C.int(center.Y),
+	pt := C.struct_Point2f{
+		x: C.float(center.X),
+		y: C.float(center.Y),
 	}
 	return OpenCVResult(C.GetRectSubPix(src.p, sz, pt, dst.p))
 }

--- a/imgproc.h
+++ b/imgproc.h
@@ -103,7 +103,7 @@ OpenCVResult PutText(Mat img, const char* text, Point org, int fontFace, double 
 OpenCVResult PutTextWithParams(Mat img, const char* text, Point org, int fontFace, double fontScale,
             Scalar color, int thickness, int lineType, bool bottomLeftOrigin);
 OpenCVResult Resize(Mat src, Mat dst, Size sz, double fx, double fy, int interp);
-OpenCVResult GetRectSubPix(Mat src, Size patchSize, Point center, Mat dst);
+OpenCVResult GetRectSubPix(Mat src, Size patchSize, Point2f center, Mat dst);
 Mat GetRotationMatrix2D(Point center, double angle, double scale);
 OpenCVResult WarpAffine(Mat src, Mat dst, Mat rot_mat, Size dsize);
 OpenCVResult WarpAffineWithParams(Mat src, Mat dst, Mat rot_mat, Size dsize, int flags, int borderMode, Scalar borderValue);

--- a/imgproc_test.go
+++ b/imgproc_test.go
@@ -1766,7 +1766,11 @@ func TestGetRectSubPix(t *testing.T) {
 	dst := NewMat()
 	defer dst.Close()
 
-	GetRectSubPix(src, image.Point{20, 30}, image.Point{200, 172}, &dst)
+	err := GetRectSubPix(src, image.Point{20, 30}, Point2f{X: 200.5, Y: 172.5}, &dst)
+	if err != nil {
+		t.Errorf("GetRectSubPix returned error: %v", err)
+	}
+
 	if dst.Cols() != 20 || dst.Rows() != 30 {
 		t.Errorf("Expected dst size of 20x30 got %dx%d", dst.Cols(), dst.Rows())
 	}


### PR DESCRIPTION
Updated the GetRectSubPix binding to use a float center (Point2f) end-to-end instead of integer coordinates, matching OpenCV’s API and intended behavior. The previous integer center lost precision at the boundary between Go and C++.

**Why int casting defeats the purpose:**
GetRectSubPix is specifically for sub-pixel sampling. Casting center coordinates to int truncates fractional values, so a center like (200.5, 172.5) becomes (200, 172). That removes sub-pixel precision and effectively turns the call into whole-pixel extraction, which defeats why this function exists.

**Note:** 
This is a breaking API change: GetRectSubPix now accepts Point2f for center instead of image.Point. Existing clients must update call sites to pass Point2f values.